### PR TITLE
Refactored RESTHandlers to accept any DatabaseConnector

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -155,6 +155,13 @@
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.findwise.hydra</groupId>
+			<artifactId>hydra-memorydb</artifactId>
+			<version>0.2.0-SNAPSHOT</version>
+			<type>jar</type>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 

--- a/core/src/main/java/com/findwise/hydra/net/HttpRESTHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/HttpRESTHandler.java
@@ -48,6 +48,10 @@ public class HttpRESTHandler implements HttpRequestHandler  {
 	}
 
 	public void handle(final HttpRequest request, final HttpResponse response, final HttpContext context) {
+		if(!accessAllowed(request)) {
+			HttpResponseWriter.printAccessDenied(response);
+			return;
+		}
 		try {
 			logger.debug("Parsing incoming request");
 			
@@ -105,6 +109,8 @@ public class HttpRESTHandler implements HttpRequestHandler  {
 		}
 		
 		return false;
+	public boolean accessAllowed(HttpRequest request) {
+		return true;
 	}
 	
 	private boolean handleIfGet(HttpRequest request, HttpResponse response) throws IOException {

--- a/core/src/main/java/com/findwise/hydra/net/HttpRESTHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/HttpRESTHandler.java
@@ -1,52 +1,79 @@
 package com.findwise.hydra.net;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.ArrayList;
+import java.util.List;
 
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.protocol.HttpContext;
-import org.apache.http.protocol.HttpRequestHandler;
-import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.findwise.hydra.DatabaseDocument;
-import com.findwise.hydra.DatabaseQuery;
+import com.findwise.hydra.DatabaseType;
 import com.findwise.hydra.NodeMaster;
-import com.findwise.hydra.common.Document;
-import com.findwise.hydra.common.JsonException;
-import com.findwise.hydra.local.LocalDocument;
-import com.findwise.hydra.local.LocalQuery;
-import com.findwise.hydra.local.RemotePipeline;
-import com.findwise.hydra.mongodb.MongoType;
 import com.google.inject.Inject;
 
-public class HttpRESTHandler implements HttpRequestHandler  {
+public class HttpRESTHandler<T extends DatabaseType> implements ResponsibleHandler {
 	private Logger logger = LoggerFactory.getLogger(HttpRESTHandler.class);
-	
-	private enum Mark { PENDING, PROCESSED, DISCARDED, FAILED };
 	
 	private NodeMaster nm;
 	
 	private String restId;
+
+	boolean localhostOnly = false;
+	
+	private ResponsibleHandler[] handlers;
+	
+	private PingHandler pingHandler;
+	
+	public boolean isLocalhostOnly() {
+		return localhostOnly;
+	}
+
+	public void setLocalhostOnly(boolean localhostOnly) {
+		this.localhostOnly = localhostOnly;
+	}
+
+	private PingHandler getPingHandler() {
+		if(pingHandler == null) {
+			pingHandler = new PingHandler(restId);
+		}
+		return pingHandler;
+	}
 	
 	@Inject
     public HttpRESTHandler(NodeMaster nm) {
         this.nm = nm;
     }
 	
+	private void createHandlers() {
+		handlers = new ResponsibleHandler[] { new PropertiesHandler(nm), new MarkHandler(nm.getDatabaseConnector()), new QueryHandler(nm), new ReleaseHandler(nm), new WriteHandler(nm) };
+	}
+	
+	private ResponsibleHandler[] getHandlers() {
+		if(handlers==null) {
+			createHandlers();
+		}
+		return handlers;
+	}
+	
 	public void setRestId(String restId) {
-		this.restId = restId;
+		getPingHandler().setServerId(restId);
+	}
+	
+	public boolean dispatch(HttpRequest request, HttpResponse response, HttpContext context, ResponsibleHandler ... handlers) throws HttpException, IOException {
+		for(ResponsibleHandler handler : handlers) {
+			if(handler.supports(request)) {
+				handler.handle(request, response, context);
+				return true;
+			}
+		}
+		return false;
 	}
 
+	@Override
 	public void handle(final HttpRequest request, final HttpResponse response, final HttpContext context) {
 		if(!accessAllowed(request)) {
 			HttpResponseWriter.printAccessDenied(response);
@@ -55,26 +82,20 @@ public class HttpRESTHandler implements HttpRequestHandler  {
 		try {
 			logger.debug("Parsing incoming request");
 			
-			if(handleIfPing(request, response)) {
+			if(dispatch(request, response, context, getPingHandler())) {
 				return;
 			}
-
+			
 			if (!nm.isAlive()) {
 				HttpResponseWriter.printDeadNode(response);
 				return;
 			}
 			
-			if(handleIfGet(request, response)) {
+			if(dispatch(request, response, context, getHandlers())) {
 				return;
 			}
 			
-			if(handleIfPost(request, response)) {
-				return;
-			}
-			
-			if(!handleSupportedRequests(request, response)) {
-				HttpResponseWriter.printUnsupportedRequest(response);
-			}
+			HttpResponseWriter.printUnsupportedRequest(response);
 		} catch (Exception e) {
 			logger.error("Unhandled exception occurred", e);
 			HttpResponseWriter.printUnhandledException(response, e);
@@ -82,323 +103,36 @@ public class HttpRESTHandler implements HttpRequestHandler  {
 		}
     }
 	
-	private boolean handleSupportedRequests(HttpRequest request, HttpResponse response) throws IOException {
-		String uri = getUri(request).substring(1);
-		logger.debug("handleSupportedRequests() uri: "+uri);
-		if (uri.startsWith(RemotePipeline.GET_DOCUMENT_URL)) {
-			handleGetDocument(request, response);
-			return true;
-		} else if (uri.startsWith(RemotePipeline.RELEASE_DOCUMENT_URL)) {
-			handleReleaseDocument(request, response);
-			return true;
-		} else if (uri.startsWith(RemotePipeline.WRITE_DOCUMENT_URL)) {
-			handleWriteDocument(request, response);
-			return true;
-		} else if (uri.startsWith(RemotePipeline.PROCESSED_DOCUMENT_URL)) {
-			handleMark(request, response, Mark.PROCESSED);
-			return true;
-		} else if (uri.startsWith(RemotePipeline.PENDING_DOCUMENT_URL)) {
-			handleMark(request, response, Mark.PENDING);
-			return true;
-		} else if (uri.startsWith(RemotePipeline.DISCARDED_DOCUMENT_URL)) {
-			handleMark(request, response, Mark.DISCARDED);
-			return true;
-		} else if (uri.startsWith(RemotePipeline.FAILED_DOCUMENT_URL)) {
-			handleMark(request, response, Mark.FAILED);
-			return true;
-		}
-		
-		return false;
 	public boolean accessAllowed(HttpRequest request) {
 		return true;
 	}
-	
-	private boolean handleIfGet(HttpRequest request, HttpResponse response) throws IOException {
-		String method = request.getRequestLine().getMethod().toUpperCase(Locale.ENGLISH);
-		if (!method.equals("GET")) {
-			return false;
-		}
-		String uri = getUri(request).substring(1);
-		if(uri.startsWith(RemotePipeline.GET_PROPERTIES_URL)) {
-			handleGetProperties(request, response);
+
+	@Override
+	public boolean supports(HttpRequest request) {
+		if(getPingHandler().supports(request)) {
 			return true;
 		}
-		return false;
-	}
-	
-	private boolean handleIfPing(HttpRequest request, HttpResponse response) {
-		String method = request.getRequestLine().getMethod().toUpperCase(Locale.ENGLISH);
-		if (method.equals("GET")) {
-			String uri = getUri(request).substring(1);
-			if (uri.equals("")) {
-				HttpResponseWriter.printID(response, restId);
+		for(ResponsibleHandler handler : handlers) {
+			if(handler.supports(request)) {
 				return true;
 			}
 		}
 		return false;
 	}
-	
-	private boolean handleIfPost(HttpRequest request, HttpResponse response) {
-		if (!(request instanceof HttpEntityEnclosingRequest)) {
-			HttpResponseWriter.printNotPost(response);
-			return true;
+
+	@Override
+	public String[] getSupportedUrls() {
+		List<String> urls = new ArrayList<String>();
+		addArrayToList(getPingHandler().getSupportedUrls(), urls);
+		for(ResponsibleHandler handler : getHandlers()) {
+			addArrayToList(handler.getSupportedUrls(), urls);
 		}
-		return false;
+		return urls.toArray(new String[urls.size()]);
 	}
 	
-	private void handleGetProperties(HttpRequest request, HttpResponse response) throws IOException {
-		logger.trace("handleGetProperties()");
-        String stage = getParam(request, RemotePipeline.STAGE_PARAM);
-        logger.debug("Received getProperties()-request for stage: "+stage);
-        
-        if(stage==null) {
-        	HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
-        	return;
-        }
-        
-        Map<String, Object> map = new HashMap<String, Object>();
-        
-        if(nm.getPipeline().hasStage(stage)) {
-        	map = nm.getPipeline().getStage(stage).getProperties();
-        }
-        else if(nm.getDatabaseConnector().getPipelineReader().getDebugPipeline().hasStage(stage)){
-        	map = nm.getDatabaseConnector().getPipelineReader().getDebugPipeline().getStage(stage).getProperties();
-        } 
-        
-        HttpResponseWriter.printJson(response, map);
-	}
-	
-	private void handleGetDocument(HttpRequest request, HttpResponse response) throws IOException {
-		logger.trace("handleGetDocument()");
-        HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request).getEntity();
-        String requestContent = EntityUtils.toString(requestEntity);
-        String stage = getParam(request, RemotePipeline.STAGE_PARAM);
-        
-        if(stage==null) {
-        	HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
-        	return;
-        }
-        
-        DatabaseQuery<MongoType> dbq;
-        try {
-        	 dbq = requestToQuery(requestContent);
-        } 
-        catch(JsonException e) {
-        	HttpResponseWriter.printJsonException(response, e);
-        	return;
-        }
-        
-        Document d;
-
-        String recurring = getParam(request, RemotePipeline.RECURRING_PARAM);
-
-        if(recurring!=null && recurring.equals("1")) {
-        	d = nm.getDatabaseConnector().getDocumentWriter().getAndTagRecurring(dbq, stage);
-        }
-        else {
-        	d = nm.getDatabaseConnector().getDocumentWriter().getAndTag(dbq, stage);
-        }
-        
-        if(d!=null) {
-        	HttpResponseWriter.printDocument(response, d, stage);
-        }
-        else {
-        	HttpResponseWriter.printNoDocument(response);
-        }
-	}
-	
-	private void handleReleaseDocument(HttpRequest request, HttpResponse response) throws IOException {
-		logger.trace("handleReleaseDocument()");
-        HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request).getEntity();
-        String requestContent = EntityUtils.toString(requestEntity);
-        String stage = getParam(request, RemotePipeline.STAGE_PARAM);
-        
-        if(stage==null) {
-        	HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
-        	return;
-        }
-        
-        try {
-        	boolean x = release(new LocalDocument(requestContent), stage);
-        	if(!x) {
-        		HttpResponseWriter.printNoDocument(response);
-        	}
-        }
-        catch(JsonException e) {
-        	HttpResponseWriter.printJsonException(response, e);
-        	return;
-        }
-        
-        HttpResponseWriter.printDocumentReleased(response);
-	}
-	
-	private boolean release(Document md, String stage) {
-		return nm.getDatabaseConnector().getDocumentWriter().markTouched(md.getID(),stage);
-	}
-	
-	private void handleMark(HttpRequest request, HttpResponse response, Mark mark) throws IOException {
-		logger.trace("handleMark(..., ..., "+mark.toString()+")");
-		
-		HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request).getEntity();
-		String requestContent = EntityUtils.toString(requestEntity);
-
-		String stage = getParam(request, RemotePipeline.STAGE_PARAM);
-		if (stage == null) {
-			HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
-			return;
+	private static <T> void addArrayToList(T[] array, List<T> list) {
+		for(T t : array) {
+			list.add(t);
 		}
-
-		DatabaseDocument<MongoType> md;
-		try {
-			md = nm.getDatabaseConnector().convert(new LocalDocument(requestContent));
-		} catch (JsonException e) {
-			HttpResponseWriter.printJsonException(response, e);
-			return;
-		}
-
-		boolean res = false;
-		switch (mark) {
-			case PENDING: {
-				res = nm.getDatabaseConnector().getDocumentWriter().markPending(md, stage);
-				break;
-			}
-			case PROCESSED: {
-				res = nm.getDatabaseConnector().getDocumentWriter().markProcessed(md, stage);
-				break;
-			}
-			case FAILED: {
-				res = nm.getDatabaseConnector().getDocumentWriter().markFailed(md, stage);
-				break;
-			}
-			case DISCARDED: {
-				res = nm.getDatabaseConnector().getDocumentWriter().markDiscarded(md, stage);
-				break;
-			}
-		}
-
-		if (!res) {
-			HttpResponseWriter.printNoDocument(response);
-		} else {
-			HttpResponseWriter.printSaveOk(response, md.getID());
-		}
-	}
- 
-	private void handleWriteDocument(HttpRequest request, HttpResponse response) throws IOException {
-		logger.trace("handleWriteDocument()");
-        HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request).getEntity();
-        String requestContent = EntityUtils.toString(requestEntity);
-
-        String stage = getParam(request, RemotePipeline.STAGE_PARAM);
-        if(stage==null) {
-        	HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
-        	return;
-        }
-        
-        String partial = getParam(request, RemotePipeline.PARTIAL_PARAM);
-        if(partial==null) {
-        	HttpResponseWriter.printMissingParameter(response, RemotePipeline.PARTIAL_PARAM);
-        	return;
-        }
-        
-        String norelease = getParam(request, RemotePipeline.NORELEASE_PARAM);
-        if(norelease==null) {
-        	HttpResponseWriter.printMissingParameter(response, RemotePipeline.NORELEASE_PARAM);
-        	return;
-        }
-        
-        DatabaseDocument<MongoType> md;
-        try {
-        	md = nm.getDatabaseConnector().convert(new LocalDocument(requestContent));
-        }
-        catch(JsonException e) {
-        	HttpResponseWriter.printJsonException(response, e);
-        	return;
-        }
-        
-        boolean saveRes;
-        if(partial.equals("1")) {
-        	saveRes = handlePartialWrite(md, response);
-        }
-        else {
-        	if(md.getID()!=null) {
-        		saveRes = handleFullUpdate(md, response);
-        	}
-        	else {
-        		saveRes = handleInsert(md, response);
-        	}
-        }
-
-		if (saveRes && norelease.equals("0")) {
-			boolean result = release(md, stage);
-			if (!result) {
-				HttpResponseWriter.printReleaseFailed(response);
-				return;
-			}
-		}
-
-    }
-	
-	private boolean handlePartialWrite(DatabaseDocument<MongoType> md, HttpResponse response) throws UnsupportedEncodingException{
-		logger.trace("handlePartialWrite()");
-		if(md.getID()==null) {
-			HttpResponseWriter.printMissingID(response);
-			return false;
-		}
-		logger.debug("Handling a partial write for document "+md.getID());
-		DatabaseDocument<MongoType> inDB = nm.getDatabaseConnector().getDocumentReader().getDocumentById(md.getID());
-		if(inDB==null) {
-			HttpResponseWriter.printUpdateFailed(response, md.getID());
-			return false;
-		}
-		inDB.putAll(md);
-
-
-		if(nm.getDatabaseConnector().getDocumentWriter().update(inDB)){
-			HttpResponseWriter.printSaveOk(response, md.getID());
-			return true;
-		} 
-		else {
-			HttpResponseWriter.printUpdateFailed(response, md.getID());
-			return false;
-		}
-	}
-	
-	private boolean handleFullUpdate(DatabaseDocument<MongoType> md, HttpResponse response) {
-		logger.trace("handleFullUpdate()");
-		if(nm.getDatabaseConnector().getDocumentWriter().update(md)) {
-			HttpResponseWriter.printSaveOk(response, md.getID());
-			return true;
-		}
-		HttpResponseWriter.printUpdateFailed(response, md.getID());
-		return false;
-	}
-	
-	private boolean handleInsert(DatabaseDocument<MongoType> md, HttpResponse response) {
-		if(nm.getDatabaseConnector().getDocumentWriter().insert(md)) {
-			HttpResponseWriter.printInsertOk(response, md);
-			return true;
-		}
-		else {
-			HttpResponseWriter.printInsertFailed(response);
-			return false;
-		}
-	}
-	
-	public static String getParam(HttpRequest request, String param) {
-		String uri = getUri(request);
-		Pattern p = Pattern.compile("[^\\?]+\\?.*"+param+"=([^&]+)");
-		Matcher m = p.matcher(uri);
-		if(!m.find()) {
-			return null;
-		}
-		return m.group(1);
-	}
-	
-	public static String getUri(HttpRequest request) {
-		return request.getRequestLine().getUri();
-	}
-	
-	private DatabaseQuery<MongoType> requestToQuery(String requestContent) throws JsonException {
-		return nm.getDatabaseConnector().convert(new LocalQuery(requestContent));
 	}
 }

--- a/core/src/main/java/com/findwise/hydra/net/HttpResponseWriter.java
+++ b/core/src/main/java/com/findwise/hydra/net/HttpResponseWriter.java
@@ -138,4 +138,10 @@ public final class HttpResponseWriter {
 		response.setStatusCode(HttpStatus.SC_OK);
 		setStringEntity(response, uuid);
 	}
+
+	public static void printAccessDenied(HttpResponse response) {
+		logger.warn("Denying access");
+		response.setStatusCode(HttpStatus.SC_FORBIDDEN);
+		setStringEntity(response, "Access forbidden");
+	}
 }

--- a/core/src/main/java/com/findwise/hydra/net/MarkHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/MarkHandler.java
@@ -1,0 +1,111 @@
+package com.findwise.hydra.net;
+
+import java.io.IOException;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.findwise.hydra.DatabaseConnector;
+import com.findwise.hydra.DatabaseDocument;
+import com.findwise.hydra.DatabaseType;
+import com.findwise.hydra.common.JsonException;
+import com.findwise.hydra.local.LocalDocument;
+import com.findwise.hydra.local.RemotePipeline;
+
+public class MarkHandler<T extends DatabaseType> implements ResponsibleHandler {
+	private enum Mark {
+		PENDING, PROCESSED, DISCARDED, FAILED
+	};
+
+	private static Logger logger = LoggerFactory.getLogger(MarkHandler.class);
+
+	DatabaseConnector<T> dbc;
+
+	public MarkHandler(DatabaseConnector<T> dbc) {
+		this.dbc = dbc;
+	}
+
+	@Override
+	public void handle(HttpRequest request, HttpResponse response,
+			HttpContext context) throws HttpException, IOException {
+		HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request)
+				.getEntity();
+		String requestContent = EntityUtils.toString(requestEntity);
+
+		String stage = RESTTools.getParam(request, RemotePipeline.STAGE_PARAM);
+		if (stage == null) {
+			HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
+			return;
+		}
+
+		DatabaseDocument<T> md;
+		try {
+			md = dbc.convert(new LocalDocument(requestContent));
+		} catch (JsonException e) {
+			HttpResponseWriter.printJsonException(response, e);
+			return;
+		}
+
+		if (!mark(md, stage, getMark(request))) {
+			HttpResponseWriter.printNoDocument(response);
+		} else {
+			HttpResponseWriter.printSaveOk(response, md.getID());
+		}
+	}
+	
+	private Mark getMark(HttpRequest request) {
+		String uri = RESTTools.getBaseUrl(request);
+		if (uri.equals(RemotePipeline.PROCESSED_DOCUMENT_URL)) {
+			return Mark.PROCESSED;
+		} else if (uri.equals(RemotePipeline.PENDING_DOCUMENT_URL)) {
+			return Mark.PENDING;
+		} else if (uri.equals(RemotePipeline.DISCARDED_DOCUMENT_URL)) {
+			return Mark.DISCARDED;
+		} else if (uri.equals(RemotePipeline.FAILED_DOCUMENT_URL)) {
+			return Mark.FAILED;
+		}
+		return null;
+	}
+
+	private boolean mark(DatabaseDocument<T> md, String stage, Mark mark) throws IOException {
+		logger.trace("handleMark(..., ..., " + mark.toString() + ")");
+
+		switch (mark) {
+		case PENDING: {
+			return dbc.getDocumentWriter().markPending(md, stage);
+			
+		}
+		case PROCESSED: {
+			return dbc.getDocumentWriter().markProcessed(md, stage);
+		}
+		case FAILED: {
+			return dbc.getDocumentWriter().markFailed(md, stage);
+		}
+		case DISCARDED: {
+			return dbc.getDocumentWriter().markDiscarded(md, stage);
+		}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean supports(HttpRequest request) {
+		return RESTTools.isPost(request) && getMark(request)!=null;
+	}
+
+	@Override
+	public String[] getSupportedUrls() {
+		return new String[] { RemotePipeline.DISCARDED_DOCUMENT_URL,
+				RemotePipeline.FAILED_DOCUMENT_URL,
+				RemotePipeline.PROCESSED_DOCUMENT_URL,
+				RemotePipeline.PENDING_DOCUMENT_URL };
+	}
+
+}

--- a/core/src/main/java/com/findwise/hydra/net/PingHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/PingHandler.java
@@ -1,0 +1,43 @@
+package com.findwise.hydra.net;
+
+import java.io.IOException;
+
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.protocol.HttpContext;
+
+public class PingHandler implements ResponsibleHandler {
+	private String serverId;
+	
+	private String pingUrl = "";
+	
+	public PingHandler(String serverId) {
+		this.serverId = serverId;
+	}
+	
+	@Override
+	public void handle(HttpRequest request, HttpResponse response, HttpContext context)
+			throws HttpException, IOException {
+		if (RESTTools.isGet(request)) {
+			String uri = RESTTools.getStrippedUri(request);
+			if (uri.equals(pingUrl)) {
+				HttpResponseWriter.printID(response, serverId);
+			}
+		}
+	}
+
+	@Override
+	public boolean supports(HttpRequest request) {
+		return RESTTools.isGet(request) && pingUrl.equals(RESTTools.getStrippedUri(request));
+	}
+
+	@Override
+	public String[] getSupportedUrls() {
+		return new String[] { pingUrl };
+	}
+
+	public void setServerId(String serverId) {
+		this.serverId = serverId;
+	}
+}

--- a/core/src/main/java/com/findwise/hydra/net/PropertiesHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/PropertiesHandler.java
@@ -1,0 +1,62 @@
+package com.findwise.hydra.net;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.protocol.HttpContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.findwise.hydra.NodeMaster;
+import com.findwise.hydra.local.RemotePipeline;
+
+public class PropertiesHandler implements ResponsibleHandler {
+	Logger logger = LoggerFactory.getLogger(PropertiesHandler.class);
+	
+	private NodeMaster nm;
+	
+	public PropertiesHandler(NodeMaster nm) {
+		this.nm = nm;
+	}
+	
+	@Override
+	public void handle(HttpRequest request, HttpResponse response, HttpContext context)
+			throws HttpException, IOException {
+		logger.trace("handleGetProperties()");
+		
+        String stage = RESTTools.getStage(request);
+        logger.debug("Received getProperties()-request for stage: "+stage);
+        
+        if(stage==null) {
+        	HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
+        	return;
+        }
+        
+        Map<String, Object> map = new HashMap<String, Object>();
+        
+        if(nm.getPipeline().hasStage(stage)) {
+        	map = nm.getPipeline().getStage(stage).getProperties();
+        }
+        else if(nm.getDatabaseConnector().getPipelineReader().getDebugPipeline().hasStage(stage)){
+        	map = nm.getDatabaseConnector().getPipelineReader().getDebugPipeline().getStage(stage).getProperties();
+        } 
+        
+        HttpResponseWriter.printJson(response, map);
+
+	}
+
+	@Override
+	public boolean supports(HttpRequest request) {
+		return RESTTools.isGet(request) && RESTTools.getBaseUrl(request).equals(RemotePipeline.GET_PROPERTIES_URL);
+	}
+
+	@Override
+	public String[] getSupportedUrls() {
+		return new String[] {RemotePipeline.GET_PROPERTIES_URL};
+	}
+
+}

--- a/core/src/main/java/com/findwise/hydra/net/PropertiesHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/PropertiesHandler.java
@@ -11,16 +11,17 @@ import org.apache.http.protocol.HttpContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.findwise.hydra.NodeMaster;
+import com.findwise.hydra.DatabaseConnector;
+import com.findwise.hydra.DatabaseType;
 import com.findwise.hydra.local.RemotePipeline;
 
-public class PropertiesHandler implements ResponsibleHandler {
+public class PropertiesHandler<T extends DatabaseType> implements ResponsibleHandler {
 	Logger logger = LoggerFactory.getLogger(PropertiesHandler.class);
 	
-	private NodeMaster nm;
+	private DatabaseConnector<T> dbc;
 	
-	public PropertiesHandler(NodeMaster nm) {
-		this.nm = nm;
+	public PropertiesHandler(DatabaseConnector<T> dbc) {
+		this.dbc = dbc;
 	}
 	
 	@Override
@@ -38,11 +39,11 @@ public class PropertiesHandler implements ResponsibleHandler {
         
         Map<String, Object> map = new HashMap<String, Object>();
         
-        if(nm.getPipeline().hasStage(stage)) {
-        	map = nm.getPipeline().getStage(stage).getProperties();
+        if(dbc.getPipelineReader().getPipeline().hasStage(stage)) {
+        	map = dbc.getPipelineReader().getPipeline().getStage(stage).getProperties();
         }
-        else if(nm.getDatabaseConnector().getPipelineReader().getDebugPipeline().hasStage(stage)){
-        	map = nm.getDatabaseConnector().getPipelineReader().getDebugPipeline().getStage(stage).getProperties();
+        else if(dbc.getPipelineReader().getDebugPipeline().hasStage(stage)){
+        	map = dbc.getPipelineReader().getDebugPipeline().getStage(stage).getProperties();
         } 
         
         HttpResponseWriter.printJson(response, map);

--- a/core/src/main/java/com/findwise/hydra/net/QueryHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/QueryHandler.java
@@ -1,0 +1,96 @@
+package com.findwise.hydra.net;
+
+import java.io.IOException;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.findwise.hydra.DatabaseQuery;
+import com.findwise.hydra.NodeMaster;
+import com.findwise.hydra.common.Document;
+import com.findwise.hydra.common.JsonException;
+import com.findwise.hydra.local.LocalQuery;
+import com.findwise.hydra.local.RemotePipeline;
+import com.findwise.hydra.mongodb.MongoType;
+import com.findwise.hydra.net.RESTTools.Method;
+
+public class QueryHandler implements ResponsibleHandler {
+
+	private NodeMaster nm;
+
+	private static Logger logger = LoggerFactory.getLogger(QueryHandler.class);
+
+	public QueryHandler(NodeMaster nm) {
+		this.nm = nm;
+	}
+
+	@Override
+	public void handle(HttpRequest request, HttpResponse response,
+			HttpContext arg2) throws HttpException, IOException {
+		logger.trace("handleGetDocument()");
+		HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request)
+				.getEntity();
+		String requestContent = EntityUtils.toString(requestEntity);
+		String stage = RESTTools.getParam(request, RemotePipeline.STAGE_PARAM);
+
+		if (stage == null) {
+			HttpResponseWriter.printMissingParameter(response,
+					RemotePipeline.STAGE_PARAM);
+			return;
+		}
+
+		DatabaseQuery<MongoType> dbq;
+		try {
+			dbq = requestToQuery(requestContent);
+		} catch (JsonException e) {
+			HttpResponseWriter.printJsonException(response, e);
+			return;
+		}
+
+		Document d;
+
+		String recurring = RESTTools.getParam(request,
+				RemotePipeline.RECURRING_PARAM);
+
+		if (recurring != null && recurring.equals("1")) {
+			d = nm.getDatabaseConnector().getDocumentWriter()
+					.getAndTagRecurring(dbq, stage);
+		} else {
+			d = nm.getDatabaseConnector().getDocumentWriter()
+					.getAndTag(dbq, stage);
+		}
+
+		if (d != null) {
+			HttpResponseWriter.printDocument(response, d, stage);
+		} else {
+			HttpResponseWriter.printNoDocument(response);
+		}
+
+	}
+
+	private DatabaseQuery<MongoType> requestToQuery(String requestContent)
+			throws JsonException {
+		return nm.getDatabaseConnector()
+				.convert(new LocalQuery(requestContent));
+	}
+
+	@Override
+	public boolean supports(HttpRequest request) {
+		return RESTTools.getMethod(request) == Method.POST
+				&& RemotePipeline.GET_DOCUMENT_URL.equals(RESTTools
+						.getBaseUrl(request));
+	}
+
+	@Override
+	public String[] getSupportedUrls() {
+		return new String[] { RemotePipeline.GET_DOCUMENT_URL };
+	}
+
+}

--- a/core/src/main/java/com/findwise/hydra/net/RESTTools.java
+++ b/core/src/main/java/com/findwise/hydra/net/RESTTools.java
@@ -1,0 +1,57 @@
+package com.findwise.hydra.net;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.http.HttpRequest;
+
+import com.findwise.hydra.local.RemotePipeline;
+
+public final class RESTTools {
+	public enum Method { GET, PUT, POST, DELETE, HEAD, TRACE, CONNECT, PATCH, OPTIONS };
+	
+	public static String getUri(HttpRequest request) {
+		return request.getRequestLine().getUri();
+	}
+
+	public static String getStrippedUri(HttpRequest request) {
+		return getUri(request).substring(1);
+	}
+	
+	public static Method getMethod(HttpRequest request) {
+		return Method.valueOf(request.getRequestLine().getMethod().toUpperCase(Locale.ENGLISH));
+	}
+	
+	public static String getParam(HttpRequest request, String param) {
+		String uri = getUri(request);
+		Pattern p = Pattern.compile("[^\\?]+\\?.*"+param+"=([^&]+)");
+		Matcher m = p.matcher(uri);
+		if(!m.find()) {
+			return null;
+		}
+		return m.group(1);
+	}
+	
+	public static String getBaseUrl(HttpRequest request) {
+		String uri = getStrippedUri(request);
+		Pattern p = Pattern.compile("([^\\?]+).*");
+		Matcher m = p.matcher(uri);
+		if(!m.find()) {
+			return null;
+		}
+		return m.group(1);
+	}
+	
+	public static String getStage(HttpRequest request) {
+		return getParam(request, RemotePipeline.STAGE_PARAM);
+	}
+	
+	public static boolean isPost(HttpRequest request) {
+		return getMethod(request) == Method.POST;
+	}
+	
+	public static boolean isGet(HttpRequest request) {
+		return getMethod(request) == Method.GET;
+	}
+}

--- a/core/src/main/java/com/findwise/hydra/net/ReleaseHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/ReleaseHandler.java
@@ -1,0 +1,79 @@
+package com.findwise.hydra.net;
+
+import java.io.IOException;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.findwise.hydra.NodeMaster;
+import com.findwise.hydra.common.Document;
+import com.findwise.hydra.common.JsonException;
+import com.findwise.hydra.local.LocalDocument;
+import com.findwise.hydra.local.RemotePipeline;
+import com.findwise.hydra.net.RESTTools.Method;
+
+public class ReleaseHandler implements ResponsibleHandler {
+
+	private NodeMaster nm;
+
+	private static Logger logger = LoggerFactory
+			.getLogger(ReleaseHandler.class);
+
+	public ReleaseHandler(NodeMaster nm) {
+		this.nm = nm;
+	}
+
+	@Override
+	public void handle(HttpRequest request, HttpResponse response,
+			HttpContext arg2) throws HttpException, IOException {
+		logger.trace("handleReleaseDocument()");
+		HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request)
+				.getEntity();
+		String requestContent = EntityUtils.toString(requestEntity);
+		String stage = RESTTools.getParam(request, RemotePipeline.STAGE_PARAM);
+
+		if (stage == null) {
+			HttpResponseWriter.printMissingParameter(response,
+					RemotePipeline.STAGE_PARAM);
+			return;
+		}
+
+		try {
+			boolean x = release(new LocalDocument(requestContent), stage);
+			if (!x) {
+				HttpResponseWriter.printNoDocument(response);
+			}
+		} catch (JsonException e) {
+			HttpResponseWriter.printJsonException(response, e);
+			return;
+		}
+
+		HttpResponseWriter.printDocumentReleased(response);
+
+	}
+
+	private boolean release(Document md, String stage) {
+		return nm.getDatabaseConnector().getDocumentWriter()
+				.markTouched(md.getID(), stage);
+	}
+
+	@Override
+	public boolean supports(HttpRequest request) {
+		return RESTTools.getMethod(request) == Method.POST
+				&& RemotePipeline.RELEASE_DOCUMENT_URL.equals(RESTTools
+						.getBaseUrl(request));
+	}
+
+	@Override
+	public String[] getSupportedUrls() {
+		return new String[] { RemotePipeline.RELEASE_DOCUMENT_URL };
+	}
+
+}

--- a/core/src/main/java/com/findwise/hydra/net/ReleaseHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/ReleaseHandler.java
@@ -12,22 +12,23 @@ import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.findwise.hydra.NodeMaster;
+import com.findwise.hydra.DatabaseConnector;
+import com.findwise.hydra.DatabaseType;
 import com.findwise.hydra.common.Document;
 import com.findwise.hydra.common.JsonException;
 import com.findwise.hydra.local.LocalDocument;
 import com.findwise.hydra.local.RemotePipeline;
 import com.findwise.hydra.net.RESTTools.Method;
 
-public class ReleaseHandler implements ResponsibleHandler {
+public class ReleaseHandler<T extends DatabaseType> implements ResponsibleHandler {
 
-	private NodeMaster nm;
+	private DatabaseConnector<T> dbc;
 
 	private static Logger logger = LoggerFactory
 			.getLogger(ReleaseHandler.class);
 
-	public ReleaseHandler(NodeMaster nm) {
-		this.nm = nm;
+	public ReleaseHandler(DatabaseConnector<T> dbc) {
+		this.dbc = dbc;
 	}
 
 	@Override
@@ -60,8 +61,7 @@ public class ReleaseHandler implements ResponsibleHandler {
 	}
 
 	private boolean release(Document md, String stage) {
-		return nm.getDatabaseConnector().getDocumentWriter()
-				.markTouched(md.getID(), stage);
+		return dbc.getDocumentWriter().markTouched(md.getID(), stage);
 	}
 
 	@Override

--- a/core/src/main/java/com/findwise/hydra/net/ResponsibleHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/ResponsibleHandler.java
@@ -1,0 +1,28 @@
+package com.findwise.hydra.net;
+
+import java.io.IOException;
+
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpRequestHandler;
+
+public interface ResponsibleHandler extends HttpRequestHandler {
+
+	/**
+	 * Implementing classes should guarantee expected behavior if and only if
+	 * supports(request) returns true.
+	 */
+	@Override
+	public void handle(HttpRequest request, HttpResponse response,
+			HttpContext context) throws HttpException, IOException;
+
+	/**
+	 * Indicates that this handler can serve the given request by a later call
+	 * to handle(...)
+	 */
+	public boolean supports(HttpRequest request);
+
+	public String[] getSupportedUrls();
+}

--- a/core/src/test/java/com/findwise/hydra/net/HttpRESTHandlerTest.java
+++ b/core/src/test/java/com/findwise/hydra/net/HttpRESTHandlerTest.java
@@ -1,0 +1,41 @@
+package com.findwise.hydra.net;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.findwise.hydra.NodeMaster;
+import com.findwise.hydra.TestModule;
+import com.findwise.hydra.local.RemotePipeline;
+import com.google.inject.Guice;
+
+public class HttpRESTHandlerTest {
+	private HttpRESTHandler<?> restHandler;
+	
+	@Before
+	public void setUp() {
+		restHandler = new HttpRESTHandler(Guice.createInjector(new TestModule("jUnit-HttpRESTHandlerTest")).getInstance(NodeMaster.class));
+	}
+	
+	@Test
+	public void supportsAllUrls() throws IllegalArgumentException, IllegalAccessException {
+		Field[] fields = RemotePipeline.class.getFields();
+		for(Field f : fields) {
+			int mod = f.getModifiers();
+			if(Modifier.isFinal(mod) && f.getName().endsWith("_URL")) {
+				isSupported((String) f.get(null));
+			}
+		}
+	}
+	
+	private boolean isSupported(String url) {
+		for(String s : restHandler.getSupportedUrls()) {
+			if(url.equals(s)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryConnector.java
+++ b/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryConnector.java
@@ -1,0 +1,101 @@
+package com.findwise.hydra.memorydb;
+
+import java.io.IOException;
+
+import com.findwise.hydra.DatabaseConnector;
+import com.findwise.hydra.DatabaseDocument;
+import com.findwise.hydra.DatabaseQuery;
+import com.findwise.hydra.DocumentReader;
+import com.findwise.hydra.DocumentWriter;
+import com.findwise.hydra.PipelineReader;
+import com.findwise.hydra.PipelineStatus;
+import com.findwise.hydra.PipelineWriter;
+import com.findwise.hydra.common.JsonException;
+import com.findwise.hydra.local.LocalDocument;
+import com.findwise.hydra.local.LocalQuery;
+
+public class MemoryConnector implements DatabaseConnector<MemoryType> {
+
+	private MemoryDocumentIO docio;
+	
+	public MemoryConnector() {
+		docio = new MemoryDocumentIO();
+	}
+	
+	@Override
+	public void connect() throws IOException {
+		
+	}
+	
+	@Override
+	public void waitForWrites(boolean alwaysBlocking) {
+		
+	}
+
+	@Override
+	public boolean isWaitingForWrites() {
+		return true;
+	}
+
+	@Override
+	public PipelineReader<MemoryType> getPipelineReader() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public PipelineWriter<MemoryType> getPipelineWriter() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public DocumentReader<MemoryType> getDocumentReader() {
+		return docio;
+	}
+
+	@Override
+	public DocumentWriter<MemoryType> getDocumentWriter() {
+		return docio;
+	}
+
+	@Override
+	public DatabaseQuery<MemoryType> convert(LocalQuery query) {
+		MemoryQuery mq = new MemoryQuery();
+		try {
+			mq.fromJson(query.toJson());
+		} catch (JsonException e) {
+			e.printStackTrace();
+		}
+		return mq;
+	}
+
+	@Override
+	public DatabaseDocument<MemoryType> convert(LocalDocument document) {
+		MemoryDocument md = new MemoryDocument();
+		try {
+			md.fromJson(document.toJson());
+		} catch (JsonException e) {
+			e.printStackTrace();
+		}
+		return md;
+	}
+
+	@Override
+	public boolean isConnected() {
+		return true;
+	}
+
+	@Override
+	public PipelineStatus getPipelineStatus() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public PipelineStatus getNewPipelineStatus() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}


### PR DESCRIPTION
RESTServer and HttpRESTHandler are now much easier to work with. It is now fairly easy to add a new controller to the Hydra core.

Additionally, they allow injection of any DatabaseConnector - meaning they can be tested with the inmemory-connector rather than being tied to MongoDB.
