### PR TITLE
No more restarts of (fatally) improperly configured stages

### DIFF
--- a/core/src/main/java/com/findwise/hydra/NodeMaster.java
+++ b/core/src/main/java/com/findwise/hydra/NodeMaster.java
@@ -53,14 +53,14 @@ public final class NodeMaster extends Thread {
 	 * Check if the JAR-file is there, in that case start it. 
 	 **/
 	private boolean launchStage(StoredStage stage) {
-		StageRunner wrapper = new StageRunner(stage, port);
-		sm.addWrapper(stage, wrapper);
-		wrapper.start();
+		StageRunner runner = new StageRunner(stage, port);
+		sm.addRunner(stage, runner);
+		runner.start();
 		return true;
 	}
 	
 	private void stopStage(StoredStage stage) {
-		StageRunner sw = sm.getWrapper(stage);
+		StageRunner sw = sm.getRunner(stage.getName());
 		if(sw!=null) {
 			sw.destroy();
 		}
@@ -96,7 +96,7 @@ public final class NodeMaster extends Thread {
 	
 	private void restartStopped() {
 		for(StoredStage s : pipeline.getStages()) {
-			if(!sm.wrapperExists(s)) {
+			if(!sm.hasRunner(s.getName())) {
 				launchStage(s);
 			}
 		}
@@ -126,8 +126,8 @@ public final class NodeMaster extends Thread {
 		
 		List<StoredStage> propUpdated = getPropertiesUpdated(newPipeline);
 		for(StoredStage stage : propUpdated) {
-			sm.getWrapper(stage).destroy();
-			sm.removeWrapper(stage);
+			sm.getRunner(stage.getName()).destroy();
+			sm.removeRunner(stage.getName());
 			addStage(stage.getName(), newPipeline);
 		}
 	}
@@ -144,9 +144,9 @@ public final class NodeMaster extends Thread {
 	}
 	
 	private void stopAndRemove(StoredStage s) {
-		if (sm.wrapperExists(s)) {
+		if (sm.hasRunner(s.getName())) {
 			stopStage(s);
-			sm.removeWrapper(s);
+			sm.removeRunner(s.getName());
 		}
 		patientRemoveStage(s, 500, 10);
 	}

--- a/core/src/main/java/com/findwise/hydra/StageManager.java
+++ b/core/src/main/java/com/findwise/hydra/StageManager.java
@@ -7,10 +7,10 @@ public final class StageManager {
 	
 	private static volatile StageManager self = null;
 
-	private Map<String, StageRunner> wrapperMap;
+	private Map<String, StageRunner> runnerMap;
 	
 	private StageManager() {
-		wrapperMap = new HashMap<String, StageRunner>();
+		runnerMap = new HashMap<String, StageRunner>();
 	}
 	
 	public static StageManager getStageManager() {
@@ -20,33 +20,33 @@ public final class StageManager {
 		return self;
 	}
 	
-	public StageRunner getWrapper(StoredStage stage) {
-		if(wrapperMap.containsKey(stage.getName())) {
-			return wrapperMap.get(stage.getName());
+	public StageRunner getRunner(String stageName) {
+		if(runnerMap.containsKey(stageName)) {
+			return runnerMap.get(stageName);
 		}
 		return null;
 	}
 	
 	
-	public boolean wrapperExists(StoredStage stage) {
-		return getWrapper(stage)!=null;
+	public boolean hasRunner(String stageName) {
+		return getRunner(stageName)!=null;
 	}
 	
-	public void addWrapper(StoredStage stage, StageRunner stageWrapper) {
-		wrapperMap.put(stage.getName(), stageWrapper);
+	public void addRunner(StoredStage stage, StageRunner stageWrapper) {
+		runnerMap.put(stage.getName(), stageWrapper);
 	}
 	
-	public StageRunner removeWrapper(StoredStage stage) {
-		if(wrapperMap.containsKey(stage.getName())) {
-			StageRunner ret = wrapperMap.get(stage.getName());
-			wrapperMap.remove(stage.getName());
+	public StageRunner removeRunner(String stageName) {
+		if(runnerMap.containsKey(stageName)) {
+			StageRunner ret = runnerMap.get(stageName);
+			runnerMap.remove(stageName);
 			return ret;
 		}
 		return null;
 	}
 	
-	public void findAndDestroy(StoredStage stage) {
-		StageRunner sw = removeWrapper(stage);
+	public void findAndDestroy(String stageName) {
+		StageRunner sw = removeRunner(stageName);
 		if(sw!=null) {
 			sw.destroy();
 		}

--- a/core/src/main/java/com/findwise/hydra/net/MarkHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/MarkHandler.java
@@ -26,7 +26,7 @@ public class MarkHandler<T extends DatabaseType> implements ResponsibleHandler {
 
 	private static Logger logger = LoggerFactory.getLogger(MarkHandler.class);
 
-	DatabaseConnector<T> dbc;
+	private DatabaseConnector<T> dbc;
 
 	public MarkHandler(DatabaseConnector<T> dbc) {
 		this.dbc = dbc;

--- a/core/src/main/java/com/findwise/hydra/net/QueryHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/QueryHandler.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import com.findwise.hydra.DatabaseConnector;
 import com.findwise.hydra.DatabaseQuery;
 import com.findwise.hydra.DatabaseType;
+import com.findwise.hydra.StageManager;
 import com.findwise.hydra.common.Document;
 import com.findwise.hydra.common.JsonException;
 import com.findwise.hydra.local.LocalQuery;
@@ -22,7 +23,7 @@ import com.findwise.hydra.local.RemotePipeline;
 import com.findwise.hydra.net.RESTTools.Method;
 
 public class QueryHandler<T extends DatabaseType> implements ResponsibleHandler {
-
+	
 	private DatabaseConnector<T> dbc;
 
 	private static Logger logger = LoggerFactory.getLogger(QueryHandler.class);
@@ -53,6 +54,8 @@ public class QueryHandler<T extends DatabaseType> implements ResponsibleHandler 
 			HttpResponseWriter.printJsonException(response, e);
 			return;
 		}
+
+		reportQuery(stage);		
 
 		Document d;
 
@@ -88,6 +91,13 @@ public class QueryHandler<T extends DatabaseType> implements ResponsibleHandler 
 	@Override
 	public String[] getSupportedUrls() {
 		return new String[] { RemotePipeline.GET_DOCUMENT_URL };
+	}
+	
+	private void reportQuery(String stage) {
+		StageManager sm = StageManager.getStageManager();
+		if(sm.hasRunner(stage)) {
+			sm.getRunner(stage).setHasQueried();
+		}
 	}
 
 }


### PR DESCRIPTION
If a stage never reaches the point where it queries for a document from
Core, it will with this change not be restarted until that
configuration changes.
