### PR TITLE
Improved handling of errors during document updates

### DIFF
--- a/api/src/main/java/com/findwise/hydra/stage/AbstractOutputStage.java
+++ b/api/src/main/java/com/findwise/hydra/stage/AbstractOutputStage.java
@@ -95,10 +95,11 @@ public abstract class AbstractOutputStage extends AbstractProcessStage {
 	}
 	
 	@Override
-	protected void persist() {
+	protected boolean persist() {
 		/*
 		 * TODO: Overridden and intentionally left blank. This structure should be refactored. 
 		 * Accept/reject/pending should be used instead for all OutputStages...
 		 */
+		return true;
 	}
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -168,6 +168,13 @@
 			<type>jar</type>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>1.9.0</version>
+			<type>jar</type>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 

--- a/core/src/main/java/com/findwise/hydra/net/HttpResponseWriter.java
+++ b/core/src/main/java/com/findwise/hydra/net/HttpResponseWriter.java
@@ -97,6 +97,11 @@ public final class HttpResponseWriter {
 		setStringEntity(response, "Document " + id + " successfully saved");
 	}
 	
+	protected static void printSaveFailed(HttpResponse response, Object id) {
+		response.setStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+		setStringEntity(response, "Unable to update document with id:"+id);
+	}
+	
 	protected static void printFileDeleteOk(HttpResponse response, String filename, Object id) {
 		logger.debug("Successfully deleted file with filename: "+filename+" from document " + id);
 		response.setStatusCode(HttpStatus.SC_OK);

--- a/core/src/main/java/com/findwise/hydra/net/WriteHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/WriteHandler.java
@@ -102,7 +102,7 @@ public class WriteHandler<T extends DatabaseType> implements ResponsibleHandler 
 		logger.debug("Handling a partial write for document "+md.getID());
 		DatabaseDocument<T> inDB = dbc.getDocumentReader().getDocumentById(md.getID());
 		if(inDB==null) {
-			HttpResponseWriter.printUpdateFailed(response, md.getID());
+			HttpResponseWriter.printNoDocument(response);
 			return false;
 		}
 		inDB.putAll(md);
@@ -113,7 +113,7 @@ public class WriteHandler<T extends DatabaseType> implements ResponsibleHandler 
 			return true;
 		} 
 		else {
-			HttpResponseWriter.printUpdateFailed(response, md.getID());
+			HttpResponseWriter.printSaveFailed(response, md.getID());
 			return false;
 		}
 	}
@@ -124,7 +124,7 @@ public class WriteHandler<T extends DatabaseType> implements ResponsibleHandler 
 			HttpResponseWriter.printSaveOk(response, md.getID());
 			return true;
 		}
-		HttpResponseWriter.printUpdateFailed(response, md.getID());
+		HttpResponseWriter.printSaveFailed(response, md.getID());
 		return false;
 	}
 	

