### PR TITLE
changed oldMaxSize and oldMaxCount for the inserter

### DIFF
--- a/examples/src/main/java/com/findwise/hydra/ExampleModule.java
+++ b/examples/src/main/java/com/findwise/hydra/ExampleModule.java
@@ -54,6 +54,8 @@ public class ExampleModule extends AbstractModule {
 		bindConstant().annotatedWith(Names.named(DatabaseConnector.DATABASE_URL_PARAM)).to(c.getDatabaseUrl());
 		bindConstant().annotatedWith(Names.named(DatabaseConnector.DATABASE_USER)).to(c.getDatabaseUser());
 		bindConstant().annotatedWith(Names.named(DatabaseConnector.DATABASE_PASSWORD)).to(c.getDatabasePassword());
+		bindConstant().annotatedWith(Names.named(DatabaseConnector.OLD_MAX_COUNT)).to(c.getOldMaxCount());
+		bindConstant().annotatedWith(Names.named(DatabaseConnector.OLD_MAX_SIZE_MB)).to(c.getOldMaxSize());
 
 		bind(DatabaseConnector.class).to(MongoConnector.class);
 	}
@@ -84,12 +86,12 @@ public class ExampleModule extends AbstractModule {
 
 			@Override
 			public int getOldMaxSize() {
-				return 100;
+				return 200;
 			}
 
 			@Override
 			public int getOldMaxCount() {
-				return 1000;
+				return 2000;
 			}
 		};
 	}

--- a/stages/processing/tika/pom.xml
+++ b/stages/processing/tika/pom.xml
@@ -5,6 +5,7 @@
 	<artifactId>hydra-tika-stages</artifactId>
 	<version>0.3.0-SNAPSHOT</version>
 	<description>Solr Output Stage</description>
+        <name>${project.artifactId}</name>
 	<url>http://findwise.github.com/Hydra</url>
 
 	<licenses>
@@ -31,7 +32,7 @@
 		<dependency>
 			<groupId>com.findwise.hydra</groupId>
 			<artifactId>hydra-api</artifactId>
-			<version>0.2.0</version>
+			<version>0.3.0-SNAPSHOT</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Changed the default oldMaxSize to 200 and oldMaxCount to 2000. So now the capped oldDocuments folder will be the same size when created by core as when created by the inserter.
