### PR TITLE
Adding MergeFieldsStage

### DIFF
--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/MergeFieldsStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/MergeFieldsStage.java
@@ -1,0 +1,107 @@
+package com.findwise.hydra.stage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.findwise.hydra.local.LocalDocument;
+
+@Stage(description = "Allows merging of the content of several different fields into one: either by explicit numeration or by field names matching a regular expression. Can merge by: concatenation (default), adding to list or by arithmetic addition.")
+public class MergeFieldsStage extends AbstractProcessStage {
+	@Parameter(required = true, description = "The field in which to store the merged fields")
+	private String outputField;
+
+	@Parameter(required = true, description = "The fields from which the merge should happen. Should be regular expression patterns, e.g. field[0-9]* will merge all fields named field<number>.")
+	private List<String> fromFields;
+
+	@Parameter(description = "If set, clears the designated outputField before " +
+			"merging any content into it")
+	private boolean clearOutputField = false;
+
+	@Parameter(description = "When merging as strings, this element will be " +
+			"used to separate the component parts. Defaults to whitespace (' ')")
+	private String separator = " ";
+
+	@Parameter(description = "If set to true, instead of merging fromFields as " +
+			"strings, attempts to do arithmetic add as long as all components are " +
+			"numbers. If any field is of a non-numeric type, the output may be " +
+			"partially added and partially concatenated, in no predictable order")
+	private boolean additionIfNumbers = false;
+
+	@Parameter(description = "If set to true, creates a list in the target field " +
+			"instead of merging into one String object. If there is already a list " +
+			"in the outputField, this list will be appended to. If the outputField " +
+			"contains something else, it will become the first element of the list.")
+	private boolean createList = false;
+
+	public void init() throws RequiredArgumentMissingException {
+		if(outputField == null) {
+			throw new RequiredArgumentMissingException("Missing required parameter 'outputField'");
+		}
+		if(fromFields == null) {
+			throw new RequiredArgumentMissingException("Missing required parameter 'fromFields'");
+		}
+	}
+	
+	@Override
+	public void process(LocalDocument doc) throws ProcessException {
+		if(clearOutputField) {
+			doc.putContentField(outputField, null);
+		}
+		String[] documentFields = doc.getContentFields().toArray(new String[doc.getContentFields().size()]);
+		for(String fieldRegex : fromFields) {
+			for(String docFieldName : documentFields) {
+				if(docFieldName.matches(fieldRegex)) {
+					Object content = doc.getContentField(docFieldName);
+					if(createList) {
+						addToOutputList(doc, content);
+					} else {
+						if(!doc.hasContentField(outputField) || doc.getContentField(outputField) == null) {
+							doc.putContentField(outputField, content);
+						} else {
+							if(additionIfNumbers && content instanceof Number && doc.getContentField(outputField) instanceof Number) {
+								doc.putContentField(outputField, addNumbers((Number)doc.getContentField(outputField), (Number) content));
+							} else {
+								doc.putContentField(outputField, doc.getContentField(outputField)+separator+content);
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	@SuppressWarnings("unchecked")
+	private void addToOutputList(LocalDocument doc, Object content) {
+		List<Object> list = new ArrayList<Object>();
+		if(doc.hasContentField(outputField)) {
+			if(!(doc.getContentField(outputField) instanceof List)) {
+				list.add(doc.getContentField(outputField));
+			}
+			else {
+				list = (List<Object>) doc.getContentField(outputField);
+			}
+		}
+		list.add(content);
+		doc.putContentField(outputField, list);
+	}
+
+	private Number addNumbers(Number x, Number y) {
+		if(x instanceof Double && y instanceof Double) {
+			return x.doubleValue() + y.doubleValue();
+		} else if (x instanceof Double && (y instanceof Long || y instanceof Integer)) {
+			return x.doubleValue() + y.longValue();
+		} else if ((x instanceof Long || x instanceof Integer) && y instanceof Double) {
+			return y.doubleValue() + x.longValue();
+		} else {
+			return addIntegers(x, y);
+		}
+	}
+	
+	private Number addIntegers(Number x, Number y) {
+		if(x instanceof Long || y instanceof Long) {
+			return x.longValue() + y.longValue();
+		} else {
+			return x.intValue() + y.intValue();
+		}
+	}
+}

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/MergeFieldsStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/MergeFieldsStage.java
@@ -32,7 +32,7 @@ public class MergeFieldsStage extends AbstractProcessStage {
 			"in the outputField, this list will be appended to. If the outputField " +
 			"contains something else, it will become the first element of the list.")
 	private boolean createList = false;
-
+	
 	public void init() throws RequiredArgumentMissingException {
 		if(outputField == null) {
 			throw new RequiredArgumentMissingException("Missing required parameter 'outputField'");
@@ -48,8 +48,8 @@ public class MergeFieldsStage extends AbstractProcessStage {
 			doc.putContentField(outputField, null);
 		}
 		String[] documentFields = doc.getContentFields().toArray(new String[doc.getContentFields().size()]);
-		for(String fieldRegex : fromFields) {
-			for(String docFieldName : documentFields) {
+		for(String docFieldName : documentFields) {
+			for(String fieldRegex : fromFields) {
 				if(docFieldName.matches(fieldRegex)) {
 					Object content = doc.getContentField(docFieldName);
 					if(createList) {
@@ -65,6 +65,7 @@ public class MergeFieldsStage extends AbstractProcessStage {
 							}
 						}
 					}
+					break;
 				}
 			}
 		}

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/MergeFieldsStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/MergeFieldsStageTest.java
@@ -1,0 +1,370 @@
+package com.findwise.hydra.stage;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import com.findwise.hydra.local.LocalDocument;
+
+public class MergeFieldsStageTest {
+	
+	@Test
+	public void testInit() throws Exception {
+		MergeFieldsStage mfs = new MergeFieldsStage();
+		
+		Map<String, Object> map = new HashMap<String, Object>();
+		mfs.setParameters(map);
+		
+		try {
+			mfs.init();
+			Assert.fail("Did not throw RequiredArgumentMissing");
+		} catch(RequiredArgumentMissingException e) {
+		}
+		
+		map.put("outputField", "out");
+		map.put("fromFields", new ArrayList<String>());
+		
+		mfs.setParameters(map);
+		
+		mfs.init();
+	}
+	
+	@Test
+	public void testProcessNoFromFields() throws Exception {
+		MergeFieldsStage mfs = new MergeFieldsStage();
+		
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("outputField", "out");
+		map.put("fromFields", new ArrayList<String>());
+		
+		mfs.setParameters(map);
+		
+		LocalDocument doc = new LocalDocument();
+		doc.putContentField("out", "xyz");
+		doc.putContentField("test", "test");
+		
+		LocalDocument doc2 = new LocalDocument(doc.toJson());
+		mfs.process(doc2);
+		
+		Assert.assertTrue(doc.isEqual(doc2));
+	}
+	
+	@Test
+	public void testProcessFieldNames() throws Exception {
+		MergeFieldsStage mfs = new MergeFieldsStage();
+		
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("outputField", "out");
+		
+		List<String> list =  new ArrayList<String>();
+		list.add("in1");
+		list.add("in2");
+		list.add("in3");
+		map.put("fromFields", list);
+		
+		mfs.setParameters(map);
+		
+		LocalDocument doc = getDocument();
+		doc.putContentField("out", "xyz");
+		
+		LocalDocument doc2 = new LocalDocument(doc.toJson());
+		mfs.process(doc2);
+		
+		Assert.assertEquals(doc.getContentField("in1"), doc2.getContentField("in1"));
+		Assert.assertEquals(doc.getContentField("in2"), doc2.getContentField("in2"));
+		Assert.assertEquals(doc.getContentField("in3"), doc2.getContentField("in3"));
+		
+		Assert.assertEquals("xyz in1 in2 in3", doc2.getContentField("out"));
+	}
+	
+	@Test
+	public void testSeparator() throws Exception {
+		MergeFieldsStage mfs = new MergeFieldsStage();
+		
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("outputField", "out");
+		map.put("separator", "___");
+		List<String> list =  new ArrayList<String>();
+		list.add("in1");
+		list.add("in2");
+		list.add("in3");
+		map.put("fromFields", list);
+		
+		mfs.setParameters(map);
+		
+		LocalDocument doc = getDocument();
+		
+		LocalDocument doc2 = new LocalDocument(doc.toJson());
+		mfs.process(doc2);
+		
+		Assert.assertEquals(doc.getContentField("in1"), doc2.getContentField("in1"));
+		Assert.assertEquals(doc.getContentField("in2"), doc2.getContentField("in2"));
+		Assert.assertEquals(doc.getContentField("in3"), doc2.getContentField("in3"));
+		
+		Assert.assertEquals("in1___in2___in3", doc2.getContentField("out"));
+	}
+	
+	@Test
+	public void testClearOutputField() throws Exception {
+		MergeFieldsStage mfs = new MergeFieldsStage();
+		
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("outputField", "out");
+		map.put("clearOutputField", true);
+
+		LocalDocument doc = getDocument();
+		doc.putContentField("out", "xyz");
+
+		List<String> list =  new ArrayList<String>();
+		map.put("fromFields", list);
+		
+		mfs.setParameters(map);
+		
+		LocalDocument doc2 = new LocalDocument(doc.toJson());
+		mfs.process(doc2);
+		
+		Assert.assertNull(doc2.getContentField("out"));
+		
+		list.add("in1");
+		list.add("in2");
+		list.add("in3");
+		
+		mfs.setParameters(map);
+		
+		doc2 = new LocalDocument(doc.toJson());
+		mfs.process(doc2);
+		
+		Assert.assertEquals("in1 in2 in3", doc2.getContentField("out"));
+	}
+	
+	@Test
+	public void testProcessRegexNames() throws Exception {
+		MergeFieldsStage mfs = new MergeFieldsStage();
+		
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("outputField", "out");
+		
+		List<String> list =  new ArrayList<String>();
+		list.add("in[0-9]*");
+		map.put("fromFields", list);
+		
+		mfs.setParameters(map);
+		
+		LocalDocument doc = getDocument();
+		doc.putContentField("out", "xyz");
+		
+		LocalDocument doc2 = new LocalDocument(doc.toJson());
+		mfs.process(doc2);
+		
+		Assert.assertEquals(doc.getContentField("in1"), doc2.getContentField("in1"));
+		Assert.assertEquals(doc.getContentField("in2"), doc2.getContentField("in2"));
+		Assert.assertEquals(doc.getContentField("in3"), doc2.getContentField("in3"));
+		
+		for(String field : doc.getContentFields()) {
+			Assert.assertTrue(doc2.getContentField("out").toString().contains(doc.getContentField(field).toString()));
+		}
+		
+		Assert.assertEquals(3*4+3, doc2.getContentField("out").toString().length());
+	}
+	
+	@Test
+	public void testProcessExtraFieldNames() throws Exception {
+		MergeFieldsStage mfs = new MergeFieldsStage();
+		
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("outputField", "newfield");
+		
+		List<String> list =  new ArrayList<String>();
+		list.add("in1");
+		list.add("in3");
+		map.put("fromFields", list);
+		
+		mfs.setParameters(map);
+		
+		LocalDocument doc = getDocument();
+		doc.putContentField("out", "xyz");
+		
+		LocalDocument doc2 = new LocalDocument(doc.toJson());
+		mfs.process(doc2);
+
+		Assert.assertEquals(doc.getContentField("out"), doc2.getContentField("out"));
+		Assert.assertEquals(doc.getContentField("in1"), doc2.getContentField("in1"));
+		Assert.assertEquals(doc.getContentField("in2"), doc2.getContentField("in2"));
+		Assert.assertEquals(doc.getContentField("in3"), doc2.getContentField("in3"));
+
+		Assert.assertTrue(doc2.getContentField("newfield").toString().contains(doc.getContentField("in1").toString()));
+		Assert.assertTrue(doc2.getContentField("newfield").toString().contains(doc.getContentField("in3").toString()));
+		Assert.assertFalse(doc2.getContentField("newfield").toString().contains(doc.getContentField("in2").toString()));		
+		Assert.assertFalse(doc2.getContentField("newfield").toString().contains(doc.getContentField("out").toString()));
+	}
+	
+	@Test
+	public void testProcessIntegerFields() throws Exception {
+		MergeFieldsStage mfs = new MergeFieldsStage();
+		
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("outputField", "out");
+		map.put("additionIfNumbers", true);
+		
+		List<String> list =  new ArrayList<String>();
+		list.add("in1");
+		list.add("in2");
+		list.add("in3");
+		map.put("fromFields", list);
+		
+		mfs.setParameters(map);
+		
+		LocalDocument doc = new LocalDocument();
+		doc.putContentField("in1", 1);
+		doc.putContentField("in2", 2);
+		doc.putContentField("in3", 5);
+		
+		LocalDocument doc2 = new LocalDocument(doc.toJson());
+		mfs.process(doc2);
+		
+		Assert.assertEquals(doc.getContentField("in1"), doc2.getContentField("in1"));
+		Assert.assertEquals(doc.getContentField("in2"), doc2.getContentField("in2"));
+		Assert.assertEquals(doc.getContentField("in3"), doc2.getContentField("in3"));
+		
+		Assert.assertEquals(1+2+5, doc2.getContentField("out"));
+	}
+	
+	@Test
+	public void testProcessDoubleFields() throws Exception {
+		MergeFieldsStage mfs = new MergeFieldsStage();
+		
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("outputField", "out");
+		map.put("additionIfNumbers", true);
+		
+		List<String> list =  new ArrayList<String>();
+		list.add("in1");
+		list.add("in2");
+		list.add("in3");
+		map.put("fromFields", list);
+		
+		mfs.setParameters(map);
+		
+		LocalDocument doc = new LocalDocument();
+		doc.putContentField("in1", 1);
+		doc.putContentField("in2", 2.2);
+		doc.putContentField("in3", 5.3);
+		
+		LocalDocument doc2 = new LocalDocument(doc.toJson());
+		mfs.process(doc2);
+		
+		
+		Assert.assertEquals(doc.getContentField("in1"), doc2.getContentField("in1"));
+		Assert.assertEquals(doc.getContentField("in2"), doc2.getContentField("in2"));
+		Assert.assertEquals(doc.getContentField("in3"), doc2.getContentField("in3"));
+		
+		Assert.assertEquals(8.5, doc2.getContentField("out"));
+	}
+	
+	@Test
+	public void testProcessMixedFields() throws Exception {
+		MergeFieldsStage mfs = new MergeFieldsStage();
+		
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("outputField", "out");
+		map.put("additionIfNumbers", true);
+		
+		List<String> list =  new ArrayList<String>();
+		list.add("in1");
+		list.add("in2");
+		list.add("in3");
+		map.put("fromFields", list);
+		
+		mfs.setParameters(map);
+		
+		LocalDocument doc = new LocalDocument();
+		doc.putContentField("in1", 1);
+		doc.putContentField("in2", 2.2);
+		doc.putContentField("in3", "string");
+		
+		LocalDocument doc2 = new LocalDocument(doc.toJson());
+		mfs.process(doc2);
+		
+		
+		Assert.assertEquals(doc.getContentField("in1"), doc2.getContentField("in1"));
+		Assert.assertEquals(doc.getContentField("in2"), doc2.getContentField("in2"));
+		Assert.assertEquals(doc.getContentField("in3"), doc2.getContentField("in3"));
+		
+		Assert.assertEquals(String.class, doc2.getContentField("out").getClass());
+	}
+
+	private LocalDocument getDocument() {
+		LocalDocument doc = new LocalDocument();
+		doc.putContentField("in1", "in1");
+		doc.putContentField("in2", "in2");
+		doc.putContentField("in3", "in3");
+		return doc;
+	}
+	
+	@Test
+	public void testToList() throws Exception {
+		LocalDocument doc2 = testList(getDocument());
+
+		Assert.assertEquals(3, ((List<?>)doc2.getContentField("out")).size());
+	}
+	
+	@Test
+	public void testAddList() throws Exception {
+		LocalDocument doc = getDocument();
+		doc.putContentField("out", Arrays.asList("out", "out2"));
+		
+		LocalDocument doc2 = testList(doc);
+		Assert.assertEquals(5, ((List<?>)doc2.getContentField("out")).size());
+	}
+	
+	@Test
+	public void testCreateList() throws Exception {
+		LocalDocument doc = getDocument();
+		doc.putContentField("out", "out");
+		
+		LocalDocument doc2 = testList(doc);
+		
+		Assert.assertTrue(((List<?>)doc2.getContentField("out")).contains("out"));
+		Assert.assertEquals(4, ((List<?>)doc2.getContentField("out")).size());
+	}
+	
+	public LocalDocument testList(LocalDocument doc) throws Exception {
+		MergeFieldsStage mfs = new MergeFieldsStage();
+		
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("outputField", "out");
+		map.put("createList", true);
+		
+		List<String> list =  new ArrayList<String>();
+		list.add("in1");
+		list.add("in2");
+		list.add("in3");
+		map.put("fromFields", list);
+		
+		mfs.setParameters(map);
+		
+		LocalDocument doc2 = new LocalDocument(doc.toJson());
+		mfs.process(doc2);
+		
+		
+		Assert.assertEquals(doc.getContentField("in1"), doc2.getContentField("in1"));
+		Assert.assertEquals(doc.getContentField("in2"), doc2.getContentField("in2"));
+		Assert.assertEquals(doc.getContentField("in3"), doc2.getContentField("in3"));
+		
+		Assert.assertTrue(doc2.getContentField("out") instanceof List);
+		List<?> outList = (List<?>)doc2.getContentField("out");
+		Assert.assertTrue(outList.contains(doc.getContentField("in1")));
+		Assert.assertTrue(outList.contains(doc.getContentField("in2")));
+		Assert.assertTrue(outList.contains(doc.getContentField("in3")));
+		
+		
+		return doc2;
+	}
+}

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/MergeFieldsStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/MergeFieldsStageTest.java
@@ -81,7 +81,41 @@ public class MergeFieldsStageTest {
 		Assert.assertEquals(doc.getContentField("in2"), doc2.getContentField("in2"));
 		Assert.assertEquals(doc.getContentField("in3"), doc2.getContentField("in3"));
 		
-		Assert.assertEquals("xyz in1 in2 in3", doc2.getContentField("out"));
+		
+		String[] outString = doc2.getContentField("out").toString().split(" ");
+		
+		Assert.assertEquals(4, outString.length);
+		for(String s : outString) {
+			Assert.assertTrue(hasValue(doc, s));
+		}
+	}
+	
+	@Test
+	public void testProcessMultipleMatches() throws Exception {
+		MergeFieldsStage mfs = new MergeFieldsStage();
+		
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("outputField", "out");
+		
+		List<String> list =  new ArrayList<String>();
+		list.add("in1");
+		list.add("in1");
+		list.add("in2");
+		map.put("fromFields", list);
+		
+		mfs.setParameters(map);
+		
+		LocalDocument doc = getDocument();
+		
+		LocalDocument doc2 = new LocalDocument(doc.toJson());
+		mfs.process(doc2);
+		
+		String[] outString = doc2.getContentField("out").toString().split(" ");
+		
+		Assert.assertEquals(2, outString.length);
+		for(String s : outString) {
+			Assert.assertTrue(hasValue(doc, s));
+		}
 	}
 	
 	@Test
@@ -104,11 +138,15 @@ public class MergeFieldsStageTest {
 		LocalDocument doc2 = new LocalDocument(doc.toJson());
 		mfs.process(doc2);
 		
-		Assert.assertEquals(doc.getContentField("in1"), doc2.getContentField("in1"));
-		Assert.assertEquals(doc.getContentField("in2"), doc2.getContentField("in2"));
-		Assert.assertEquals(doc.getContentField("in3"), doc2.getContentField("in3"));
+		String[] outString = doc2.getContentField("out").toString().split("___");
 		
-		Assert.assertEquals("in1___in2___in3", doc2.getContentField("out"));
+		Assert.assertEquals(3, outString.length);
+		for(String s : outString) {
+			Assert.assertTrue(hasValue(doc, s));
+		}
+		
+		Assert.assertEquals("___", doc2.getContentField("out").toString().substring(3,6));
+		Assert.assertEquals("___", doc2.getContentField("out").toString().substring(9,12));
 	}
 	
 	@Test
@@ -141,7 +179,12 @@ public class MergeFieldsStageTest {
 		doc2 = new LocalDocument(doc.toJson());
 		mfs.process(doc2);
 		
-		Assert.assertEquals("in1 in2 in3", doc2.getContentField("out"));
+		String[] outString = doc2.getContentField("out").toString().split(" ");
+		
+		Assert.assertEquals(3, outString.length);
+		for(String s : outString) {
+			Assert.assertTrue(hasValue(doc, s));
+		}
 	}
 	
 	@Test
@@ -163,15 +206,13 @@ public class MergeFieldsStageTest {
 		LocalDocument doc2 = new LocalDocument(doc.toJson());
 		mfs.process(doc2);
 		
-		Assert.assertEquals(doc.getContentField("in1"), doc2.getContentField("in1"));
-		Assert.assertEquals(doc.getContentField("in2"), doc2.getContentField("in2"));
-		Assert.assertEquals(doc.getContentField("in3"), doc2.getContentField("in3"));
+		String[] outString = doc2.getContentField("out").toString().split(" ");
 		
-		for(String field : doc.getContentFields()) {
-			Assert.assertTrue(doc2.getContentField("out").toString().contains(doc.getContentField(field).toString()));
+		Assert.assertEquals(4, outString.length);
+		
+		for(String s : outString) {
+			Assert.assertTrue(hasValue(doc, s));
 		}
-		
-		Assert.assertEquals(3*4+3, doc2.getContentField("out").toString().length());
 	}
 	
 	@Test
@@ -194,15 +235,12 @@ public class MergeFieldsStageTest {
 		LocalDocument doc2 = new LocalDocument(doc.toJson());
 		mfs.process(doc2);
 
-		Assert.assertEquals(doc.getContentField("out"), doc2.getContentField("out"));
-		Assert.assertEquals(doc.getContentField("in1"), doc2.getContentField("in1"));
-		Assert.assertEquals(doc.getContentField("in2"), doc2.getContentField("in2"));
-		Assert.assertEquals(doc.getContentField("in3"), doc2.getContentField("in3"));
-
-		Assert.assertTrue(doc2.getContentField("newfield").toString().contains(doc.getContentField("in1").toString()));
-		Assert.assertTrue(doc2.getContentField("newfield").toString().contains(doc.getContentField("in3").toString()));
-		Assert.assertFalse(doc2.getContentField("newfield").toString().contains(doc.getContentField("in2").toString()));		
-		Assert.assertFalse(doc2.getContentField("newfield").toString().contains(doc.getContentField("out").toString()));
+		String[] newString = doc2.getContentField("newfield").toString().split(" ");
+		
+		Assert.assertEquals(2, newString.length);
+		for(String s : newString) {
+			Assert.assertTrue(hasValue(doc, s));
+		}
 	}
 	
 	@Test
@@ -228,10 +266,6 @@ public class MergeFieldsStageTest {
 		
 		LocalDocument doc2 = new LocalDocument(doc.toJson());
 		mfs.process(doc2);
-		
-		Assert.assertEquals(doc.getContentField("in1"), doc2.getContentField("in1"));
-		Assert.assertEquals(doc.getContentField("in2"), doc2.getContentField("in2"));
-		Assert.assertEquals(doc.getContentField("in3"), doc2.getContentField("in3"));
 		
 		Assert.assertEquals(1+2+5, doc2.getContentField("out"));
 	}
@@ -260,11 +294,6 @@ public class MergeFieldsStageTest {
 		LocalDocument doc2 = new LocalDocument(doc.toJson());
 		mfs.process(doc2);
 		
-		
-		Assert.assertEquals(doc.getContentField("in1"), doc2.getContentField("in1"));
-		Assert.assertEquals(doc.getContentField("in2"), doc2.getContentField("in2"));
-		Assert.assertEquals(doc.getContentField("in3"), doc2.getContentField("in3"));
-		
 		Assert.assertEquals(8.5, doc2.getContentField("out"));
 	}
 	
@@ -291,11 +320,6 @@ public class MergeFieldsStageTest {
 		
 		LocalDocument doc2 = new LocalDocument(doc.toJson());
 		mfs.process(doc2);
-		
-		
-		Assert.assertEquals(doc.getContentField("in1"), doc2.getContentField("in1"));
-		Assert.assertEquals(doc.getContentField("in2"), doc2.getContentField("in2"));
-		Assert.assertEquals(doc.getContentField("in3"), doc2.getContentField("in3"));
 		
 		Assert.assertEquals(String.class, doc2.getContentField("out").getClass());
 	}
@@ -367,4 +391,14 @@ public class MergeFieldsStageTest {
 		
 		return doc2;
 	}
+	
+	private boolean hasValue(LocalDocument doc, String s) {
+		for(String f : doc.getContentFields()) {
+			if(doc.getContentField(f).equals(s)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
 }


### PR DESCRIPTION
Allows merging of the content of several different fields into one: either by explicit numeration or by field names matching regular expression.

Can merge by: concatenation (default), adding to a list or by arithmetic addition.
