### PR TITLE
Adding a debug setting to stage configs, fixed bug in CmdlineInserter

### DIFF
--- a/api/src/main/java/com/findwise/hydra/stage/AbstractStage.java
+++ b/api/src/main/java/com/findwise/hydra/stage/AbstractStage.java
@@ -157,9 +157,9 @@ public abstract class AbstractStage extends Thread {
 		setParameters(properties);
 		this.createAndApplyShutDownHook();
 	}
-
+	
 	@SuppressWarnings("unchecked")
-	public static void main(String args[]) {
+	public static AbstractStage getInstance(String[] args) {
 		Logger.debug("Starting AbstractStage with args: " + Arrays.toString(args));
 		if (args.length < 1) {
 			Logger.error("No stage name found", new RequiredArgumentMissingException("No stage name was specified"));
@@ -202,31 +202,34 @@ public abstract class AbstractStage extends Thread {
 			stage.setName(stageName);
 			stage.setUp(rp, properties);
 			stage.init();
-			stage.start();
-			Logger.info("Started stage: " + stage.getName());
+			
+			return stage;
 
 		} catch (RequiredArgumentMissingException e) {
 			Logger.error("Failed to read arguments", e);
-			System.exit(1);
 		} catch (ClassNotFoundException e) {
 			Logger.error("Could not find the Stage class in classpath", e);
-			System.exit(1);
 		} catch (InstantiationException e) {
 			Logger.error("Could not instantiate the Stage class", e);
-			System.exit(1);
 		} catch (IllegalAccessException e) {
 			Logger.error("Could not access constructor of Stage class", e);
-			System.exit(1);
 		} catch (JsonException e) {
 			Logger.error("Communication failiure when reading properties", e);
-			System.exit(1);
 		} catch (HttpException e) {
 			Logger.error("Communication failiure when reading properties", e);
-			System.exit(1);
 		} catch (IOException e) {
 			Logger.error("Communication failiure when reading properties", e);
+		}
+		return null;
+	}
+
+	public static void main(String args[]) {
+		AbstractStage stage = getInstance(args);
+		if(stage==null) {
 			System.exit(1);
 		}
+		stage.start();
+		Logger.info("Started stage: " + stage.getName());
 	}
 
 	/**

--- a/core/src/main/java/com/findwise/hydra/NodeMaster.java
+++ b/core/src/main/java/com/findwise/hydra/NodeMaster.java
@@ -138,7 +138,7 @@ public final class NodeMaster extends Thread {
 		StoredStage stage = new StoredStage(stageName, newStage.getDatabaseFile());
 		stage.setProperties(newStage.getProperties());
 		stage.setPropertiesModifiedDate(newStage.getPropertiesModifiedDate());
-		stage.setActive(newStage.isActive());
+		stage.setMode(newStage.getMode());
 		stage.getDatabaseFile().attach(dbc.getPipelineReader().getStream(stage.getDatabaseFile()));
 		pipeline.addStage(stage);
 		stage.getDatabaseFile().detachInputStream();

--- a/core/src/main/java/com/findwise/hydra/net/HttpRESTHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/HttpRESTHandler.java
@@ -151,7 +151,15 @@ public class HttpRESTHandler implements HttpRequestHandler  {
         	map = nm.getPipeline().getStage(stage).getProperties();
         }
         
+        if(handleGetDebugProperties()) {
+        	return;
+        }
+        
         HttpResponseWriter.printJson(response, map);
+	}
+	
+	private boolean handleGetDebugProperties() {
+		return false;
 	}
 	
 	private void handleGetDocument(HttpRequest request, HttpResponse response) throws IOException {

--- a/database/src/main/java/com/findwise/hydra/Stage.java
+++ b/database/src/main/java/com/findwise/hydra/Stage.java
@@ -6,9 +6,10 @@ import java.util.Map;
 import com.findwise.hydra.common.SerializationUtils;
 
 public class Stage {
+	public enum Mode { ACTIVE, INACTIVE, DEBUG }
 	private String name;
 	private DatabaseFile databaseFile;
-	private boolean active;
+	private Mode mode;
 	private Map<String, Object> properties;
 	private Date propertiesModifiedDate;
 	boolean changedProperties;
@@ -33,13 +34,13 @@ public class Stage {
 	public void setDatabaseFile(DatabaseFile databaseFile) {
 		this.databaseFile = databaseFile;
 	}
-
-	boolean isActive() {
-		return active;
+	
+	public void setMode(Mode mode) {
+		this.mode = mode;
 	}
 	
-	public void setActive(boolean active) {
-		this.active = active;
+	public Mode getMode() {
+		return mode;
 	}
 	
 	public Map<String, Object> getProperties() {

--- a/database/src/main/java/com/findwise/hydra/mongodb/MongoPipelineReader.java
+++ b/database/src/main/java/com/findwise/hydra/mongodb/MongoPipelineReader.java
@@ -53,7 +53,7 @@ public class MongoPipelineReader implements PipelineReader<MongoType> {
 	public Pipeline<Stage> getPipeline() {
 		Pipeline<Stage> p = new Pipeline<Stage>();
 		
-		DBCursor cursor = stages.find(new BasicDBObject(ACTIVE_KEY, true));
+		DBCursor cursor = stages.find(new BasicDBObject(ACTIVE_KEY, Stage.Mode.ACTIVE.toString()));
 		
 		while(cursor.hasNext()) {
 			p.addStage(getStage(cursor.next()));

--- a/database/src/main/java/com/findwise/hydra/mongodb/MongoPipelineWriter.java
+++ b/database/src/main/java/com/findwise/hydra/mongodb/MongoPipelineWriter.java
@@ -51,7 +51,7 @@ public class MongoPipelineWriter implements PipelineWriter<MongoType> {
 	
 	public void inactivate(Stage stage) {
 		DBObject q = reader.getStageQuery(stage.getName());
-		stages.findAndModify(q, new BasicDBObject(MongoPipelineReader.ACTIVE_KEY, false));
+		stages.findAndModify(q, new BasicDBObject(MongoPipelineReader.ACTIVE_KEY, Stage.Mode.INACTIVE.toString()));
 	}
 	
 	
@@ -70,7 +70,7 @@ public class MongoPipelineWriter implements PipelineWriter<MongoType> {
 		props.put(MongoPipelineReader.PROPERTIES_MAP_SUBKEY, s.getProperties());
 		
 		obj.put(MongoPipelineReader.PROPERTIES_KEY, props);
-		obj.put(MongoPipelineReader.ACTIVE_KEY, true);
+		obj.put(MongoPipelineReader.ACTIVE_KEY, Stage.Mode.ACTIVE.toString());
 		if(s.getDatabaseFile()!=null) {
 			obj.put(MongoPipelineReader.FILE_KEY, s.getDatabaseFile().getId());
 		}
@@ -86,7 +86,7 @@ public class MongoPipelineWriter implements PipelineWriter<MongoType> {
 	@Deprecated
 	public void removeInactiveFiles() {
 		BasicDBObject query = new BasicDBObject();
-		query.put(MongoPipelineReader.ACTIVE_KEY, new BasicDBObject("$ne", 1));
+		query.put(MongoPipelineReader.ACTIVE_KEY, Stage.Mode.INACTIVE.toString());
 		List<GridFSDBFile> list = pipelinefs.find(query);
 		for(GridFSDBFile file : list) {
 			pipelinefs.remove(file);

--- a/examples/src/main/java/com/findwise/hydra/CmdlineInserter.java
+++ b/examples/src/main/java/com/findwise/hydra/CmdlineInserter.java
@@ -104,11 +104,17 @@ public class CmdlineInserter {
 	
 	public static Object addFile(MongoConnector dbc, String jar) throws FileNotFoundException, URISyntaxException {
 		URL path = ClassLoader.getSystemResource(jar);
+		File f;
 		if(path==null) {
-			System.out.println("Unable to locate file "+jar);
-			return null;
+			f = new File(jar);
+			if(!f.exists()) {
+				System.out.println("Unable to locate file "+jar);
+				return null;
+			}
 		}
-		File f = new File(path.toURI());
+		else {
+			f = new File(path.toURI());
+		}
 		return dbc.getPipelineWriter().save(f.getName(), new FileInputStream(f));
 	}
 }

--- a/stages/processing/basic/pom.xml
+++ b/stages/processing/basic/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>com.findwise.hydra</groupId>
 			<artifactId>hydra-api</artifactId>
-			<version>0.1.0</version>
+			<version>0.2.0-SNAPSHOT</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>


### PR DESCRIPTION
Made sure CmdlineInserter now looks in the current directory as well as system resource directories for the library jar.

Debug-flag is added to make it possible to store a configuration in the repository, while avoiding it being loaded by Hydra-core. Configuration can still be accessed and injected by AbstractStage though, allowing for IDE debugging.