--- a/core/src/test/java/com/findwise/hydra/net/WriteHandlerTest.java
+++ b/core/src/test/java/com/findwise/hydra/net/WriteHandlerTest.java
@@ -1,0 +1,92 @@
+package com.findwise.hydra.net;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.findwise.hydra.DatabaseConnector;
+import com.findwise.hydra.DatabaseDocument;
+import com.findwise.hydra.DatabaseType;
+import com.findwise.hydra.DocumentReader;
+import com.findwise.hydra.DocumentWriter;
+import com.findwise.hydra.local.LocalDocument;
+import com.findwise.hydra.local.RemotePipeline;
+
+public class WriteHandlerTest {
+	@SuppressWarnings("rawtypes")
+	private DatabaseConnector dbc;
+	private DocumentWriter<?> writer;
+	private DocumentReader<?> reader;
+	private RESTServer server;
+	
+	@SuppressWarnings("unchecked")
+	@Before
+	public void setUp() throws Exception {
+		writer = mock(DocumentWriter.class);
+		reader = mock(DocumentReader.class);
+		dbc = mock(DatabaseConnector.class);
+		when(dbc.getDocumentWriter()).thenReturn(writer);
+		when(dbc.getDocumentReader()).thenReturn(reader);
+		server = RESTServer.getNewStartedRESTServer(14000, new HttpRESTHandler<DatabaseType>(dbc));
+		
+		
+	}
+
+	@SuppressWarnings({ "unchecked"})
+	@Test
+	public void testSaveFull() throws Exception {
+		when(writer.insert(any(DatabaseDocument.class))).thenReturn(false);
+		
+		DatabaseDocument<?> dbdoc = mock(DatabaseDocument.class);
+		when(dbc.convert(any(LocalDocument.class))).thenReturn(dbdoc);
+		
+		when(dbdoc.getID()).thenReturn(null);
+		
+		RemotePipeline rp = new RemotePipeline("localhost", server.getPort(), "stage");
+		LocalDocument ld = new LocalDocument();
+		
+		boolean result = rp.saveFull(ld);
+		
+		if(result) {
+			fail("Did not get false response");
+		}
+		
+		verify(writer, times(1)).insert(any(DatabaseDocument.class));
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public void testSave() throws Exception {
+		when(writer.insert(any(DatabaseDocument.class))).thenReturn(false);
+		
+		DatabaseDocument dbdoc = mock(DatabaseDocument.class);
+		when(dbc.convert(any(LocalDocument.class))).thenReturn(dbdoc);
+		
+		when(dbdoc.getID()).thenReturn(1);
+		when(reader.getDocumentById(1)).thenReturn(dbdoc);
+		
+		RemotePipeline rp = new RemotePipeline("localhost", server.getPort(), "stage");
+		LocalDocument ld = new LocalDocument();
+		
+		boolean result = rp.saveFull(ld);
+		
+		if(result) {
+			fail("Did not get false response on saveFull");
+		}
+		
+		result = rp.save(ld);
+		
+		if(result) {
+			fail("Did not get false response on save");
+		}
+		
+		verify(writer, times(2)).update(any(DatabaseDocument.class));
+	}
+
+}

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/TestModule.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/TestModule.java
@@ -1,11 +1,9 @@
 package com.findwise.hydra;
 
-import com.findwise.hydra.DatabaseConnector;
 import com.findwise.hydra.mongodb.MongoConnector;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import com.google.inject.name.Names;
 
 public class TestModule extends AbstractModule {
 	private String namespace;

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOTest.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOTest.java
@@ -243,6 +243,45 @@ public class MongoDocumentIOTest {
 		
 	}
 	
+	@Test
+	public void testInsertLargeDocument() throws Exception {
+		DocumentWriter<MongoType> dw = mdc.getDocumentWriter();
+		dw.prepare();
+		
+		MongoDocument d = new MongoDocument();
+		makeDocumentTooLarge(d);
+		
+		if(dw.insert(d)) {
+			fail("No error inserting big document");
+		}
+	}
+	
+	@Test
+	public void testUpdateLargeDocument() throws Exception {
+
+		DocumentWriter<MongoType> dw = mdc.getDocumentWriter();
+		dw.prepare();
+		
+		
+		
+		MongoDocument d = new MongoDocument();
+		d.putContentField("some_field", "some data");
+		
+		dw.insert(d);
+		
+		makeDocumentTooLarge(d);
+		
+		if(dw.update(d)) {
+			fail("No error updating big document");
+		}
+	}
+	
+	private void makeDocumentTooLarge(MongoDocument d) {
+		int maxMongoDBObjectSize = mdc.getDB().getMongo().getConnector().getMaxBsonObjectSize();
+		while(d.toJson().getBytes().length <= maxMongoDBObjectSize) {
+			d.putContentField(getRandomString(5), getRandomString(1000000));
+		}
+	}
 	
 	int testReadCount = 1;
 	@Test


### PR DESCRIPTION
AbstractProcessStage now checks for exceptional return values when calling saveCurrentDocument. If an abnormal return value is detected, it attempts to fail the document instead. If even that fails, it logs an error.

Also added regression tests to ensure that:
- MongoDocumentIO returns false when attempting to write a document that is too large rather than throw an exception
- WriteHandler/RemotePipeline integration works properly for when DocumentWriter.insert/update returns false
