### PR TITLE
Silencing unnecessary log output during test

### DIFF
--- a/api/src/main/java/com/findwise/hydra/common/Logger.java
+++ b/api/src/main/java/com/findwise/hydra/common/Logger.java
@@ -4,6 +4,8 @@ package com.findwise.hydra.common;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
+import com.findwise.hydra.common.Logger.Level;
+
 /**
  * This class is mirrors the Log4J error levels, providing an interface
  * for logging on stdout which will be redirected to Log4J by 
@@ -26,6 +28,8 @@ public final class Logger {
     public static final String STACKTRACEMESSAGE = "$STACKTRACE$ ";
 
     private static Level internalLoggingLevel = Level.WARN;
+
+	private static Level globalLevel = Level.TRACE;
 
     /**
      * Sets the name of the Log4J logger (equivalent to <code>new log4j.Logger(String clazz)</code>)
@@ -52,6 +56,9 @@ public final class Logger {
      * @param s
      */
     public static void log(Level l, String s) {
+    	if(!logOnLevel(l)) {
+    		return;
+    	}
         System.out.println(PREFIXES[l.ordinal()]+s);
     }
     
@@ -61,6 +68,9 @@ public final class Logger {
      * @param s
      */
     public static void log(Level l, String s, Throwable e) {
+    	if(!logOnLevel(l)) {
+    		return;
+    	}
     	System.out.println(STACKTRACEMESSAGE);
     	log(l, s);
         StringWriter st = new StringWriter();
@@ -185,5 +195,20 @@ public final class Logger {
      */
     public static void setInternalLoggingLevel(Level internalLevel) {
         internalLoggingLevel = internalLevel;
+    }
+    
+    /**
+     * Sets the global logging level. 
+     */
+    public static void setGlobalLoggingLevel(Level loggingLevel) {
+    	globalLevel  = loggingLevel;
+    }
+    
+    public static Level getGlobalLoggingLevel() {
+    	return globalLevel;
+    }
+    
+    private static boolean logOnLevel(Level l) {
+    	return l.ordinal()>=globalLevel.ordinal() && l!=Level.OFF;
     }
 }

--- a/api/src/test/java/com/findwise/hydra/stage/AbstractProcessStageTest.java
+++ b/api/src/test/java/com/findwise/hydra/stage/AbstractProcessStageTest.java
@@ -17,6 +17,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.findwise.hydra.common.Logger;
+import com.findwise.hydra.common.Logger.Level;
 import com.findwise.hydra.local.LocalDocument;
 import com.findwise.hydra.local.LocalQuery;
 import com.findwise.hydra.local.RemotePipeline;
@@ -28,7 +30,7 @@ public class AbstractProcessStageTest {
 
 	@Before
 	public void setUp() throws Exception {
-
+		Logger.setGlobalLoggingLevel(Level.OFF);
 	}
 
 	@After


### PR DESCRIPTION
Also, along with this, added support for statically telling Logger what logger level it shouldn't log under.
