### PR TITLE
Added stats-collecting functionality and class

### DIFF
--- a/admin-service/pom.xml
+++ b/admin-service/pom.xml
@@ -6,14 +6,13 @@
 	<version>0.3.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 
-
 	<properties>
 		<spring.version>3.1.1.RELEASE</spring.version>
 		<cglib.version>2.2.2</cglib.version>
 	</properties>
 
 	<build>
-		<finalName>rest</finalName>
+		<finalName>hydra</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/admin-service/pom.xml
+++ b/admin-service/pom.xml
@@ -2,7 +2,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.findwise.hydra</groupId>
-	<artifactId>admin-service</artifactId>
+	<artifactId>hydra-admin-service</artifactId>
 	<version>0.3.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 

--- a/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryConnector.java
+++ b/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryConnector.java
@@ -8,8 +8,9 @@ import com.findwise.hydra.DatabaseQuery;
 import com.findwise.hydra.DocumentReader;
 import com.findwise.hydra.DocumentWriter;
 import com.findwise.hydra.PipelineReader;
-import com.findwise.hydra.PipelineStatus;
 import com.findwise.hydra.PipelineWriter;
+import com.findwise.hydra.StatusReader;
+import com.findwise.hydra.StatusWriter;
 import com.findwise.hydra.common.JsonException;
 import com.findwise.hydra.local.LocalDocument;
 import com.findwise.hydra.local.LocalQuery;
