### PR TITLE
Adding support for marking a document as FAILED

### DIFF
--- a/api/src/main/java/com/findwise/hydra/common/Document.java
+++ b/api/src/main/java/com/findwise/hydra/common/Document.java
@@ -16,6 +16,7 @@ public interface Document extends JsonDeserializer, JsonSerializer {
 	String PENDING_METADATA_FLAG = "pending";
 	String PROCESSED_METADATA_FLAG = "processed";
 	String DISCARDED_METADATA_FLAG = "discarded";
+	String FAILED_METADATA_FLAG = "failed";
 	String DATE_METADATA_SUBKEY = "date";
 	String STAGE_METADATA_SUBKEY = "stage";
 	String ERROR_METADATA_KEY = "error";

--- a/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
+++ b/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
@@ -21,6 +21,7 @@ public class RemotePipeline {
 	public static final String PENDING_DOCUMENT_URL = "pendingDocument";
 	public static final String DISCARDED_DOCUMENT_URL = "discardedDocument";
 	public static final String GET_PROPERTIES_URL = "getProperties";
+	public static final String FAILED_DOCUMENT_URL = "failedDocument";
 	
 	public static final String STAGE_PARAM = "stage";
 	public static final String RECURRING_PARAM = "recurring";
@@ -39,6 +40,7 @@ public class RemotePipeline {
 	private String writeUrl;
 	private String releaseUrl;
 	private String processedUrl;
+	private String failedUrl;
 	private String pendingUrl;
 	private String discardedUrl;
 	private String propertyUrl;
@@ -60,6 +62,7 @@ public class RemotePipeline {
 		writeUrl = "/"+WRITE_DOCUMENT_URL+"?"+STAGE_PARAM+"="+stageName;
 		releaseUrl = "/"+RELEASE_DOCUMENT_URL+"?"+STAGE_PARAM+"="+stageName;
 		processedUrl = "/"+PROCESSED_DOCUMENT_URL+"?"+STAGE_PARAM+"="+stageName;
+		failedUrl = "/"+FAILED_DOCUMENT_URL+"?"+STAGE_PARAM+"="+stageName;
 		pendingUrl = "/"+PENDING_DOCUMENT_URL+"?"+STAGE_PARAM+"="+stageName;
 		discardedUrl = "/"+DISCARDED_DOCUMENT_URL+"?"+STAGE_PARAM+"="+stageName;
 		propertyUrl = "/"+GET_PROPERTIES_URL+"?"+STAGE_PARAM+"="+stageName;
@@ -211,6 +214,19 @@ public class RemotePipeline {
 	
 	public boolean markPending(LocalDocument d) throws IOException, HttpException {
 		HttpResponse response = core.post(pendingUrl, d.contentFieldsToJson(null));
+		if(response.getStatusLine().getStatusCode()==HttpStatus.SC_OK) {
+			EntityUtils.consume(response.getEntity());
+		
+			return true;
+		}
+		
+		logUnexpected(response);
+		
+		return false;
+	}
+	
+	public boolean markFailed(LocalDocument d) throws IOException, HttpException {
+		HttpResponse response = core.post(failedUrl, d.contentFieldsToJson(null));
 		if(response.getStatusLine().getStatusCode()==HttpStatus.SC_OK) {
 			EntityUtils.consume(response.getEntity());
 		

--- a/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
+++ b/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
@@ -226,7 +226,7 @@ public class RemotePipeline {
 	}
 	
 	public boolean markFailed(LocalDocument d) throws IOException, HttpException {
-		HttpResponse response = core.post(failedUrl, d.contentFieldsToJson(null));
+		HttpResponse response = core.post(failedUrl, d.modifiedFieldsToJson());
 		if(response.getStatusLine().getStatusCode()==HttpStatus.SC_OK) {
 			EntityUtils.consume(response.getEntity());
 		
@@ -239,7 +239,7 @@ public class RemotePipeline {
 	}
 	
 	public boolean markProcessed(LocalDocument d) throws IOException, HttpException {
-		HttpResponse response = core.post(processedUrl, d.contentFieldsToJson(null));
+		HttpResponse response = core.post(processedUrl, d.modifiedFieldsToJson());
 		if(response.getStatusLine().getStatusCode()==HttpStatus.SC_OK) {
 			EntityUtils.consume(response.getEntity());
 		
@@ -252,7 +252,7 @@ public class RemotePipeline {
 	}
 	
 	public boolean markDiscarded(LocalDocument d) throws IOException, HttpException {
-		HttpResponse response = core.post(discardedUrl, d.contentFieldsToJson(null));
+		HttpResponse response = core.post(discardedUrl, d.modifiedFieldsToJson());
 		if(response.getStatusLine().getStatusCode()==HttpStatus.SC_OK) {
 			EntityUtils.consume(response.getEntity());
 		

--- a/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
+++ b/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
@@ -45,6 +45,8 @@ public class RemotePipeline {
 	private String discardedUrl;
 	private String propertyUrl;
 	
+	private String stageName;
+	
 	private LocalDocument currentDocument;
 	
 	/**
@@ -58,6 +60,7 @@ public class RemotePipeline {
 	}
 	
 	public RemotePipeline(String hostName, int port, String stageName) {
+		this.stageName = stageName;
 		getUrl = "/"+GET_DOCUMENT_URL+"?"+STAGE_PARAM+"="+stageName;
 		writeUrl = "/"+WRITE_DOCUMENT_URL+"?"+STAGE_PARAM+"="+stageName;
 		releaseUrl = "/"+RELEASE_DOCUMENT_URL+"?"+STAGE_PARAM+"="+stageName;
@@ -236,6 +239,11 @@ public class RemotePipeline {
 		logUnexpected(response);
 		
 		return false;
+	}
+	
+	public boolean markFailed(LocalDocument d, Throwable t) throws IOException, HttpException {
+		d.addError(stageName, t);
+		return markFailed(d);
 	}
 	
 	public boolean markProcessed(LocalDocument d) throws IOException, HttpException {

--- a/core/src/main/java/com/findwise/hydra/net/HttpRESTHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/HttpRESTHandler.java
@@ -32,6 +32,8 @@ import com.google.inject.Inject;
 public class HttpRESTHandler implements HttpRequestHandler  {
 	private Logger logger = LoggerFactory.getLogger(HttpRESTHandler.class);
 	
+	private enum Mark { PENDING, PROCESSED, DISCARDED, FAILED };
+	
 	private NodeMaster nm;
 	
 	private String restId;
@@ -89,13 +91,16 @@ public class HttpRESTHandler implements HttpRequestHandler  {
 			handleWriteDocument(request, response);
 			return true;
 		} else if (uri.startsWith(RemotePipeline.PROCESSED_DOCUMENT_URL)) {
-			handleProcessedDocument(request, response);
+			handleMark(request, response, Mark.PROCESSED);
 			return true;
 		} else if (uri.startsWith(RemotePipeline.PENDING_DOCUMENT_URL)) {
-			handlePendingDocument(request, response);
+			handleMark(request, response, Mark.PENDING);
 			return true;
 		} else if (uri.startsWith(RemotePipeline.DISCARDED_DOCUMENT_URL)) {
-			handleDiscardedRequest(request, response);
+			handleMark(request, response, Mark.DISCARDED);
+			return true;
+		} else if (uri.startsWith(RemotePipeline.FAILED_DOCUMENT_URL)) {
+			handleMark(request, response, Mark.FAILED);
 			return true;
 		}
 		
@@ -225,92 +230,50 @@ public class HttpRESTHandler implements HttpRequestHandler  {
 		return nm.getDatabaseConnector().getDocumentWriter().markTouched(md.getID(),stage);
 	}
 	
-	private void handleProcessedDocument(HttpRequest request, HttpResponse response) throws IOException {
-		logger.trace("handleProcessedDocument()");
-        HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request).getEntity();
-        String requestContent = EntityUtils.toString(requestEntity);
-        
-        String stage = getParam(request, RemotePipeline.STAGE_PARAM);
-        if(stage==null) {
-        	HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
-        	return;
-        }
-        
-        DatabaseDocument<MongoType> md;
-        try {
-        	md = nm.getDatabaseConnector().convert(new LocalDocument(requestContent));
-        }
-        catch(JsonException e) {
-        	HttpResponseWriter.printJsonException(response, e);
-        	return;
-        }
-        
-        boolean res = nm.getDatabaseConnector().getDocumentWriter().markProcessed(md, stage);
-        if(!res) {
-        	HttpResponseWriter.printNoDocument(response);
-        }
-        else {
-        	HttpResponseWriter.printSaveOk(response, md.getID());
-        }
-	}
-	
-	private void handlePendingDocument(HttpRequest request, HttpResponse response) throws IOException {
-		logger.trace("handlePendingDocument()");
-        HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request).getEntity();
-        String requestContent = EntityUtils.toString(requestEntity);
-        
-        String stage = getParam(request, RemotePipeline.STAGE_PARAM);
-        if(stage==null) {
-        	HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
-        	return;
-        }
-        
-        DatabaseDocument<MongoType> md;
-        try {
-        	md = nm.getDatabaseConnector().convert(new LocalDocument(requestContent));
-        }
-        catch(JsonException e) {
-        	HttpResponseWriter.printJsonException(response, e);
-        	return;
-        }
-        boolean res = nm.getDatabaseConnector().getDocumentWriter().markPending(md, stage);
-        if(!res) {
-            logger.debug("Missing document: "+md.toJson());
-        	HttpResponseWriter.printNoDocument(response);
-        }
-        else {
-        	HttpResponseWriter.printSaveOk(response, md.getID());
-        }
-	}
-	
-	private void handleDiscardedRequest(HttpRequest request, HttpResponse response) throws IOException {
-		logger.trace("handleDiscardedRequest()");
-        HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request).getEntity();
-        String requestContent = EntityUtils.toString(requestEntity);
-        
-        String stage = getParam(request, RemotePipeline.STAGE_PARAM);
-        if(stage==null) {
-        	HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
-        	return;
-        }
-        
-        DatabaseDocument<MongoType> md;
-        try {
-        	md = nm.getDatabaseConnector().convert(new LocalDocument(requestContent));
-        }
-        catch(JsonException e) {
-        	HttpResponseWriter.printJsonException(response, e);
-        	return;
-        }
-        
-        boolean res = nm.getDatabaseConnector().getDocumentWriter().markDiscarded(md, stage);
-        
-        if(!res) {
-        	HttpResponseWriter.printNoDocument(response);
-        }
-        else {
-        	HttpResponseWriter.printSaveOk(response, md.getID());
-        }
+	private void handleMark(HttpRequest request, HttpResponse response, Mark mark) throws IOException {
+		logger.trace("handleMark(..., ..., "+mark.toString()+")");
+		
+		HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request).getEntity();
+		String requestContent = EntityUtils.toString(requestEntity);
+
+		String stage = getParam(request, RemotePipeline.STAGE_PARAM);
+		if (stage == null) {
+			HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
+			return;
+		}
+
+		DatabaseDocument<MongoType> md;
+		try {
+			md = nm.getDatabaseConnector().convert(new LocalDocument(requestContent));
+		} catch (JsonException e) {
+			HttpResponseWriter.printJsonException(response, e);
+			return;
+		}
+
+		boolean res = false;
+		switch (mark) {
+			case PENDING: {
+				res = nm.getDatabaseConnector().getDocumentWriter().markPending(md, stage);
+				break;
+			}
+			case PROCESSED: {
+				res = nm.getDatabaseConnector().getDocumentWriter().markProcessed(md, stage);
+				break;
+			}
+			case FAILED: {
+				break;
+			}
+			case DISCARDED: {
+				res = nm.getDatabaseConnector().getDocumentWriter().markDiscarded(md, stage);
+				break;
+			}
+		}
+
+		if (!res) {
+			HttpResponseWriter.printNoDocument(response);
+		} else {
+			HttpResponseWriter.printSaveOk(response, md.getID());
+		}
 	}
  
 	private void handleWriteDocument(HttpRequest request, HttpResponse response) throws IOException {

--- a/core/src/main/java/com/findwise/hydra/net/HttpRESTHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/HttpRESTHandler.java
@@ -261,6 +261,7 @@ public class HttpRESTHandler implements HttpRequestHandler  {
 				break;
 			}
 			case FAILED: {
+				res = nm.getDatabaseConnector().getDocumentWriter().markFailed(md, stage);
 				break;
 			}
 			case DISCARDED: {

--- a/database/src/main/java/com/findwise/hydra/DocumentReader.java
+++ b/database/src/main/java/com/findwise/hydra/DocumentReader.java
@@ -21,6 +21,12 @@ public interface DocumentReader<T extends DatabaseType> {
 
 	DatabaseDocument<T> getDocumentById(Object id, boolean includeInactive);
 	
+	/**
+	 * Returns a TailableIterator over all inactive documents, no longer being
+	 * processed. 
+	 */
+	TailableIterator<T> getInactiveIterator();
+	
 	List<DatabaseDocument<T>> getDocuments(DatabaseQuery<T> q, int limit);
 
 	DocumentFile getDocumentFile(DatabaseDocument<T> d) throws IOException;

--- a/database/src/main/java/com/findwise/hydra/DocumentReader.java
+++ b/database/src/main/java/com/findwise/hydra/DocumentReader.java
@@ -19,6 +19,8 @@ public interface DocumentReader<T extends DatabaseType> {
 
 	DatabaseDocument<T> getDocumentById(Object id);
 
+	DatabaseDocument<T> getDocumentById(Object id, boolean includeInactive);
+	
 	List<DatabaseDocument<T>> getDocuments(DatabaseQuery<T> q, int limit);
 
 	DocumentFile getDocumentFile(DatabaseDocument<T> d) throws IOException;

--- a/database/src/main/java/com/findwise/hydra/DocumentWriter.java
+++ b/database/src/main/java/com/findwise/hydra/DocumentWriter.java
@@ -93,6 +93,22 @@ public interface DocumentWriter<T extends DatabaseType> {
 	 * @return
 	 */
 	boolean markDiscarded(DatabaseDocument<T> d, String stage);
+	
+	/**
+	 * Indicates that the document has failed in processing, without having been
+	 * successfully passed out of it. A valid reason for this might be that the 
+	 * output stage threw  an exception while sending the document out.
+	 * 
+	 * After this method is called on a given document, it should not show up in
+	 * normal get-operations performed by this interface.
+	 * 
+	 * @param d
+	 *            the document to fail
+	 * @param stage
+	 *            the name of the stage that discarded this document.
+	 * @return
+	 */
+	boolean markFailed(DatabaseDocument<T> d, String stage);
 
 	/**
 	 * Indicates that this document has reached an output stage which will

--- a/database/src/main/java/com/findwise/hydra/TailableIterator.java
+++ b/database/src/main/java/com/findwise/hydra/TailableIterator.java
@@ -1,0 +1,7 @@
+package com.findwise.hydra;
+
+import java.util.Iterator;
+
+public interface TailableIterator<T extends DatabaseType> extends Iterator<DatabaseDocument<T>> {
+	void interrupt();
+}

--- a/database/src/main/java/com/findwise/hydra/mongodb/MongoDocumentIO.java
+++ b/database/src/main/java/com/findwise/hydra/mongodb/MongoDocumentIO.java
@@ -17,6 +17,7 @@ import com.findwise.hydra.common.Document;
 import com.findwise.hydra.common.DocumentFile;
 import com.mongodb.BasicDBObject;
 import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.Bytes;
 import com.mongodb.CommandResult;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
@@ -450,5 +451,10 @@ public class MongoDocumentIO implements DocumentReader<MongoType>, DocumentWrite
 	@Override
 	public long getInactiveDatabaseSize() {
 		return oldDocuments.count();
+	}
+
+	@Override
+	public MongoTailableIterator getInactiveIterator() {
+		return new MongoTailableIterator(oldDocuments.find(new BasicDBObject()).sort(new BasicDBObject("$natural", 1)).addOption(Bytes.QUERYOPTION_TAILABLE).addOption(Bytes.QUERYOPTION_AWAITDATA));
 	}
 }

--- a/database/src/main/java/com/findwise/hydra/mongodb/MongoTailableIterator.java
+++ b/database/src/main/java/com/findwise/hydra/mongodb/MongoTailableIterator.java
@@ -1,0 +1,53 @@
+package com.findwise.hydra.mongodb;
+
+import java.util.Iterator;
+
+import com.findwise.hydra.DatabaseDocument;
+import com.findwise.hydra.TailableIterator;
+import com.mongodb.DBCursor;
+import com.mongodb.MongoException.CursorNotFound;
+
+public class MongoTailableIterator implements TailableIterator<MongoType> {
+
+	private Iterator<DatabaseDocument<MongoType>> iterator; 
+	private DBCursor cursor;
+	
+	boolean closed = false;
+	
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public MongoTailableIterator(DBCursor cursor) {
+		this.cursor = cursor;
+		this.iterator = (Iterator) cursor;
+	}
+	
+	@Override
+	public boolean hasNext() {
+		try {
+			if(closed) {
+				return false;
+			}
+			return iterator.hasNext();
+		} catch(CursorNotFound e) {
+			return false;
+		}
+	}
+
+	@Override
+	public DatabaseDocument<MongoType> next() {
+		if(closed) {
+			return null;
+		}
+		return iterator.next();
+	}
+
+	@Override
+	public void remove() {
+		throw new UnsupportedOperationException("remove() is not supported");
+	}
+
+	@Override
+	public void interrupt() {
+		cursor.close();
+	}
+
+}

--- a/database/src/test/java/com/findwise/hydra/mongodb/MongoConnectorTest.java
+++ b/database/src/test/java/com/findwise/hydra/mongodb/MongoConnectorTest.java
@@ -297,6 +297,26 @@ public class MongoConnectorTest {
 	}
 	
 	@Test
+	public void testFailedDocument() {		
+		DatabaseDocument<MongoType> failed = mdc.getDocumentWriter().getAndTag(new MongoQuery(), "failedTag");
+		
+		mdc.getDocumentWriter().markFailed(failed, "test_stage");
+		
+		if(mdc.getDocumentReader().getDocumentById(failed.getID())!=null) {
+			fail("Failed document was retrieved after discard");
+		}
+		
+		DatabaseDocument<MongoType> old = mdc.getDocumentReader().getDocumentById(failed.getID(), true);
+		if(old==null) {
+			fail("Failed to find the document in the 'old' database");
+		}
+		
+		if(!old.getMetadataMap().containsKey(Document.FAILED_METADATA_FLAG)) {
+			fail("No failed flag on the document");
+		}
+	}
+	
+	@Test
 	public void testActiveDatabaseSize() {
 		if(mdc.getDocumentReader().getActiveDatabaseSize() != 3) {
 			fail("Not the correct active database size. Expected 3 got: "+mdc.getDocumentReader().getActiveDatabaseSize());


### PR DESCRIPTION
New exit status from the pipeline FAILED is added, along with, as it were, exit statuses in general.

The markFailed() method will allow documents in the oldDocuments collection to be found which have had a failiure in the pipeline (such as an exception in a critical stage). Any stage may call markFailed(), though it is recommended to do it only from the output stage or if you have some critical business logic that you know must have a precondition that the document does not meet. If your case is the latter, use with caution.
