### PR TITLE
SolrOutputStage now persists errors when failing a document

### DIFF
--- a/api/src/main/java/com/findwise/hydra/stage/AbstractOutputStage.java
+++ b/api/src/main/java/com/findwise/hydra/stage/AbstractOutputStage.java
@@ -86,6 +86,10 @@ public abstract class AbstractOutputStage extends AbstractProcessStage {
 		return getRemotePipeline().markFailed(document);
 	}
 	
+	protected boolean fail(LocalDocument document, Throwable throwable) throws IOException {
+		return getRemotePipeline().markFailed(document, throwable);
+	}
+	
 	private boolean reject() throws IOException {
 		return getRemotePipeline().releaseLastDocument();
 	}

--- a/stages/out/solr-out/src/main/java/com/findwise/hydra/output/solr/SolrOutputStage.java
+++ b/stages/out/solr-out/src/main/java/com/findwise/hydra/output/solr/SolrOutputStage.java
@@ -119,19 +119,14 @@ public class SolrOutputStage extends AbstractOutputStage {
 			}
 		}
 	}
-	
-	private void failDocument(LocalDocument doc) {
-		try {
-			fail(doc);
-		} catch (Exception e) {
-			Logger.error(
-					"Could not fail document with hydra id: " + doc.getID(), e);
-		}
-	}
 
 	private void failDocument(LocalDocument doc, Throwable reason) {
-		Logger.error("Failing document due to exception", reason);
-		failDocument(doc);
+		try {
+			Logger.error("Failing document "+doc.getID(), reason);
+			fail(doc, reason);
+		} catch (Exception e) {
+			Logger.error("Could not fail document with hydra id: " + doc.getID(), e);
+		}
 	}
 
 	private SolrServer getSolrServer() throws MalformedURLException {


### PR DESCRIPTION
SolrOutputStage wasn't persisting any failiures it encountered when sending documents to Solr. 

This should greatly help anyone tailing the oldDocuments collection (through the TailableIterator) figure out why documents aren't being indexed.

Added a method to AbstractOutputStage to make sure it works.