@@ -17,6 +18,7 @@ import com.findwise.hydra.local.LocalQuery;
 public class MemoryConnector implements DatabaseConnector<MemoryType> {
 
 	private MemoryDocumentIO docio;
+	private MemoryStatusIO statusio;
 	
 	public MemoryConnector() {
 		docio = new MemoryDocumentIO();
@@ -87,15 +89,13 @@ public class MemoryConnector implements DatabaseConnector<MemoryType> {
 	}
 
 	@Override
-	public PipelineStatus getPipelineStatus() {
-		// TODO Auto-generated method stub
-		return null;
+	public StatusWriter<MemoryType> getStatusWriter() {
+		return statusio;
 	}
 
 	@Override
-	public PipelineStatus getNewPipelineStatus() {
-		// TODO Auto-generated method stub
-		return null;
+	public StatusReader<MemoryType> getStatusReader() {
+		return statusio;
 	}
 
 }

--- a/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryStatusIO.java
+++ b/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryStatusIO.java
@@ -1,0 +1,108 @@
+package com.findwise.hydra.memorydb;
+
+import com.findwise.hydra.PipelineStatus;
+import com.findwise.hydra.StatusReader;
+import com.findwise.hydra.StatusWriter;
+
+public class MemoryStatusIO implements StatusReader<MemoryType>, StatusWriter<MemoryType> {
+
+	
+	@Override
+	public void increment(int processed, int failed, int discarded) {
+		
+	}
+
+	@Override
+	public MemoryPipelineStatus getStatus() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void save(PipelineStatus<MemoryType> status) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	public static class MemoryPipelineStatus implements PipelineStatus<MemoryType> {
+
+		@Override
+		public void setDiscardOldDocuments(boolean discardOld) {
+			// TODO Auto-generated method stub
+			
+		}
+
+		@Override
+		public boolean isDiscardingOldDocuments() {
+			// TODO Auto-generated method stub
+			return false;
+		}
+
+		@Override
+		public void setDiscardedToKeep(long numberToKeep) {
+			// TODO Auto-generated method stub
+			
+		}
+
+		@Override
+		public long getNumberToKeep() {
+			// TODO Auto-generated method stub
+			return 0;
+		}
+
+		@Override
+		public void setDiscardedMaxSize(int maxSize) {
+			// TODO Auto-generated method stub
+			
+		}
+
+		@Override
+		public int getDiscardedMaxSize() {
+			// TODO Auto-generated method stub
+			return 0;
+		}
+
+		@Override
+		public int getDiscardedCount() {
+			// TODO Auto-generated method stub
+			return 0;
+		}
+
+		@Override
+		public void setDiscardedCount(int i) {
+			// TODO Auto-generated method stub
+			
+		}
+
+		@Override
+		public int getProcessedCount() {
+			// TODO Auto-generated method stub
+			return 0;
+		}
+
+		@Override
+		public void setProcessedCount(int i) {
+			// TODO Auto-generated method stub
+			
+		}
+
+		@Override
+		public int getFailedCount() {
+			// TODO Auto-generated method stub
+			return 0;
+		}
+
+		@Override
+		public void setFailedCount(int i) {
+			// TODO Auto-generated method stub
+			
+		}
+		
+	}
+
+	@Override
+	public boolean hasStatus() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+}

--- a/database-impl/mongodb/pom.xml
+++ b/database-impl/mongodb/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>org.mongodb</groupId>
 			<artifactId>mongo-java-driver</artifactId>
-			<version>2.8.0</version>
+			<version>2.9.1</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>

--- a/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoConnector.java
+++ b/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoConnector.java
@@ -111,6 +111,8 @@ public class MongoConnector implements DatabaseConnector<MongoType> {
 		} else {
 			pipelineStatus = statusIO.getStatus();
 		}
+
+		statusUpdater = new StatusUpdater(this);
 		
 		if(!pipelineStatus.isPrepared()) {
 			logger.info("Database is new, preparing it");
@@ -118,18 +120,17 @@ public class MongoConnector implements DatabaseConnector<MongoType> {
 			pipelineStatus.setDiscardedMaxSize(conf.getOldMaxSize());
 			pipelineStatus.setDiscardedToKeep(conf.getOldMaxCount());
 			
-			documentIO = new MongoDocumentIO(db, concern, pipelineStatus.getNumberToKeep(), pipelineStatus.getDiscardedMaxSize(), new StatusUpdater(this));
+			documentIO = new MongoDocumentIO(db, concern, pipelineStatus.getNumberToKeep(), pipelineStatus.getDiscardedMaxSize(), statusUpdater);
 			documentIO.prepare();
 			pipelineWriter.prepare();
 			
 			statusIO.save(pipelineStatus);
 		} else {
-			documentIO = new MongoDocumentIO(db, concern, pipelineStatus.getNumberToKeep(), pipelineStatus.getDiscardedMaxSize(), new StatusUpdater(this));
+			documentIO = new MongoDocumentIO(db, concern, pipelineStatus.getNumberToKeep(), pipelineStatus.getDiscardedMaxSize(), statusUpdater);
 		}
 
 		connected = true;
 		
-		statusUpdater = new StatusUpdater(this);
 		statusUpdater.start();
 	}
 

--- a/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoConnector.java
+++ b/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoConnector.java
@@ -10,28 +10,26 @@ import org.slf4j.LoggerFactory;
 import com.findwise.hydra.DatabaseConfiguration;
 import com.findwise.hydra.DatabaseConnector;
 import com.findwise.hydra.PipelineReader;
+import com.findwise.hydra.StatusUpdater;
 import com.findwise.hydra.common.JsonException;
 import com.findwise.hydra.local.LocalDocument;
 import com.findwise.hydra.local.LocalQuery;
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import com.mongodb.DB;
-import com.mongodb.DBCollection;
 import com.mongodb.Mongo;
 import com.mongodb.MongoException;
 import com.mongodb.WriteConcern;
-import com.mongodb.WriteResult;
 
 public class MongoConnector implements DatabaseConnector<MongoType> {
-
-	public static final String HYDRA_COLLECTION_NAME = "hydra";
 	public static final int OLD_DOCUMENTS_TO_KEEP_DEFAULT = 1000;
-	
-	private DBCollection hydraCollection;
 	
 	protected static final String TMP_DIR = "tmp";
 	
 	private DB db;
+	
+	private MongoStatusIO statusIO;
+	
+	private StatusUpdater statusUpdater;
 
 	/**
 	 * Creates the tmp dir if it doesn't exist
@@ -72,11 +70,6 @@ public class MongoConnector implements DatabaseConnector<MongoType> {
 	
 	private boolean connected = false;
 
-	
-	public MongoConnector(){
-		
-	}
-
 	@Inject
 	public MongoConnector(DatabaseConfiguration conf) {
 		this.conf = conf;
@@ -107,31 +100,41 @@ public class MongoConnector implements DatabaseConnector<MongoType> {
 
 		pipelineReader = new MongoPipelineReader(db);
 		pipelineWriter = new MongoPipelineWriter(pipelineReader, concern);
-
-		hydraCollection = db.getCollection(HYDRA_COLLECTION_NAME);
-		hydraCollection.setObjectClass(MongoPipelineStatus.class);
 		
-		if(hydraCollection.count()==0) {
-			MongoPipelineStatus status = getNewPipelineStatus();
-			status.setDiscardedMaxSize(conf.getOldMaxSize());
-			status.setDiscardedToKeep(conf.getOldMaxCount());
+		statusIO = new MongoStatusIO(db);
+		
+		MongoPipelineStatus pipelineStatus;
+		if(!statusIO.hasStatus()) {
+			pipelineStatus = new MongoPipelineStatus();
 			
-			WriteResult wr = hydraCollection.insert(status);
+			statusIO.save(pipelineStatus);
+		} else {
+			pipelineStatus = statusIO.getStatus();
 		}
 		
-		MongoPipelineStatus pipelineStatus = getPipelineStatus();
-		
-		documentIO = new MongoDocumentIO(db, concern, pipelineStatus.getNumberToKeep(), pipelineStatus.getDiscardedMaxSize());
-	
 		if(!pipelineStatus.isPrepared()) {
 			logger.info("Database is new, preparing it");
+			pipelineStatus.setPrepared(true);
+			pipelineStatus.setDiscardedMaxSize(conf.getOldMaxSize());
+			pipelineStatus.setDiscardedToKeep(conf.getOldMaxCount());
+			
+			documentIO = new MongoDocumentIO(db, concern, pipelineStatus.getNumberToKeep(), pipelineStatus.getDiscardedMaxSize(), new StatusUpdater(this));
 			documentIO.prepare();
 			pipelineWriter.prepare();
-			pipelineStatus.setPrepared(true);
-			hydraCollection.save(pipelineStatus);
+			
+			statusIO.save(pipelineStatus);
+		} else {
+			documentIO = new MongoDocumentIO(db, concern, pipelineStatus.getNumberToKeep(), pipelineStatus.getDiscardedMaxSize(), new StatusUpdater(this));
 		}
 
 		connected = true;
+		
+		statusUpdater = new StatusUpdater(this);
+		statusUpdater.start();
+	}
+
+	public StatusUpdater getStatusUpdater() {
+		return statusUpdater;
 	}
 	
 	private boolean requiresAuthentication(Mongo mongo) {
@@ -141,16 +144,6 @@ public class MongoConnector implements DatabaseConnector<MongoType> {
 		} catch (MongoException e) {
 			return true;
 		}
-	}
-
-	@Override
-	public MongoPipelineStatus getNewPipelineStatus() {
-		return new MongoPipelineStatus();
-	}
-	
-	@Override
-	public MongoPipelineStatus getPipelineStatus() {
-		return (MongoPipelineStatus) hydraCollection.findOne();
 	}
 	
 	@Override
@@ -217,5 +210,15 @@ public class MongoConnector implements DatabaseConnector<MongoType> {
 	
 	public DB getDB() {
 		return db;
+	}
+
+	@Override
+	public MongoStatusIO getStatusWriter() {
+		return statusIO;
+	}
+
+	@Override
+	public MongoStatusIO getStatusReader() {
+		return statusIO;
 	}
 }

--- a/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoPipelineStatus.java
+++ b/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoPipelineStatus.java
@@ -1,33 +1,31 @@
 package com.findwise.hydra.mongodb;
 
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
 import org.bson.BSONObject;
 
-import com.findwise.hydra.PipelineStatus;
+import com.findwise.hydra.AbstractPipelineStatus;
 import com.mongodb.DBObject;
 
-public class MongoPipelineStatus implements PipelineStatus, DBObject {
-	private Map<String, Object> map;
-	
-	public static final String DISCARDS_OLD_KEY = "discardOld";
+public class MongoPipelineStatus extends AbstractPipelineStatus<MongoType> implements DBObject {
 	
 	/**
 	 * created defaults to NOW
 	 * prepared defaults to false
 	 */
 	public MongoPipelineStatus() {
-		map = new HashMap<String, Object>();
 		setCreated(new Date());
 		setPrepared(false);
+		setDiscardedCount(0);
+		setProcessedCount(0);
+		setFailedCount(0);
 	}
 	
 	@Override
 	public boolean containsField(String arg0) {
-		return map.containsKey(arg0);
+		return getMap().containsKey(arg0);
 	}
 
 	@Override
@@ -37,41 +35,41 @@ public class MongoPipelineStatus implements PipelineStatus, DBObject {
 
 	@Override
 	public Object get(String arg0) {
-		return map.get(arg0);
+		return getMap().get(arg0);
 	}
 
 	@Override
 	public Set<String> keySet() {
-		return map.keySet();
+		return getMap().keySet();
 	}
 
 	@Override
 	public Object put(String arg0, Object arg1) {
-		return map.put(arg0, arg1);
+		return getMap().put(arg0, arg1);
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public void putAll(BSONObject arg0) {
-		map.putAll(arg0.toMap());
+		getMap().putAll(arg0.toMap());
 		
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
 	public void putAll(Map arg0) {
-		map.putAll(arg0);
+		getMap().putAll(arg0);
 	}
 
 	@Override
 	public Object removeField(String arg0) {
-		return map.remove(arg0);
+		return getMap().remove(arg0);
 	}
 
 	@SuppressWarnings("rawtypes")
 	@Override
 	public Map toMap() {
-		return map;
+		return getMap();
 	}
 	
 	private boolean partial = false;
@@ -86,53 +84,20 @@ public class MongoPipelineStatus implements PipelineStatus, DBObject {
 		partial = true;
 	}
 
-	@Override
-	public void setDiscardOldDocuments(boolean discardOld) {
-		if(discardOld) {
-			map.put(DISCARDS_OLD_KEY, getNumberToKeep());
-		} else {
-			map.remove(DISCARDS_OLD_KEY);
-		}
-	}
-
-	@Override
-	public boolean isDiscardingOldDocuments() {
-		return map.containsKey(DISCARDS_OLD_KEY);
-	}
-
-	@Override
-	public void setDiscardedToKeep(long numberToKeep) {
-		map.put(DISCARDS_OLD_KEY, numberToKeep);
-	}
-
-	@Override
-	public long getNumberToKeep() {
-		return (Long) map.get(DISCARDS_OLD_KEY);
-	}
 	
 	public void setCreated(Date date) {
-		map.put("created", date);
+		getMap().put("created", date);
 	}
 	
 	public Date getCreated() {
-		return (Date) map.get("created");
+		return (Date) getMap().get("created");
 	}
 	
 	public void setPrepared(boolean prepared) {
-		map.put("prepared", prepared);
+		getMap().put("prepared", prepared);
 	}
 	
 	public boolean isPrepared() {
-		return (Boolean) map.get("prepared");
-	}
-
-	@Override
-	public void setDiscardedMaxSize(int maxSize) {
-		map.put("discard_size", maxSize);
-	}
-
-	@Override
-	public int getDiscardedMaxSize() {
-		return (Integer) map.get("discard_size");
+		return (Boolean) getMap().get("prepared");
 	}
 }

--- a/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoStatusIO.java
+++ b/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoStatusIO.java
@@ -1,0 +1,57 @@
+package com.findwise.hydra.mongodb;
+
+import com.findwise.hydra.PipelineStatus;
+import com.findwise.hydra.StatusReader;
+import com.findwise.hydra.StatusWriter;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+
+public class MongoStatusIO implements StatusReader<MongoType>, StatusWriter<MongoType> {
+
+	public static final String HYDRA_COLLECTION_NAME = "hydra";
+	
+	private DBCollection collection;
+	
+	public MongoStatusIO(DB db) {
+		collection = db.getCollection(HYDRA_COLLECTION_NAME);
+		collection.setObjectClass(MongoPipelineStatus.class);
+	}
+
+	@Override
+	public void increment(int processed, int failed, int discarded) {
+		MongoPipelineStatus mps = getStatus();
+		
+		if(mps==null) {
+			return;
+		}
+		
+		mps.setProcessedCount(mps.getProcessedCount()+processed);
+
+		mps.setFailedCount(mps.getFailedCount()+failed);
+
+		mps.setDiscardedCount(mps.getDiscardedCount()+discarded);
+		
+		save(mps);
+	}
+
+	@Override
+	public MongoPipelineStatus getStatus() {
+		return (MongoPipelineStatus) collection.findOne();
+	}
+
+	@Override
+	public void save(PipelineStatus<MongoType> status) {
+		MongoPipelineStatus mps = (MongoPipelineStatus) status;
+		if(mps.containsField("_id")) {
+			collection.save(mps);
+		} else {
+			collection.remove(new BasicDBObject());
+			collection.insert(mps);
+		}
+	}
+
+	public boolean hasStatus() {
+		return collection.count()!=0;
+	}
+}

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoConnectorTest.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoConnectorTest.java
@@ -137,7 +137,7 @@ public class MongoConnectorTest {
 	}
 
 	@Test
-	public void getDocuments() {
+	public void testGetDocuments() {
 		MongoQuery mdq = new MongoQuery();
 		List<DatabaseDocument<MongoType>> list = mdc.getDocumentReader().getDocuments(mdq, 3);
 		if(list.size()!=3) {

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOTest.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.fail;
 
 import java.util.Random;
 
+import junit.framework.Assert;
+
 import org.bson.types.ObjectId;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -14,12 +16,13 @@ import com.findwise.hydra.DatabaseDocument;
 import com.findwise.hydra.DocumentWriter;
 import com.findwise.hydra.TailableIterator;
 import com.findwise.hydra.TestModule;
-import com.findwise.hydra.common.SerializationUtils;
 import com.findwise.hydra.common.Document.Status;
+import com.findwise.hydra.common.SerializationUtils;
 import com.google.inject.Guice;
+import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
-import com.mongodb.DBCollection;
 import com.mongodb.Mongo;
+import com.mongodb.WriteConcern;
 
 public class MongoDocumentIOTest {
 	private MongoConnector mdc;
@@ -65,17 +68,25 @@ public class MongoDocumentIOTest {
 	}
 	
 	private boolean isCapped() {
-		DBCollection dbc = mdc.getDB().getCollection(MongoDocumentIO.OLD_DOCUMENT_COLLECTION);
-		if(dbc.getStats().containsField("capped")) {
-			return dbc.getStats().get("capped").equals(1);
-		}
-		return false;
+		return mdc.getDB().getCollection(MongoDocumentIO.OLD_DOCUMENT_COLLECTION).isCapped();
 	}
 	
 	@Test
 	public void testConnectPrepare() throws Exception {
 		mdc.getDB().dropDatabase();
+		while(mdc.getDB().getCollection(MongoStatusIO.HYDRA_COLLECTION_NAME).count()!=0) {
+			mdc.getDB().getCollection(MongoStatusIO.HYDRA_COLLECTION_NAME).remove(new BasicDBObject(), WriteConcern.SAFE);
+			Thread.sleep(50);
+		}
+		
+		if(mdc.getStatusReader().hasStatus()) {
+			fail("Test error");
+		}
+		
+		Assert.assertFalse(isCapped());
+		
 		mdc.connect();
+
 		if(!isCapped()) {
 			fail("Collection was not capped on connect");
 		}
@@ -86,7 +97,7 @@ public class MongoDocumentIOTest {
 		DocumentWriter<MongoType> dw = mdc.getDocumentWriter();
 		dw.prepare();
 
-		for(int i=0; i<mdc.getPipelineStatus().getNumberToKeep(); i++) {
+		for(int i=0; i<mdc.getStatusReader().getStatus().getNumberToKeep(); i++) {
 			dw.insert(new MongoDocument());
 			DatabaseDocument<MongoType> dd = dw.getAndTag(new MongoQuery(), "tag");
 			dw.markProcessed(dd, "tag");
@@ -96,7 +107,7 @@ public class MongoDocumentIOTest {
 			fail("Still some active docs..");
 		}
 		
-		if(mdc.getDocumentReader().getInactiveDatabaseSize()!=mdc.getPipelineStatus().getNumberToKeep()) {
+		if(mdc.getDocumentReader().getInactiveDatabaseSize()!=mdc.getStatusReader().getStatus().getNumberToKeep()) {
 			fail("Incorrect number of old documents kept");
 		}
 		
@@ -107,7 +118,7 @@ public class MongoDocumentIOTest {
 		if(mdc.getDocumentReader().getActiveDatabaseSize()!=0) {
 			fail("Still some active docs..");
 		}
-		if(mdc.getDocumentReader().getInactiveDatabaseSize()!=mdc.getPipelineStatus().getNumberToKeep()) {
+		if(mdc.getDocumentReader().getInactiveDatabaseSize()!=mdc.getStatusReader().getStatus().getNumberToKeep()) {
 			fail("Incorrect number of old documents kept: "+ mdc.getDocumentReader().getInactiveDatabaseSize());
 		}
 	}
@@ -238,7 +249,7 @@ public class MongoDocumentIOTest {
 	public void testReadStatus() throws Exception {
 		mdc.getDocumentWriter().prepare();
 		
-		testReadCount = (int)mdc.getPipelineStatus().getNumberToKeep(); 
+		testReadCount = (int)mdc.getStatusReader().getStatus().getNumberToKeep(); 
 		
 		TailReader tr = new TailReader(mdc.getDocumentReader().getInactiveIterator());
 		tr.start();

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoStatusIOTest.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoStatusIOTest.java
@@ -1,0 +1,93 @@
+package com.findwise.hydra.mongodb;
+
+import static org.junit.Assert.*;
+
+import java.net.UnknownHostException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.mongodb.DB;
+import com.mongodb.Mongo;
+import com.mongodb.MongoException;
+
+public class MongoStatusIOTest {
+	private DB db;
+	
+	@Before
+	public void setUp() throws UnknownHostException, MongoException {
+		tearDown();
+		db = new Mongo().getDB("junit-statusiotest");
+	}
+	
+	@After
+	public void tearDown() throws MongoException, UnknownHostException {
+		new Mongo().getDB("junit-statusiotest").dropDatabase();
+	}
+	
+	@Test
+	public void testSaveInsert() {
+		MongoStatusIO io = new MongoStatusIO(db);
+		
+		if(io.hasStatus() && io.getStatus().isPrepared()) {
+			fail("Not set up properly");
+		}
+		
+		MongoPipelineStatus mps = new MongoPipelineStatus();
+		mps.setPrepared(true);
+		io.save(mps);
+		
+		if(!io.getStatus().isPrepared()) {
+			fail("Did not insert properly");
+		}
+		
+	}
+	
+	@Test
+	public void testCounts() {
+		MongoStatusIO io = new MongoStatusIO(db);
+		MongoPipelineStatus mps = new MongoPipelineStatus();
+		
+		if(mps.getFailedCount()!=0) {
+			fail("Failed was non-zero from the start");
+		}
+		if(mps.getProcessedCount()!=0) {
+			fail("Processed was non-zero from the start");
+		}
+		if(mps.getDiscardedCount()!=0) {
+			fail("Discarded was non-zero from the start");
+		}
+		
+		mps.setFailedCount(1);
+		mps.setDiscardedCount(2);
+		mps.setProcessedCount(3);
+		
+		io.save(mps);
+		
+		mps = io.getStatus();
+
+		assertEquals(1, mps.getFailedCount());
+		assertEquals(2, mps.getDiscardedCount());
+		assertEquals(3, mps.getProcessedCount());
+	}
+	
+	@Test
+	public void testIncrement() {
+		MongoStatusIO io = new MongoStatusIO(db);
+		MongoPipelineStatus mps = new MongoPipelineStatus();
+		io.save(mps);
+		
+		assertEquals(mps.getDiscardedCount(), 0);
+		assertEquals(mps.getFailedCount(), 0);
+		assertEquals(mps.getProcessedCount(), 0);
+		
+		io.increment(1, 3, Integer.MAX_VALUE);
+		
+		mps = io.getStatus();
+		
+		assertEquals(1, mps.getProcessedCount());
+		assertEquals(3, mps.getFailedCount());
+		assertEquals(Integer.MAX_VALUE, mps.getDiscardedCount());
+	}
+}

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -5,7 +5,7 @@
 	<packaging>jar</packaging>
 	<version>0.3.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
-	<description>Hydra Database Package - Database interfaces AND MongoDB implementation</description>
+	<description>Hydra Database Package - Database interfaces</description>
 	<url>http://findwise.github.com/Hydra</url>
 
 	<licenses>
@@ -43,6 +43,12 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.10</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>1.6.4</version>
@@ -55,6 +61,13 @@
 			<version>2.1</version>
 			<type>jar</type>
 			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>1.9.5-rc1</version>
+			<type>jar</type>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/database/src/main/java/com/findwise/hydra/AbstractPipelineStatus.java
+++ b/database/src/main/java/com/findwise/hydra/AbstractPipelineStatus.java
@@ -5,8 +5,6 @@ import java.util.Map;
 
 /**
  * Convenience class for map-based implementation of PipelineStatus
- * 
- *
  */
 public abstract class AbstractPipelineStatus<T extends DatabaseType> implements PipelineStatus<T> {
 	private Map<String, Object> map = new HashMap<String, Object>();

--- a/database/src/main/java/com/findwise/hydra/AbstractPipelineStatus.java
+++ b/database/src/main/java/com/findwise/hydra/AbstractPipelineStatus.java
@@ -1,0 +1,85 @@
+package com.findwise.hydra;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Convenience class for map-based implementation of PipelineStatus
+ * 
+ *
+ */
+public abstract class AbstractPipelineStatus<T extends DatabaseType> implements PipelineStatus<T> {
+	private Map<String, Object> map = new HashMap<String, Object>();
+
+	private static final String DISCARDS_OLD_KEY = "discardOld";
+	
+	@Override
+	public void setDiscardOldDocuments(boolean discardOld) {
+		if(discardOld) {
+			map.put(DISCARDS_OLD_KEY, getNumberToKeep());
+		} else {
+			map.remove(DISCARDS_OLD_KEY);
+		}
+	}
+	
+	protected Map<String, Object> getMap() {
+		return map;
+	}
+
+	@Override
+	public boolean isDiscardingOldDocuments() {
+		return map.containsKey(DISCARDS_OLD_KEY);
+	}
+
+	@Override
+	public void setDiscardedToKeep(long numberToKeep) {
+		map.put(DISCARDS_OLD_KEY, numberToKeep);
+	}
+
+	@Override
+	public long getNumberToKeep() {
+		return (Long) map.get(DISCARDS_OLD_KEY);
+	}
+
+	@Override
+	public void setDiscardedMaxSize(int maxSize) {
+		map.put("discard_size", maxSize);
+	}
+
+	@Override
+	public int getDiscardedMaxSize() {
+		return (Integer) map.get("discard_size");
+	}
+
+	@Override
+	public int getDiscardedCount() {
+		return (Integer) map.get("discarded_count");
+	}
+
+	@Override
+	public void setDiscardedCount(int i) {
+		map.put("discarded_count", i);
+		
+	}
+
+	@Override
+	public int getProcessedCount() {
+		return (Integer) map.get("processed_count");
+	}
+
+	@Override
+	public void setProcessedCount(int i) {
+		map.put("processed_count", i);
+		
+	}
+
+	@Override
+	public int getFailedCount() {
+		return (Integer) map.get("failed_count");
+	}
+
+	@Override
+	public void setFailedCount(int i) {
+		map.put("failed_count", i);
+	}
+}

--- a/database/src/main/java/com/findwise/hydra/DatabaseConnector.java
+++ b/database/src/main/java/com/findwise/hydra/DatabaseConnector.java
@@ -41,8 +41,8 @@ public interface DatabaseConnector<T extends DatabaseType> {
 
 	boolean isConnected();
 
-	PipelineStatus getPipelineStatus();
-
-	PipelineStatus getNewPipelineStatus();
+	StatusWriter<T> getStatusWriter();
+	
+	StatusReader<T> getStatusReader();
 	
 }

--- a/database/src/main/java/com/findwise/hydra/PipelineStatus.java
+++ b/database/src/main/java/com/findwise/hydra/PipelineStatus.java
@@ -11,7 +11,7 @@ package com.findwise.hydra;
  * @author joel.westberg
  *
  */
-public interface PipelineStatus {
+public interface PipelineStatus<T extends DatabaseType> {
 
 	boolean DEFAULT_DISCARD_OLD = true;
 	long DEFAULT_NUMBER_TO_KEEP = 1000;
@@ -38,4 +38,15 @@ public interface PipelineStatus {
 	
 	int getDiscardedMaxSize();
 	
+	int getDiscardedCount();
+	
+	void setDiscardedCount(int i);
+	
+	int getProcessedCount();
+	
+	void setProcessedCount(int i);
+	
+	int getFailedCount();
+	
+	void setFailedCount(int i);
 }

--- a/database/src/main/java/com/findwise/hydra/StatusReader.java
+++ b/database/src/main/java/com/findwise/hydra/StatusReader.java
@@ -1,0 +1,10 @@
+package com.findwise.hydra;
+
+public interface StatusReader<T extends DatabaseType> {
+	PipelineStatus<T> getStatus();
+	
+	/**
+	 * @return true if there is a status saved, otherwise false.
+	 */
+	boolean hasStatus();
+}

--- a/database/src/main/java/com/findwise/hydra/StatusUpdater.java
+++ b/database/src/main/java/com/findwise/hydra/StatusUpdater.java
@@ -1,0 +1,81 @@
+package com.findwise.hydra;
+
+
+
+public class StatusUpdater extends Thread {
+	private int processed;
+	private int failed;
+	private int discarded;
+	
+	private int interval;
+	
+	private DatabaseConnector<?> connector;
+	
+	/**
+	 * Sets up a StatusUpdater with default update interval of 1000.
+	 * 
+	 * Equivalent of calling StatusUpdater(connector, 1000)
+	 */
+	public StatusUpdater(DatabaseConnector<?> connector) {
+		this(connector, 1000);
+	}
+	
+	public StatusUpdater(DatabaseConnector<?> connector, int updateIntervalMs) {
+		this.connector = connector;
+		this.interval = updateIntervalMs;
+	}
+	
+	public void setUpdateInterval(int updateIntervalMs) {
+		interval = updateIntervalMs;
+	}
+	
+	public int getUpdateInterval() {
+		return interval;
+	}
+	
+	public synchronized void addProcessed(int toAdd) {
+		processed += toAdd;
+	}
+	
+	private synchronized int getAndClearProcessed() {
+		int a = processed;
+		processed = 0;
+		return a;
+	}
+	
+	public synchronized void addFailed(int toAdd) {
+		failed += toAdd;
+	}
+	
+	private synchronized int getAndClearFailed() {
+		int a = failed;
+		failed = 0;
+		return a;
+	}
+	
+	public synchronized void addDiscarded(int toAdd) {
+		discarded += toAdd;
+	}
+	
+	private synchronized int getAndClearDiscarded() {
+		int a = discarded;
+		discarded = 0;
+		return a;
+	}
+
+	public void run() {
+		while (!isInterrupted()) {
+			try {
+				saveStatus();
+				Thread.sleep(interval);
+			} catch (InterruptedException e) {
+				interrupt();
+			}
+		}
+		saveStatus();
+	}
+
+	public void saveStatus() {
+		connector.getStatusWriter().increment(getAndClearProcessed(), getAndClearFailed(), getAndClearDiscarded());
+	}
+}

--- a/database/src/main/java/com/findwise/hydra/StatusUpdater.java
+++ b/database/src/main/java/com/findwise/hydra/StatusUpdater.java
@@ -1,7 +1,6 @@
 package com.findwise.hydra;
 
 
-
 public class StatusUpdater extends Thread {
 	private int processed;
 	private int failed;

--- a/database/src/main/java/com/findwise/hydra/StatusWriter.java
+++ b/database/src/main/java/com/findwise/hydra/StatusWriter.java
@@ -1,0 +1,10 @@
+package com.findwise.hydra;
+
+
+public interface StatusWriter<T extends DatabaseType> {
+
+	void increment(int processed, int failed, int discarded);
+
+	void save(PipelineStatus<T> status);
+
+}

--- a/database/src/test/java/com/findwise/hydra/StatusUpdaterTest.java
+++ b/database/src/test/java/com/findwise/hydra/StatusUpdaterTest.java
@@ -1,0 +1,48 @@
+package com.findwise.hydra;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class StatusUpdaterTest {
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void testRun() throws Exception {
+		DatabaseConnector<?> dbc = Mockito.mock(DatabaseConnector.class);
+		StatusWriter sw = Mockito.mock(StatusWriter.class);
+		Mockito.when(dbc.getStatusWriter()).thenReturn(sw);
+		
+		StatusUpdater su = new StatusUpdater(dbc, 1);
+		Mockito.verify(sw, Mockito.never()).increment(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyInt());
+		su.start();
+		
+		Thread.sleep(10);
+		
+		su.interrupt();
+		
+		Mockito.verify(sw, Mockito.atLeast(2)).increment(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyInt());
+		
+		Thread.sleep(10);
+		Mockito.verifyNoMoreInteractions(sw);
+	}
+	
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void testSaveStatus() {
+		DatabaseConnector<?> dbc = Mockito.mock(DatabaseConnector.class);
+		StatusWriter sw = Mockito.mock(StatusWriter.class);
+		Mockito.when(dbc.getStatusWriter()).thenReturn(sw);
+		StatusUpdater su = new StatusUpdater(dbc);
+		su.addProcessed(3);
+		su.addFailed(2);
+		su.addDiscarded(1);
+		su.saveStatus();
+		
+		Mockito.verify(sw).increment(3, 2, 1);
+		su.saveStatus();
+		
+		Mockito.verify(sw).increment(0, 0, 0);
+		
+	}
+
+}

--- a/examples/src/main/java/com/findwise/hydra/InteractiveOutputStage.java
+++ b/examples/src/main/java/com/findwise/hydra/InteractiveOutputStage.java
@@ -1,0 +1,55 @@
+package com.findwise.hydra;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+
+import com.findwise.hydra.local.LocalDocument;
+import com.findwise.hydra.local.RemotePipeline;
+import com.findwise.hydra.stage.AbstractOutputStage;
+import com.findwise.hydra.stage.Stage;
+
+@Stage
+public class InteractiveOutputStage extends AbstractOutputStage {
+	
+	@Override
+	public void output(LocalDocument document) {
+		try {
+			String s = new Scanner(System.in).nextLine();
+			if(s.equals("d")) {
+				System.out.println("Discarding the document");
+				getRemotePipeline().markDiscarded(document);
+			} else if(s.equals("p")) {
+				System.out.println("Processing the document");
+				getRemotePipeline().markProcessed(document);
+			} else if(s.equals("f")) {
+				System.out.println("Failing the document");
+				getRemotePipeline().markFailed(document);
+			} else {
+				System.out.println("Unknown command: "+s);
+			}
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+	
+	/**
+	 * For convenience...
+	 * @param args
+	 */
+	public static void main(String[] args) {
+		//AbstractStage.main(args);
+		try {
+			InteractiveOutputStage ios = new InteractiveOutputStage();
+			Map<String, Object> map = new HashMap<String, Object>();
+			map.put("stageClass", ios.getClass().getName());
+			ios.setUp(new RemotePipeline("interactive"), map);
+			ios.start();
+			
+		} catch(Exception e) {
+			e.printStackTrace();
+		}
+	}
+	
+}

--- a/examples/src/main/java/com/findwise/hydra/InteractiveOutputStage.java
+++ b/examples/src/main/java/com/findwise/hydra/InteractiveOutputStage.java
@@ -1,6 +1,7 @@
 package com.findwise.hydra;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Scanner;
 
@@ -15,7 +16,8 @@ public class InteractiveOutputStage extends AbstractOutputStage {
 	@Override
 	public void output(LocalDocument document) {
 		try {
-			String s = new Scanner(System.in).nextLine();
+			System.out.print("(p)rocessed, (d)elete, (f)ailed. Select action: ");
+			String s = new Scanner(System.in).nextLine().toLowerCase(Locale.ENGLISH);
 			if(s.equals("d")) {
 				System.out.println("Discarding the document");
 				getRemotePipeline().markDiscarded(document);


### PR DESCRIPTION
In short, Hydra will now record how many documents are failed, processed or discarded during normal running. These stats are synced to Mongo every second. 

Refactored a lot of things regarding the PipelineStatus class. Hopefully, this will now be extensible and allow for easier hookup of new stats one wants to collect in the future.
