### PR TITLE
Improving MarkHandler to make sure data is not lost

### DIFF
--- a/api/src/main/java/com/findwise/hydra/local/LocalDocument.java
+++ b/api/src/main/java/com/findwise/hydra/local/LocalDocument.java
@@ -201,6 +201,10 @@ public class LocalDocument implements Document {
 	public String toJson() {
 		return SerializationUtils.toJson(documentMap);
 	}
+	
+	protected Map<String, Object> getDocumentMap() {
+		return documentMap;
+	}
 
 	@Override
 	public boolean isEqual(Document d) {

--- a/core/src/main/java/com/findwise/hydra/net/MarkHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/MarkHandler.java
@@ -52,8 +52,11 @@ public class MarkHandler<T extends DatabaseType> implements ResponsibleHandler {
 			HttpResponseWriter.printJsonException(response, e);
 			return;
 		}
+		
+		DatabaseDocument<T> dbdoc = dbc.getDocumentReader().getDocumentById(md.getID());
+		dbdoc.putAll(md);
 
-		if (!mark(md, stage, getMark(request))) {
+		if (!mark(dbdoc, stage, getMark(request))) {
 			HttpResponseWriter.printNoDocument(response);
 		} else {
 			HttpResponseWriter.printSaveOk(response, md.getID());

--- a/core/src/main/java/com/findwise/hydra/net/MarkHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/MarkHandler.java
@@ -54,6 +54,12 @@ public class MarkHandler<T extends DatabaseType> implements ResponsibleHandler {
 		}
 		
 		DatabaseDocument<T> dbdoc = dbc.getDocumentReader().getDocumentById(md.getID());
+		
+		if(dbdoc==null) {
+			HttpResponseWriter.printNoDocument(response);
+			return;
+		}
+		
 		dbdoc.putAll(md);
 
 		if (!mark(dbdoc, stage, getMark(request))) {

--- a/core/src/test/java/com/findwise/hydra/net/MarkHandlerTest.java
+++ b/core/src/test/java/com/findwise/hydra/net/MarkHandlerTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
+import com.findwise.hydra.common.Document.Status;
 import com.findwise.hydra.local.LocalDocument;
 import com.findwise.hydra.local.LocalQuery;
 import com.findwise.hydra.local.RemotePipeline;
@@ -50,6 +51,10 @@ public class MarkHandlerTest {
 			if(!doc.getContentField(field).equals(doc2.getContentField(field))) {
 				fail("Content mismatch");
 			}
+		}
+		
+		if(!doc2.getStatus().equals(Status.PROCESSED)) {
+			fail("No FAILED status on the document");
 		}
 	}
 }

--- a/core/src/test/java/com/findwise/hydra/net/MarkHandlerTest.java
+++ b/core/src/test/java/com/findwise/hydra/net/MarkHandlerTest.java
@@ -1,0 +1,55 @@
+package com.findwise.hydra.net;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import com.findwise.hydra.local.LocalDocument;
+import com.findwise.hydra.local.LocalQuery;
+import com.findwise.hydra.local.RemotePipeline;
+import com.findwise.hydra.memorydb.MemoryConnector;
+import com.findwise.hydra.memorydb.MemoryDocument;
+import com.findwise.hydra.memorydb.MemoryType;
+
+public class MarkHandlerTest {
+	private MemoryConnector mc;
+	private RESTServer server;
+	private HttpRESTHandler<MemoryType> handler;
+	
+	@Before
+	public void setUp() {
+		mc = new MemoryConnector();
+		handler = new HttpRESTHandler<MemoryType>(mc);
+		server = RESTServer.getNewStartedRESTServer(20000, handler);
+	}
+	
+	@Test
+	public void testMarkPersistance() throws Exception {
+		RemotePipeline rp = new RemotePipeline("localhost", server.getPort(), "x");
+		
+		LocalDocument doc = new LocalDocument();
+
+		doc.putContentField("field", "value");
+		doc.putContentField("field2", "value2");
+		
+		MemoryDocument d = (MemoryDocument)mc.convert(doc);
+		mc.getDocumentWriter().insert(d);
+		
+		doc = rp.getDocument(new LocalQuery());
+		
+		doc.putContentField("field3", "value3");
+		
+		rp.markProcessed(doc);
+		
+		MemoryDocument doc2 = (MemoryDocument) mc.getDocumentReader().getDocumentById(d.getID(), true);
+		
+		for(String field : doc.getContentFields()) {
+			if(!doc2.hasContentField(field)) {
+				fail("Missing a field");
+			}
+			if(!doc.getContentField(field).equals(doc2.getContentField(field))) {
+				fail("Content mismatch");
+			}
+		}
+	}
+}

--- a/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryDocument.java
+++ b/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryDocument.java
@@ -8,8 +8,6 @@ import com.findwise.hydra.DatabaseDocument;
 import com.findwise.hydra.local.LocalDocument;
 
 public class MemoryDocument extends LocalDocument implements DatabaseDocument<MemoryType> {
-
-	private Object id;
 	
 	@Override
 	public Object putMetadataField(String key, Object value) {
@@ -115,11 +113,11 @@ public class MemoryDocument extends LocalDocument implements DatabaseDocument<Me
 	}
 
 	public void setID(Object id) {
-		this.id = id;
+		getDocumentMap().put(ID_KEY, id);
 	}
 	
 	@Override
 	public Object getID() {
-		return id;
+		return getDocumentMap().get(ID_KEY);
 	}
 }


### PR DESCRIPTION
Previously, the MarkHandler overwrote the document in the database when marking the document to a finished status. 
