### PR TITLE
Allow user generated library file IDs

### DIFF
--- a/database/pom.xml
+++ b/database/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.mongodb</groupId>
 			<artifactId>mongo-java-driver</artifactId>
-			<version>2.7.2</version>
+			<version>2.7.3</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>

--- a/database/src/main/java/com/findwise/hydra/PipelineWriter.java
+++ b/database/src/main/java/com/findwise/hydra/PipelineWriter.java
@@ -18,6 +18,13 @@ public interface PipelineWriter<T extends DatabaseType> {
 	 * @return the id of the written file
 	 */
 	Object save(String filename, InputStream file);
+
+	/**
+	 * Saves a file to the database with the given id
+	 * 
+	 * @return true if save was successful. 
+	 */
+	boolean save(Object id, String fileName, InputStream file);
 	
 	/**
 	 * Removes a file from the database.
@@ -36,4 +43,5 @@ public interface PipelineWriter<T extends DatabaseType> {
 	 * brand new, and needs to be set up in some way.
 	 */
 	void prepare();
+
 }

--- a/database/src/main/java/com/findwise/hydra/mongodb/MongoPipelineWriter.java
+++ b/database/src/main/java/com/findwise/hydra/mongodb/MongoPipelineWriter.java
@@ -99,6 +99,16 @@ public class MongoPipelineWriter implements PipelineWriter<MongoType> {
 		inputFile.save();
 		return inputFile.getId();
 	}
+	
+	@Override
+	public boolean save(Object id, String fileName, InputStream file) {
+		pipelinefs.remove(new BasicDBObject(MongoDocument.MONGO_ID_KEY, id));
+		
+		GridFSInputFile inputFile = pipelinefs.createFile(file, fileName);
+		inputFile.put("_id", id);
+		inputFile.save();
+		return true;
+	}
 
 	@Override
 	public boolean deleteFile(Object id) {

--- a/examples/src/main/java/com/findwise/hydra/CmdlineInserter.java
+++ b/examples/src/main/java/com/findwise/hydra/CmdlineInserter.java
@@ -33,7 +33,13 @@ public class CmdlineInserter {
 		
 		if(args[0].equals("add")) {
 			if(args[1].equals("library")) {
-				Object outId = addFile(mdc, args[3]);
+				Object outId;
+				if(args.length<5) {
+					outId = addFile(mdc, args[3]);
+				}
+				else {
+					outId = addFile(mdc, args[3], args[4]);
+				}
 				if(outId!=null) {
 					System.out.println("Added stage library with id: "+outId);
 				}
@@ -49,7 +55,11 @@ public class CmdlineInserter {
 					map = SerializationUtils.fromJson(maps);
 				}
 				DatabaseFile df = new DatabaseFile();
-				df.setId(new ObjectId(libraryId));
+				try {
+					df.setId(new ObjectId(libraryId));
+				} catch(Exception e) {
+					df.setId(libraryId);
+				}
 				Stage s = new Stage(name, df);
 				s.setProperties(map);
 				Pipeline<Stage> pipeline = mdc.getPipelineReader().getPipeline();
@@ -101,8 +111,11 @@ public class CmdlineInserter {
 		return fileData.toString();
 	}
 
-	
 	public static Object addFile(MongoConnector dbc, String jar) throws FileNotFoundException, URISyntaxException {
+		return addFile(dbc, jar, null);
+	}
+	
+	public static Object addFile(MongoConnector dbc, String jar, String id) throws FileNotFoundException, URISyntaxException {
 		URL path = ClassLoader.getSystemResource(jar);
 		File f;
 		if(path==null) {
@@ -115,6 +128,10 @@ public class CmdlineInserter {
 		else {
 			f = new File(path.toURI());
 		}
-		return dbc.getPipelineWriter().save(f.getName(), new FileInputStream(f));
+		if(id==null) {
+			return dbc.getPipelineWriter().save(f.getName(), new FileInputStream(f));			
+		}
+		dbc.getPipelineWriter().save(id, f.getName(), new FileInputStream(f));
+		return id;
 	}
 }


### PR DESCRIPTION
Adding support for user generated file IDs (e.g. allowing the filename
to be the ID, for instance)

This allows for an easier scripted configuration with Maven or similar
tools.
