### PR TITLE
updated solr-out to support the sendAll parameter, not requireing fieldmapping. Also added automatically building of example into inserter-jar-with-dependencies.jar

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,10 +1,11 @@
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>com.findwise.hydra</groupId>
-  <artifactId>hydra-examples</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-  <name>Hydra Test Setups</name>
-  <description>Contains scripts to perform certain manual tests</description>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.findwise.hydra</groupId>
+    <artifactId>hydra-examples</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>Hydra Test Setups</name>
+    <description>Contains scripts to perform certain manual tests</description>
     <build>
         <plugins>
             <plugin>
@@ -15,6 +16,12 @@
                     <source>1.6</source>
                     <target>1.6</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>com.findwise.hydra.CmdlineInserter</mainClass>
+                        </manifest>
+                    </archive>                    
                 </configuration>
             </plugin>
             <plugin>
@@ -25,38 +32,63 @@
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <finalName>inserter</finalName>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>com.findwise.hydra.CmdlineInserter</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            
         </plugins>
     </build>
     <dependencies>
-  	<dependency>
-  		<groupId>com.findwise.hydra</groupId>
-  		<artifactId>hydra-database</artifactId>
-  		<version>0.2.0-SNAPSHOT</version>
-  		<type>jar</type>
-  		<scope>compile</scope>
-  	</dependency>
-  	<dependency>
-  		<groupId>com.findwise.hydra</groupId>
-  		<artifactId>hydra-basic-stages</artifactId>
-  		<version>0.2.0-SNAPSHOT</version>
-  		<type>jar</type>
-  		<scope>compile</scope>
-  	</dependency>
-  	<dependency>
-  		<groupId>ch.qos.logback</groupId>
-  		<artifactId>logback-classic</artifactId>
-  		<version>1.0.0</version>
-  		<type>jar</type>
-  		<scope>compile</scope>
-  	</dependency>
-  	<dependency>
-  		<groupId>commons-lang</groupId>
-  		<artifactId>commons-lang</artifactId>
-  		<version>2.1</version>
-  		<type>jar</type>
-  		<scope>compile</scope>
-  	</dependency>
-  </dependencies>
+        <dependency>
+            <groupId>com.findwise.hydra</groupId>
+            <artifactId>hydra-database</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+            <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.findwise.hydra</groupId>
+            <artifactId>hydra-basic-stages</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+            <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.0.0</version>
+            <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.1</version>
+            <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/stages/out/solr-out/src/test/java/com/findwise/hydra/output/solr/SolrOutputStageTest.java
+++ b/stages/out/solr-out/src/test/java/com/findwise/hydra/output/solr/SolrOutputStageTest.java
@@ -17,138 +17,161 @@ import java.util.List;
 import java.util.Map;
 
 public class SolrOutputStageTest {
-	
-	SolrOutputStage solrOutput;
-	SolrServer mockServer;
-	RemotePipeline mockRP;
 
-	@Before
-	public void setUp() throws Exception {
-		solrOutput = new SolrOutputStage();
-		mockServer = Mockito.mock(SolrServer.class);
+    SolrOutputStage solrOutput;
+    SolrServer mockServer;
+    RemotePipeline mockRP;
+
+    @Before
+    public void setUp() throws Exception {
+        solrOutput = new SolrOutputStage();
+        mockServer = Mockito.mock(SolrServer.class);
         mockRP = Mockito.mock(RemotePipeline.class);
         solrOutput.setSolrServer(mockServer);
         solrOutput.setRemotePipeline(mockRP);
         solrOutput.init();
-	}
+    }
 
-	@After
-	public void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
+    }
 
-	}
+    @Ignore
+    @Test
+    public void testSolrConnection() throws Exception {
+        LocalDocument doc = new LocalDocument();
+        doc.putContentField("_solrAction", "add");
+        doc.putContentField("id", "someid1");
+        doc.putContentField("name", "jockeh");
+        solrOutput.output(doc);
 
-	@Ignore
-	@Test
-	public void testSolrConnection() throws Exception {
-		LocalDocument doc = new LocalDocument();
-		doc.putContentField("_solrAction", "add");
-		doc.putContentField("id", "someid1");
-		doc.putContentField("name", "jockeh");
-		solrOutput.output(doc);
-		
-		doc.putContentField("_solrAction", "del");
-		solrOutput.output(doc);
-	}
+        doc.putContentField("_solrAction", "del");
+        solrOutput.output(doc);
+    }
 
