### PR TITLE
No longer allow stages not annotated with @Stage

### DIFF
--- a/api/src/main/java/com/findwise/hydra/stage/AbstractStage.java
+++ b/api/src/main/java/com/findwise/hydra/stage/AbstractStage.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 import com.findwise.hydra.common.JsonDeserializer;
 import com.findwise.hydra.common.JsonException;
@@ -143,6 +144,8 @@ public abstract class AbstractStage extends Thread {
 					field.setAccessible(prevAccessible);
 				}
 			}
+		} else {
+			throw new NoSuchElementException("No Stage-annotation found on the specified class "+getClass().getCanonicalName());
 		}
 	}
 	


### PR DESCRIPTION
Parameters won't be injected without it, so forgetting it will lead to
inconsistent/unexpected behavior. Better to fail than to do the wrong
thing.
