### PR TITLE
Boosting performance through per-stage indexes

### DIFF
--- a/core/src/main/java/com/findwise/hydra/net/HttpResponseWriter.java
+++ b/core/src/main/java/com/findwise/hydra/net/HttpResponseWriter.java
@@ -134,7 +134,7 @@ public final class HttpResponseWriter {
 	
 
 	protected static void printID(HttpResponse response, String uuid) {
-		logger.error("Got ID ping!");
+		logger.info("Got ID ping!");
 		response.setStatusCode(HttpStatus.SC_OK);
 		setStringEntity(response, uuid);
 	}

--- a/core/src/test/java/com/findwise/hydra/net/RemotePipelineStressTest.java
+++ b/core/src/test/java/com/findwise/hydra/net/RemotePipelineStressTest.java
@@ -1,6 +1,6 @@
 package com.findwise.hydra.net;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 import java.util.Random;
 
@@ -8,13 +8,17 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 
 import com.findwise.hydra.DatabaseConnector;
 import com.findwise.hydra.NodeMaster;
+import com.findwise.hydra.TestModule;
 import com.findwise.hydra.local.LocalQuery;
 import com.findwise.hydra.local.RemotePipeline;
 import com.findwise.hydra.mongodb.MongoDocument;
-import com.findwise.hydra.TestModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
@@ -25,6 +29,9 @@ public class RemotePipelineStressTest {
 	
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
+		Logger root = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+		root.setLevel(Level.OFF);
+		
 		inj = Guice.createInjector(new TestModule("jUnit-RemotePipelineStressTest"));
 		server = RESTServer.getNewStartedRESTServer(inj);
 		
@@ -40,45 +47,88 @@ public class RemotePipelineStressTest {
 	@Before
 	public void setUp() {
 		nm = inj.getInstance(NodeMaster.class);
-		DatabaseConnector dbc = nm.getDatabaseConnector();
+		DatabaseConnector<?> dbc = nm.getDatabaseConnector();
 		dbc.getDocumentWriter().deleteAll();
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		DatabaseConnector dbc = nm.getDatabaseConnector();
+		DatabaseConnector<?> dbc = nm.getDatabaseConnector();
 		dbc.getDocumentWriter().deleteAll();
+		System.out.println("Deleted everything\n");
+	}
+
+	@Test
+	public void testStressGet100() throws Exception {
+		insertAndGet(100);
+	}
+
+	@Test
+	public void testStressGet1000() throws Exception {
+		insertAndGet(1000);
+	}
+
+	@Test
+	public void testStressGet10000() throws Exception {
+		insertAndGet(10000);
 	}
 	
-	@Test
-	public void testStressGetDocument() throws Exception {
-		int count = 10000;
-		RemotePipeline rp1 = new RemotePipeline("127.0.0.1", server.getPort(), "stage1");
-
-		
+	public void insertAndGet(int count) throws Exception {
+		System.out.println("Inserted "+count+" documents in "+insertDocuments(count)+" ms");
+		stressGetDocument(count);
+		System.out.println();
+	}
+	
+	public long insertDocuments(int count) throws Exception {
+		long start = System.currentTimeMillis();
 		for(int i=0; i<count; i++) {
 			MongoDocument d = new MongoDocument();
 			d.putContentField(getRandomString(5), getRandomString(20));
 			nm.getDatabaseConnector().getDocumentWriter().insert(d);
 		}
+		return System.currentTimeMillis()-start;
+	}
+	
+	public void stressGetDocument(int count) throws Exception {
+		RemotePipeline rp1 = new RemotePipeline("127.0.0.1", server.getPort(), "stage1");
+
 		
+		long start = System.currentTimeMillis();
 		for(int i=0; i<count; i++) {
 			if(rp1.getDocument(new LocalQuery())==null) {
 				fail("Should not have been null...");
 			}
 		}
 		
+
+		
 		if(rp1.getDocument(new LocalQuery())!=null) {
 			fail("All documents should have been seen already!");
 		}
-		
+		System.out.println("Saw "+count+" documents in "+(System.currentTimeMillis()-start)+" ms");
+		start = System.currentTimeMillis();
 		RemotePipeline rp2 = new RemotePipeline("127.0.0.1", server.getPort(), "stage2");
 		for(int i=0; i<count; i++) {
 			if(rp2.getDocument(new LocalQuery())==null) {
 				fail("Should not have been null...");
 			}
 		}
+
+		System.out.println("Saw "+count+" documents again in "+(System.currentTimeMillis()-start)+" ms");
 		if(rp2.getDocument(new LocalQuery())!=null) {
+			fail("All documents should have been seen already!");
+		}
+		
+		start = System.currentTimeMillis();
+		RemotePipeline rp3 = new RemotePipeline("127.0.0.1", server.getPort(), "stage3");
+		for(int i=0; i<count; i++) {
+			if(rp3.getDocument(new LocalQuery())==null) {
+				fail("Should not have been null...");
+			}
+		}
+
+		System.out.println("Saw "+count+" documents again (again) in "+(System.currentTimeMillis()-start)+" ms");
+		if(rp3.getDocument(new LocalQuery())!=null) {
 			fail("All documents should have been seen already!");
 		}
 	}

--- a/core/src/test/resources/logback.xml
+++ b/core/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/database/src/test/java/com/findwise/hydra/mongodb/TaggingModelTest.java
+++ b/database/src/test/java/com/findwise/hydra/mongodb/TaggingModelTest.java
@@ -40,38 +40,16 @@ public class TaggingModelTest {
 	public void testDiff() throws Exception {
 		int count = 1000;
 		long[] currentMs = testCurrent(count);
-		System.out.println(Arrays.toString(currentMs));
 		
 		reset();
 		
-		long[] currentIndexMs = testCurrentWithIndividualIndexes(count);
-		System.out.println(Arrays.toString(currentIndexMs));
-		
-		//reset();
-		
 		//long[] otherMs = testArray(1000);
-		
-		
+
+		System.out.println(Arrays.toString(currentMs));
 	}
 	
 	
 	public long[] testCurrent(int count) throws Exception {
-		long[] ret = new long[4];
-		ret[0] = insertCurrentDocuments(count);
-		ret[1] = getCurrent(count, "tag");
-		ret[2] = getCurrent(count, "tag2");
-		ret[3] = getCurrent(count, "tag3");
-		
-		return ret;
-	}
-	
-	public long[] testCurrentWithIndividualIndexes(int count) throws Exception {
-
-		mdc.getDB().getCollection("documents").ensureIndex("metadata.fetched.tag");
-		mdc.getDB().getCollection("documents").ensureIndex("metadata.fetched.tag2");
-		mdc.getDB().getCollection("documents").ensureIndex("metadata.fetched.tag3");
-		
-
 		long[] ret = new long[4];
 		ret[0] = insertCurrentDocuments(count);
 		ret[1] = getCurrent(count, "tag");

--- a/database/src/test/java/com/findwise/hydra/mongodb/TaggingModelTest.java
+++ b/database/src/test/java/com/findwise/hydra/mongodb/TaggingModelTest.java
@@ -1,0 +1,121 @@
+package com.findwise.hydra.mongodb;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.findwise.hydra.TestModule;
+import com.google.inject.Guice;
+
+public class TaggingModelTest {
+	MongoConnector mdc;
+
+	private void createAndConnect() throws Exception {
+		mdc = Guice.createInjector(new TestModule("junit-TaggingModelTest")).getInstance(MongoConnector.class);
+		
+		mdc.waitForWrites(true);
+		
+		mdc.connect();
+		
+	}
+	
+	@Before
+	public void setUp() throws Exception {
+		createAndConnect();
+		reset();
+	}
+
+
+	@After
+	public void reset() throws Exception {
+		mdc.getDB().dropDatabase();
+		createAndConnect();
+		
+	}
+	
+	@Test
+	public void testDiff() throws Exception {
+		int count = 1000;
+		long[] currentMs = testCurrent(count);
+		System.out.println(Arrays.toString(currentMs));
+		
+		reset();
+		
+		long[] currentIndexMs = testCurrentWithIndividualIndexes(count);
+		System.out.println(Arrays.toString(currentIndexMs));
+		
+		//reset();
+		
+		//long[] otherMs = testArray(1000);
+		
+		
+	}
+	
+	
+	public long[] testCurrent(int count) throws Exception {
+		long[] ret = new long[4];
+		ret[0] = insertCurrentDocuments(count);
+		ret[1] = getCurrent(count, "tag");
+		ret[2] = getCurrent(count, "tag2");
+		ret[3] = getCurrent(count, "tag3");
+		
+		return ret;
+	}
+	
+	public long[] testCurrentWithIndividualIndexes(int count) throws Exception {
+
+		mdc.getDB().getCollection("documents").ensureIndex("metadata.fetched.tag");
+		mdc.getDB().getCollection("documents").ensureIndex("metadata.fetched.tag2");
+		mdc.getDB().getCollection("documents").ensureIndex("metadata.fetched.tag3");
+		
+
+		long[] ret = new long[4];
+		ret[0] = insertCurrentDocuments(count);
+		ret[1] = getCurrent(count, "tag");
+		ret[2] = getCurrent(count, "tag2");
+		ret[3] = getCurrent(count, "tag3");
+		
+		return ret;
+	}
+	
+	public long getCurrent(int count, String tag) {
+		long start = System.currentTimeMillis();
+		System.out.println("Getting "+count+" documents for '"+tag+"'");
+		MongoQuery mq = new MongoQuery();
+		MongoDocumentIO reader = mdc.getDocumentReader();
+		for(int i=0; i<count; i++) {
+			if(i%(count/10) == 0) {
+				System.out.print('.');
+			}
+			reader.getAndTag(mq, tag);
+		}
+		System.out.println();
+		return System.currentTimeMillis()-start;
+	}
+	
+	public long insertCurrentDocuments(int count) throws Exception {
+		long start = System.currentTimeMillis();
+		for(int i=0; i<count; i++) {
+			MongoDocument d = new MongoDocument();
+			d.putContentField(getRandomString(5), getRandomString(20));
+			mdc.getDocumentWriter().insert(d);
+		}
+		return System.currentTimeMillis()-start;
+	}
+
+	
+	private String getRandomString(int length) {
+		char[] ca = new char[length];
+
+		Random r = new Random(System.currentTimeMillis());
+
+		for (int i = 0; i < length; i++) {
+			ca[i] = (char) ('A' + r.nextInt(26));
+		}
+
+		return new String(ca);
+	}
+}


### PR DESCRIPTION
Added measurements to fetching StressTest. Discovered how poor performance was in the usecase of batch-adding documents while Hydra is not working. Fixed those performance issues by adding per-stage indexes in MongoDB.

When a new stage connects to a Core, an index is now automatically created for that stage's "fetched" metadata. Increases performance over 100000 document batches by roughly 50x. Makes Hydra faster in general as well, but not at this dramatic level.