-	@Test
-	public void testAdd() throws Exception {
-                solrOutput.setFieldMappings(new HashMap<String, String>());
-                
-		LocalDocument doc = new LocalDocument();
-		doc.setAction(Action.ADD);
-		doc.putContentField("name", "jonas");
-		solrOutput.output(doc);
-		Mockito.verify(mockServer).add(Mockito.anyCollectionOf(SolrInputDocument.class));
-	}
-	@Test
-	public void testDelete() throws Exception {
-		LocalDocument doc = new LocalDocument();
-		doc.setAction(Action.DELETE);
-		doc.putContentField("name", "jonas");
-		solrOutput.output(doc);
-		Mockito.verify(mockServer).deleteById(Mockito.anyListOf(String.class));
-	}
-	@Test
-	public void testSendLimit() throws Exception {
-                solrOutput.setFieldMappings(new HashMap<String, String>());
-		solrOutput.setSendLimit(5);
-		solrOutput.setCommitLimit(15);
-		LocalDocument doc = new LocalDocument();
-		doc.setAction(Action.ADD);
-		doc.putContentField("name", "one");
-		solrOutput.output(doc);
-		doc = new LocalDocument();
-		doc.setAction(Action.ADD);
-		doc.putContentField("name", "two");
-		solrOutput.output(doc);
-		doc = new LocalDocument();
-		doc.setAction(Action.ADD);
-		doc.putContentField("name", "three");
-		solrOutput.output(doc);
-		doc = new LocalDocument();
-		doc.setAction(Action.ADD);
-		doc.putContentField("name", "four");
-		solrOutput.output(doc);
-		doc = new LocalDocument();
-		doc.setAction(Action.ADD);
-		doc.putContentField("name", "five");
-		solrOutput.output(doc);
-		Mockito.verify(mockServer,Mockito.times(1)).add(Mockito.anyCollectionOf(SolrInputDocument.class));
-	}
-	
-	@Test
-	public void testCommitLimit() throws Exception {
-                solrOutput.setFieldMappings(new HashMap<String, String>());
-		solrOutput.setSendLimit(15);
-		solrOutput.setCommitLimit(5);
-		LocalDocument doc = new LocalDocument();
-		doc.setAction(Action.ADD);
-		doc.putContentField("name", "one");
-		solrOutput.output(doc);
-		doc = new LocalDocument();
-		doc.setAction(Action.ADD);
-		doc.putContentField("name", "two");
-		solrOutput.output(doc);
-		doc = new LocalDocument();
-		doc.setAction(Action.ADD);
-		doc.putContentField("name", "three");
-		solrOutput.output(doc);
-		doc = new LocalDocument();
-		doc.setAction(Action.ADD);
-		doc.putContentField("name", "four");
-		solrOutput.output(doc);
-		doc = new LocalDocument();
-		doc.setAction(Action.ADD);
-		doc.putContentField("name", "five");
-		solrOutput.output(doc);
-		Mockito.verify(mockServer,Mockito.times(1)).commit();
-	}
-        
-        @Test
-	public void testFieldConfig() throws Exception {
-		LocalDocument doc = new LocalDocument();
-		doc.putContentField("name", "jens");
-                doc.putContentField("reference", "http://www.giantbomb.com");
-                List<String> multiValued = new ArrayList<String>();
-                multiValued.add("james bond");
-                multiValued.add("heman");
-                doc.putContentField("hero", multiValued);
-                                           
-                Map<String, String> fieldMappings = new HashMap<String, String>();
-                fieldMappings.put("name", "fullname");
-                fieldMappings.put("reference", "url");
-                fieldMappings.put("doesnotexist", "doesnotmatter");
-                fieldMappings.put("hero", "heroes");
-                
-                solrOutput.setFieldMappings(fieldMappings);
-                                
-                SolrInputDocument inputDoc = solrOutput.createSolrInputDocumentWithFieldConfig(doc);
-   
-                org.junit.Assert.assertEquals(inputDoc.getFieldValue("fullname"),
-                        doc.getContentField("name").toString());
-                              
-                org.junit.Assert.assertArrayEquals(multiValued.toArray(), 
-                        inputDoc.getFieldValues("heroes").toArray());
-               
-	}
+    @Test
+    public void testAdd() throws Exception {
+        solrOutput.setFieldMappings(new HashMap<String, String>());
+
+        LocalDocument doc = new LocalDocument();
+        doc.setAction(Action.ADD);
+        doc.putContentField("name", "jonas");
+        solrOutput.output(doc);
+        Mockito.verify(mockServer).add(Mockito.anyCollectionOf(SolrInputDocument.class));
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        LocalDocument doc = new LocalDocument();
+        doc.setAction(Action.DELETE);
+        doc.putContentField("name", "jonas");
+        solrOutput.output(doc);
+        Mockito.verify(mockServer).deleteById(Mockito.anyListOf(String.class));
+    }
+
+    @Test
+    public void testSendLimit() throws Exception {
+        solrOutput.setFieldMappings(new HashMap<String, String>());
+        solrOutput.setSendLimit(5);
+        solrOutput.setCommitLimit(15);
+        LocalDocument doc = new LocalDocument();
+        doc.setAction(Action.ADD);
+        doc.putContentField("name", "one");
+        solrOutput.output(doc);
+        doc = new LocalDocument();
+        doc.setAction(Action.ADD);
+        doc.putContentField("name", "two");
+        solrOutput.output(doc);
+        doc = new LocalDocument();
+        doc.setAction(Action.ADD);
+        doc.putContentField("name", "three");
+        solrOutput.output(doc);
+        doc = new LocalDocument();
+        doc.setAction(Action.ADD);
+        doc.putContentField("name", "four");
+        solrOutput.output(doc);
+        doc = new LocalDocument();
+        doc.setAction(Action.ADD);
+        doc.putContentField("name", "five");
+        solrOutput.output(doc);
+        Mockito.verify(mockServer, Mockito.times(1)).add(Mockito.anyCollectionOf(SolrInputDocument.class));
+    }
+
+    @Test
+    public void testCommitLimit() throws Exception {
+        solrOutput.setFieldMappings(new HashMap<String, String>());
+        solrOutput.setSendLimit(15);
+        solrOutput.setCommitLimit(5);
+        LocalDocument doc = new LocalDocument();
+        doc.setAction(Action.ADD);
+        doc.putContentField("name", "one");
+        solrOutput.output(doc);
+        doc = new LocalDocument();
+        doc.setAction(Action.ADD);
+        doc.putContentField("name", "two");
+        solrOutput.output(doc);
+        doc = new LocalDocument();
+        doc.setAction(Action.ADD);
+        doc.putContentField("name", "three");
+        solrOutput.output(doc);
+        doc = new LocalDocument();
+        doc.setAction(Action.ADD);
+        doc.putContentField("name", "four");
+        solrOutput.output(doc);
+        doc = new LocalDocument();
+        doc.setAction(Action.ADD);
+        doc.putContentField("name", "five");
+        solrOutput.output(doc);
+        Mockito.verify(mockServer, Mockito.times(1)).commit();
+    }
+
+    @Test
+    public void testFieldConfig() throws Exception {
+        LocalDocument doc = new LocalDocument();
+        doc.putContentField("name", "jens");
+        doc.putContentField("reference", "http://www.giantbomb.com");
+        List<String> multiValued = new ArrayList<String>();
+        multiValued.add("james bond");
+        multiValued.add("heman");
+        doc.putContentField("hero", multiValued);
+
+        Map<String, String> fieldMappings = new HashMap<String, String>();
+        fieldMappings.put("name", "fullname");
+        fieldMappings.put("reference", "url");
+        fieldMappings.put("doesnotexist", "doesnotmatter");
+        fieldMappings.put("hero", "heroes");
+
+        solrOutput.setFieldMappings(fieldMappings);
+        SolrInputDocument inputDoc = solrOutput.createSolrInputDocumentWithFieldConfig(doc);
+
+        org.junit.Assert.assertEquals(inputDoc.getFieldValue("fullname"),
+                doc.getContentField("name").toString());
+
+        org.junit.Assert.assertArrayEquals(multiValued.toArray(),
+                inputDoc.getFieldValues("heroes").toArray());
+
+    }
+
+    @Test
+    public void testFieldConfigWithSendallTrue() throws Exception {
+        LocalDocument doc = new LocalDocument();
+        doc.putContentField("name", "jens");
+        doc.putContentField("reference", "http://www.giantbomb.com");
+        List<String> multiValued = new ArrayList<String>();
+        multiValued.add("james bond");
+        multiValued.add("heman");
+        doc.putContentField("hero", multiValued);
+        solrOutput.setSendAll(true);
+        SolrInputDocument inputDoc = solrOutput.createSolrInputDocumentWithFieldConfig(doc);
+
+        org.junit.Assert.assertEquals(inputDoc.getFieldValue("name"),
+                doc.getContentField("name").toString());
+
+        org.junit.Assert.assertEquals(inputDoc.getFieldValue("reference"),
+                doc.getContentField("reference").toString());
+
+        org.junit.Assert.assertArrayEquals(((ArrayList) doc.getContentField("hero")).toArray(),
+                inputDoc.getFieldValues("hero").toArray());
+
+    }
 }


### PR DESCRIPTION
man...github is really, really cool

(this is Roar Granevang, btw)
