### PR TITLE
Added support for fetching basic document information for the admin service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ target/
 .classpath
 .project
 examples/src/main/resources/*.jar
-
+.springBeans
 bin/
 nbactions.xml

--- a/admin-service/README.md
+++ b/admin-service/README.md
@@ -7,7 +7,8 @@ Available endpoints
 * **/** - Method: GET
 
 	Lists some general statistics about the Hydra node.
-* **/library** - Method: GET 
+	
+* **/libraries** - Method: GET 
 
 	Lists libraries currently available in the database. For each library, a list of available stages and their parameters are presented. Here's an example of how the returned JSON might look:
 	
@@ -61,11 +62,11 @@ Available endpoints
 	}
 	```
 	
-* **/library/{library-id}** - Method: GET
+* **/libraries/{library-id}** - Method: GET
 
 	Same as **/library** but only for the specified library id. 
 	
-* **/library/{library-id}** - Method: POST
+* **/libraries/{library-id}** - Method: POST
 	
 	Request format: *multipart/form-data*
 	
@@ -80,4 +81,194 @@ Available endpoints
         <input type="file" name="file"/>
         <input type="submit"/>
     </form>
+	```
+	
+* **/libraries/{library-id}/stages/{stage-name}** - Method: POST
+	
+	Request format: *application/json*
+	
+	Request content: Stage configuration in json format
+
+	Adds a stage or replaces a stage in the pipeline with the attached configuration as raw body.
+	
+* **/stages** - Method: GET
+	
+	Lists all active stages in the pipeline. Sample response:
+	```
+	{
+	    "stages": [
+	        {
+	            "name": "languageDetection",
+	            "databaseFile": {
+	                "filename": "language-detection-stage-jar-with-dependencies.jar",
+	                "uploadDate": 1350482288206,
+	                "id": "language-detection",
+	                "inputStream": null
+	            },
+	            "mode": "ACTIVE",
+	            "properties": {
+	                "languages": [
+	                    "en",
+	                    "sv",
+	                    "da",
+	                    "no",
+	                    "de",
+	                    "lv",
+	                    "lt",
+	                    "uk"
+	                ],
+	                "query": {
+	                    "touched": {
+	                        "cleanContent": true
+	                    }
+	                },
+	                "map": {
+	                    "DRECONTENT": "language_code"
+	                },
+	                "defaultLanguage": "GeneralUTF8",
+	                "threshold": 500,
+	                "stageClass": "com.findwise.hydra.stage.languageDetection.LanguageDetectionStage"
+	            },
+	            "propertiesModifiedDate": 1351525890276,
+	            "propertiesChanged": true
+	        },
+	        {
+	            "name": "cleanParentInfo",
+	            "databaseFile": {
+	                "filename": "hydra-basic-stages-jar-with-dependencies.jar",
+	                "uploadDate": 1350482283857,
+	                "id": "basic",
+	                "inputStream": null
+	            },
+	            "mode": "ACTIVE",
+	            "properties": {
+	                "regexConfigs": [
+	                    {
+	                        "outField": "PARENT_TITLE",
+	                        "regex": ">(.*)<",
+	                        "inField": "PARENT_TITLE",
+	                        "substitute": "$1"
+	                    },
+	                    {
+	                        "outField": "PARENT_LINK",
+	                        "regex": "href=\"(.*?)\"",
+	                        "inField": "PARENT_LINK",
+	                        "substitute": "$1"
+	                    }
+	                ],
+	                "query": {
+	                    "touched": {
+	                        "extractParentInfo": true
+	                    }
+	                },
+	                "stageClass": "com.findwise.hydra.stage.RegexStage"
+	            },
+	            "propertiesModifiedDate": 1351525890276,
+	            "propertiesChanged": true
+	        }
+	    ]
+	}
+	```
+	
+  
+* **/stages/{stage-name}** - Method: GET
+
+	Same as **/stages** but only for the specified stage name. 
+	
+
+* **/documents** - Method: GET
+	
+	Lists the (first 10) documents matching a query (or any documents if the query is ommitted). 
+	The number of documents to be returned and what document to start counting from, can be configured with request parameters
+	
+	Available parameters: 
+	
+		- q: A json query to be matched by the counted documents (*default: {}*)
+		
+		- limit: The number of documents to return (*default: 10*)
+		
+		- skip: The number of documents to skip (used for example if you which to do pagination on returned documents) (*default: 0*)
+	
+	Sample request: http://localhost:8080/hydra/documents?q={fetched:{rename:true}}&limit=10&skip=0
+	
+	Sample response: 
+	```
+	{
+	    "documents": [
+	        {
+	            "actionTouched": false,
+	            "touchedContent": [],
+	            "touchedMetadata": [],
+	            "partialObject": false,
+	            "id": {
+	                "time": 1350460786000,
+	                "new": false,
+	                "machine": -880203394,
+	                "timeSecond": 1350460786,
+	                "inc": 1616527124
+	            },
+	            "status": "PROCESSING",
+	            "action": "DELETE",
+	            "metadataMap": {
+	                "fetched": {
+	                    "addContent": 1350460788405,
+	                    "renameDeleteReference": 1350460787082
+	                },
+	                "touched": {
+	                    "addContent": 1350460788422,
+	                    "renameDeleteReference": 1350460787097
+	                }
+	            },
+	            "contentFields": [
+	                "content",
+	                "url"
+	            ],
+	            "contentsMap": {
+	                "content": "content",
+	                "url":"http://asdf.com",
+	            },
+	            "idkey": "_id"
+	        }
+	    ]
+	}
+	```
+	
+* **/documents/count** - Method: GET
+	
+	Returns the number of document matching a query (or the total number of documents if the query is ommitted)
+
+	Available parameters: 
+	
+		- q: A json query to be matched by the counted documents (*default: {}*)
+	
+	Sample request: http://localhost:8080/hydra/documents/count?q={fetched:{rename:true}}
+	
+	Sample response: 
+	
+	```
+	{
+		numberOfDocuments: 13
+	}
+	```
+	
+	
+* **/documents/edit** - Method: POST
+	
+	Changes the metadata of a document matching a query. Currently only supports deleting the a stages from the fetched and/or touched array  
+	
+	Available parameters: 
+	
+		- q: A json query to be matched by the counted documents (*default: {}*)
+		
+		- limit: The maximum number of documents to update (*default: 1*)
+	
+	Request content: A json configuration describing the change. Format: {"deletes":{fetched:["staticField"]},touched:["staticField"]}
+	
+	Sample resopnse:
+	
+	```
+	{
+	    "numberOfChangedDocuments": 5,
+	    "changedDocuments": [...] (a list of documents as described above)
+	}
 	```

--- a/admin-service/pom.xml
+++ b/admin-service/pom.xml
@@ -17,7 +17,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-            	<version>2.3.2</version>
+				<version>2.3.2</version>
 				<configuration>
 					<source>1.6</source>
 					<target>1.6</target>
@@ -102,6 +102,12 @@
 			<version>1.2.2</version>
 			<type>jar</type>
 			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.10</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/admin-service/src/main/java/com/findwise/hydra/admin/database/AdminServiceQuery.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/database/AdminServiceQuery.java
@@ -1,0 +1,96 @@
+package com.findwise.hydra.admin.database;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.findwise.hydra.DatabaseQuery;
+import com.findwise.hydra.common.Document.Action;
+import com.findwise.hydra.common.JsonException;
+import com.findwise.hydra.common.SerializationUtils;
+import com.findwise.hydra.local.LocalQuery;
+import com.google.gson.JsonParseException;
+
+
+public class AdminServiceQuery extends LocalQuery implements DatabaseQuery<AdminServiceType> {
+
+	Map<String, Boolean> requireMetadataFieldExists;
+	
+	Map<String, Object> requireMetadataFieldEquals, requireMetadataFieldNotEquals;
+	
+	List<Action> requireAction;
+
+	private Map<String, Boolean> fetched = new HashMap<String, Boolean>();
+	 
+	public AdminServiceQuery() {
+		requireMetadataFieldExists = new HashMap<String, Boolean>();
+		
+		requireMetadataFieldEquals = new HashMap<String, Object>();
+		requireMetadataFieldNotEquals = new HashMap<String, Object>();
+		
+		requireAction = new ArrayList<Action>();
+	}
+	
+	public AdminServiceQuery(String jsonQuery) {
+		try {
+			fromJson(jsonQuery);
+		} catch (JsonException e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	public String toJson() {
+		Map<String, Object> x = new HashMap<String, Object>();
+		x.put("equals", getEquals());
+		x.put("notEquals", getNotEquals());
+		x.put("exists", getExists());
+		x.put("touched", getTouched());
+		x.put("fetched", fetched);
+		
+		if(getAction()!=null) {
+			x.put("action", getAction().toString());
+		}
+		
+		return SerializationUtils.toJson(x); 
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Override
+	public void fromJson(String json) throws JsonException{
+		try {
+
+			Map<String, Object> queryObject = (Map<String, Object>) SerializationUtils.fromJson(json);
+			if(queryObject.containsKey("fetched")) {
+				fetched = (Map<String, Boolean>) queryObject.get("fetched");
+			}
+			super.fromJson(json);
+			
+		} 
+		catch(JsonParseException jse) {
+			throw new JsonException(jse);
+		}
+	}
+	
+	@Override
+	public void requireMetadataFieldEquals(String fieldName, Object o) {
+		requireMetadataFieldEquals.put(fieldName, o);
+	}
+
+	@Override
+	public void requireMetadataFieldNotEquals(String fieldName, Object o) {
+		requireMetadataFieldNotEquals.put(fieldName, o);
+	}
+
+	@Override
+	public void requireMetadataFieldExists(String fieldName) {
+		requireMetadataFieldExists.put(fieldName, true);
+	}
+
+	@Override
+	public void requireMetadataFieldNotExists(String fieldName) {
+		requireMetadataFieldExists.put(fieldName, false);
+	}
+	
+}

--- a/admin-service/src/main/java/com/findwise/hydra/admin/database/AdminServiceType.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/database/AdminServiceType.java
@@ -1,0 +1,12 @@
+package com.findwise.hydra.admin.database;
+
+import com.findwise.hydra.DatabaseType;
+
+/**
+ * Empty interface to be implemented by all classes using AdminService
+ * @author simon.stenstrom
+ *
+ */
+public interface AdminServiceType extends DatabaseType {
+
+}

--- a/admin-service/src/main/java/com/findwise/hydra/admin/documents/DocumentsService.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/documents/DocumentsService.java
@@ -2,8 +2,10 @@ package com.findwise.hydra.admin.documents;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.findwise.hydra.DatabaseConnector;
 import com.findwise.hydra.DatabaseDocument;
@@ -12,6 +14,7 @@ import com.findwise.hydra.DatabaseType;
 import com.findwise.hydra.admin.database.AdminServiceQuery;
 import com.findwise.hydra.admin.database.AdminServiceType;
 import com.findwise.hydra.common.JsonException;
+import com.findwise.hydra.common.SerializationUtils;
 
 public class DocumentsService<T extends DatabaseType> {
 
@@ -28,6 +31,7 @@ public class DocumentsService<T extends DatabaseType> {
 			DatabaseQuery<AdminServiceType> query = new AdminServiceQuery();
 			query.fromJson(jsonQuery);
 			ret.put("numberOfDocuments", getNumberOfDocuments(connector.convert(query)));
+
 		} catch (JsonException e) {
 			Map<String, String> error = new HashMap<String, String>();
 			error.put("Invalid query", jsonQuery);
@@ -45,6 +49,7 @@ public class DocumentsService<T extends DatabaseType> {
 			DatabaseQuery<AdminServiceType> query = new AdminServiceQuery();
 			query.fromJson(jsonQuery);
 			ret.put("documents", getDocuments(connector.convert(query), limit, skip));
+
 		} catch (JsonException e) {
 			Map<String, String> error = new HashMap<String, String>();
 			error.put("Invalid query", jsonQuery);
@@ -54,8 +59,7 @@ public class DocumentsService<T extends DatabaseType> {
 
 		return ret;
 	}
-	
-	
+
 	private long getNumberOfDocuments(DatabaseQuery<T> query) {
 		return getConnector().getDocumentReader().getNumberOfDocuments((DatabaseQuery<T>) query);
 	}
@@ -66,6 +70,87 @@ public class DocumentsService<T extends DatabaseType> {
 
 	public DatabaseConnector<T> getConnector() {
 		return connector;
+	}
+
+	public Map<String, Object> updateDocuments(String jsonQuery, int limit,
+			String changes) {
+
+		Map<String, Object> ret = new HashMap<String, Object>();
+		try {
+			DatabaseQuery<AdminServiceType> query = new AdminServiceQuery();
+			query.fromJson(jsonQuery);
+			List<DatabaseDocument<T>> documents = getDocuments(
+					connector.convert(query), limit, 0);
+
+			if (!documents.isEmpty()) {
+
+				try {
+					Map<String, Object> changesMap = SerializationUtils
+							.fromJson(changes);
+					Set<DatabaseDocument<T>> changedDocuments = new HashSet<DatabaseDocument<T>>();
+
+					@SuppressWarnings("unchecked")
+					Map<String, List<String>> deleteObject = (Map<String, List<String>>) changesMap
+							.get("deletes");
+
+					if (deleteObject != null) {
+						for (DatabaseDocument<T> document : documents) {
+							List<String> fetched = deleteObject.get("fetched");
+							if (fetched != null) {
+								for (String field : fetched) {
+									boolean change = document
+											.removeFetchedBy(field);
+									if (change) {
+										connector.getDocumentWriter().update(
+												document);
+										changedDocuments.add(document);
+									}
+								}
+							}
+							List<String> touched = deleteObject.get("touched");
+							if (touched != null) {
+								for (String field : touched) {
+									boolean change = document
+											.removeTouchedBy(field);
+									if (change) {
+										connector.getDocumentWriter().update(
+												document);
+										changedDocuments.add(document);
+									}
+								}
+							}
+						}
+					}
+
+					ret.put("numberOfChangedDocuments", changedDocuments.size());
+					ret.put("changedDocuments", changedDocuments);
+				} catch (ClassCastException e) {
+					Map<String, String> error = new HashMap<String, String>();
+					error.put("Invalid change map", changes);
+					error.put("Expected format:",
+							"{\"deletes\":{fetched:[\"staticField\"]},touched:[\"staticField\"]}");
+					ret.put("error", error);
+					ret.put("numberOfChangedDocuments", 0);
+				} catch (JsonException e) {
+					Map<String, String> error = new HashMap<String, String>();
+					error.put("Invalid change map", changes);
+					error.put("Expected format:",
+							"{\"deletes\":{fetched:[\"staticField\"]},touched:[\"staticField\"]}");
+					ret.put("error", error);
+					ret.put("numberOfChangedDocuments", 0);
+				}
+
+			}
+
+		} catch (JsonException e) {
+
+			Map<String, String> error = new HashMap<String, String>();
+			error.put("Invalid query", jsonQuery);
+			ret.put("error", error);
+			ret.put("numberOfChangedDocuments", 0);
+		}
+
+		return ret;
 	}
 
 }

--- a/admin-service/src/main/java/com/findwise/hydra/admin/documents/DocumentsService.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/documents/DocumentsService.java
@@ -1,0 +1,71 @@
+package com.findwise.hydra.admin.documents;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.findwise.hydra.DatabaseConnector;
+import com.findwise.hydra.DatabaseDocument;
+import com.findwise.hydra.DatabaseQuery;
+import com.findwise.hydra.DatabaseType;
+import com.findwise.hydra.admin.database.AdminServiceQuery;
+import com.findwise.hydra.admin.database.AdminServiceType;
+import com.findwise.hydra.common.JsonException;
+
+public class DocumentsService<T extends DatabaseType> {
+
+	private DatabaseConnector<T> connector;
+
+	public DocumentsService(DatabaseConnector<T> connector) {
+		this.connector = connector;
+	}
+
+	public Map<String, Object> getNumberOfDocuments(String jsonQuery) {
+		Map<String, Object> ret = new HashMap<String, Object>();
+
+		try {
+			DatabaseQuery<AdminServiceType> query = new AdminServiceQuery();
+			query.fromJson(jsonQuery);
+			ret.put("numberOfDocuments", getNumberOfDocuments(connector.convert(query)));
+		} catch (JsonException e) {
+			Map<String, String> error = new HashMap<String, String>();
+			error.put("Invalid query", jsonQuery);
+			ret.put("error", error);
+			ret.put("numberOfDocuments", 0);
+		}
+
+		return ret;
+	}
+
+	public Map<String, Object> getDocuments(String jsonQuery, int limit, int skip) {
+		Map<String, Object> ret = new HashMap<String, Object>();
+
+		try {
+			DatabaseQuery<AdminServiceType> query = new AdminServiceQuery();
+			query.fromJson(jsonQuery);
+			ret.put("documents", getDocuments(connector.convert(query), limit, skip));
+		} catch (JsonException e) {
+			Map<String, String> error = new HashMap<String, String>();
+			error.put("Invalid query", jsonQuery);
+			ret.put("error", error);
+			ret.put("documents", new ArrayList<DatabaseDocument<T>>());
+		}
+
+		return ret;
+	}
+	
+	
+	private long getNumberOfDocuments(DatabaseQuery<T> query) {
+		return getConnector().getDocumentReader().getNumberOfDocuments((DatabaseQuery<T>) query);
+	}
+
+	private List<DatabaseDocument<T>> getDocuments(DatabaseQuery<T> query, int limit, int skip) {
+		return getConnector().getDocumentReader().getDocuments(query, limit, skip);
+	}
+
+	public DatabaseConnector<T> getConnector() {
+		return connector;
+	}
+
+}

--- a/admin-service/src/main/java/com/findwise/hydra/admin/rest/AppConfig.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/rest/AppConfig.java
@@ -10,61 +10,68 @@ import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 
 import com.findwise.hydra.DatabaseConfiguration;
 import com.findwise.hydra.admin.ConfigurationService;
+import com.findwise.hydra.admin.documents.DocumentsService;
 import com.findwise.hydra.mongodb.MongoConnector;
 import com.findwise.hydra.mongodb.MongoType;
 
 @Configuration
 @ComponentScan(basePackages = "com.findwise.hydra.admin.rest")
 public class AppConfig {
-	
-	@Bean(name="multipartResolver")
+
+	private static MongoConnector connector = new MongoConnector(
+			new DatabaseConfiguration() {
+
+				public int getOldMaxSize() {
+					return 100;
+				}
+
+				public int getOldMaxCount() {
+					return 10000;
+				}
+
+				public String getNamespace() {
+					return "pipeline";
+				}
+
+				public String getDatabaseUser() {
+					return "admin";
+				}
+
+				public String getDatabaseUrl() {
+					return "localhost";
+				}
+
+				public String getDatabasePassword() {
+					return "changeme";
+				}
+			});
+
+	@Bean(name = "multipartResolver")
 	public static CommonsMultipartResolver multipartResolver() {
 		CommonsMultipartResolver cmr = new CommonsMultipartResolver();
-		
-		cmr.setMaxUploadSize(1024*1024*1024); //1 Gigabyte...
-		
+
+		cmr.setMaxUploadSize(1024 * 1024 * 1024); // 1 Gigabyte...
+
 		return cmr;
 	}
-	
-	
+
 	@Bean
 	public static PropertyPlaceholderConfigurer properties() {
 		PropertyPlaceholderConfigurer ppc = new PropertyPlaceholderConfigurer();
-		final Resource[] resources = new ClassPathResource[] { };
+		final Resource[] resources = new ClassPathResource[] {};
 		ppc.setLocations(resources);
 		ppc.setIgnoreUnresolvablePlaceholders(true);
 		return ppc;
 	}
 
 	@Bean
-	public static ConfigurationService<MongoType> service() {
-		return new ConfigurationService<MongoType>(new MongoConnector(
-				new DatabaseConfiguration() {
+	public static ConfigurationService<MongoType> configurationService() {
+		return new ConfigurationService<MongoType>(connector);
+	}
 
-					public int getOldMaxSize() {
-						return 100;
-					}
-
-					public int getOldMaxCount() {
-						return 10000;
-					}
-
-					public String getNamespace() {
-						return "pipeline";
-					}
-
-					public String getDatabaseUser() {
-						return "admin";
-					}
-
-					public String getDatabaseUrl() {
-						return "localhost";
-					}
-
-					public String getDatabasePassword() {
-						return "changeme";
-					}
-				}));
+	@Bean
+	public static DocumentsService<MongoType> documentsService() {
+		return new DocumentsService<MongoType>(connector);
 	}
 
 }

--- a/admin-service/src/main/java/com/findwise/hydra/admin/rest/AppConfig.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/rest/AppConfig.java
@@ -11,6 +11,7 @@ import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 import com.findwise.hydra.DatabaseConfiguration;
 import com.findwise.hydra.admin.ConfigurationService;
 import com.findwise.hydra.admin.documents.DocumentsService;
+import com.findwise.hydra.admin.stages.StagesService;
 import com.findwise.hydra.mongodb.MongoConnector;
 import com.findwise.hydra.mongodb.MongoType;
 
@@ -30,7 +31,7 @@ public class AppConfig {
 				}
 
 				public String getNamespace() {
-					return "pipeline";
+					return "blogs";
 				}
 
 				public String getDatabaseUser() {
@@ -72,6 +73,12 @@ public class AppConfig {
 	@Bean
 	public static DocumentsService<MongoType> documentsService() {
 		return new DocumentsService<MongoType>(connector);
+
+	}
+	
+	@Bean
+	public static StagesService<MongoType> stagesService() {
+		return new StagesService<MongoType>(connector);
 	}
 
 }

--- a/admin-service/src/main/java/com/findwise/hydra/admin/rest/AppConfig.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/rest/AppConfig.java
@@ -10,60 +10,68 @@ import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 
 import com.findwise.hydra.DatabaseConfiguration;
 import com.findwise.hydra.admin.ConfigurationService;
+import com.findwise.hydra.admin.documents.DocumentsService;
 import com.findwise.hydra.mongodb.MongoConnector;
 import com.findwise.hydra.mongodb.MongoType;
 
 @Configuration
 @ComponentScan(basePackages = "com.findwise.hydra.admin.rest")
 public class AppConfig {
-	
-	@Bean(name="multipartResolver")
+
+	private static MongoConnector connector = new MongoConnector(
+			new DatabaseConfiguration() {
+
+				public int getOldMaxSize() {
+					return 100;
+				}
+
+				public int getOldMaxCount() {
+					return 10000;
+				}
+
+				public String getNamespace() {
+					return "pipeline";
+				}
+
+				public String getDatabaseUser() {
+					return "admin";
+				}
+
+				public String getDatabaseUrl() {
+					return "localhost";
+				}
+
+				public String getDatabasePassword() {
+					return "changeme";
+				}
+			});
+
+	@Bean(name = "multipartResolver")
 	public static CommonsMultipartResolver multipartResolver() {
 		CommonsMultipartResolver cmr = new CommonsMultipartResolver();
-		
-		cmr.setMaxUploadSize(1024*1024*1024); //1 Gigabyte...
-		
+
+		cmr.setMaxUploadSize(1024 * 1024 * 1024); // 1 Gigabyte...
+
 		return cmr;
 	}
-	
-	
+
 	@Bean
 	public static PropertyPlaceholderConfigurer properties() {
 		PropertyPlaceholderConfigurer ppc = new PropertyPlaceholderConfigurer();
-		final Resource[] resources = new ClassPathResource[] { };
+		final Resource[] resources = new ClassPathResource[] {};
 		ppc.setLocations(resources);
 		ppc.setIgnoreUnresolvablePlaceholders(true);
 		return ppc;
 	}
 
 	@Bean
-	public static ConfigurationService<MongoType> service() {
-		return new ConfigurationService<MongoType>(new MongoConnector(
-				new DatabaseConfiguration() {
-					public int getOldMaxSize() {
-						return 100;
-					}
+	public static ConfigurationService<MongoType> configurationService() {
+		return new ConfigurationService<MongoType>(connector);
+	}
 
-					public int getOldMaxCount() {
-						return 10000;
-					}
-
-					public String getNamespace() {
-						return "pipeline";
-					}
-
-					public String getDatabaseUser() {
-						return "admin";
-					}
-
-					public String getDatabaseUrl() {
-						return "localhost";
-					}
-
-					public String getDatabasePassword() {
-						return "changeme";
-					}
-				}));
+	@Bean
+	public static DocumentsService<MongoType> documentsService() {
+		return new DocumentsService<MongoType>(connector);
 	}
 
 }

--- a/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
@@ -77,7 +77,7 @@ public class ConfigurationController {
 	@ResponseBody
 	@RequestMapping(method = RequestMethod.GET, value = "/documents/list")
 	public Map<String, Object> getDocuments(
-			@RequestParam(required = true, value = "q") String jsonQuery,
+			@RequestParam(required = false, defaultValue = "{}", value = "q") String jsonQuery,
 			@RequestParam(required = false, defaultValue = "10", value = "limit") int limit,
 			@RequestParam(required = false, defaultValue = "0", value = "skip") int skip) {
 		return documentService.getDocuments(jsonQuery, limit, skip);

--- a/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
@@ -1,12 +1,14 @@
 package com.findwise.hydra.admin.rest;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,8 +16,13 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.findwise.hydra.Stage;
 import com.findwise.hydra.admin.ConfigurationService;
 import com.findwise.hydra.admin.documents.DocumentsService;
+
+import com.findwise.hydra.admin.stages.StagesService;
+import com.findwise.hydra.common.JsonException;
+
 
 @Controller("/rest")
 public class ConfigurationController {
@@ -25,6 +32,9 @@ public class ConfigurationController {
 	@Autowired
 	private DocumentsService<?> documentService;
 
+	@Autowired
+	private StagesService<?> stagesService;
+	
 	public DocumentsService<?> getDocumentService() {
 		return documentService;
 	}
@@ -40,32 +50,55 @@ public class ConfigurationController {
 		this.service = service;
 	}
 
-	@ResponseBody
-	@RequestMapping(method=RequestMethod.GET, value="/library")
-	public Map<String, Object> getLibraries() {
-		return service.getLibraries();
-	}
 	
-	@ResponseBody
-	@RequestMapping(method=RequestMethod.GET, value="/library/{id}")
-	public Map<String, Object> getLibrary(@PathVariable String id) {
-		return service.getLibrary(id);
-	}
-	
-	@ResponseStatus(HttpStatus.ACCEPTED)
-	@RequestMapping(method=RequestMethod.POST, value="/library/{id}")
-	@ResponseBody
-	public Map<String, Object> addLibrary(@PathVariable String id, @RequestParam MultipartFile file) throws IOException {
-		service.addLibrary(id, file.getOriginalFilename(), file.getInputStream());
-		return getLibrary(id);
-	}
-
 	@ResponseBody
 	@RequestMapping(method=RequestMethod.GET, value="") 
 	public Map<String, Object> getStats() {
 		return service.getStats();
 	}
 	
+	@ResponseBody
+	@RequestMapping(method=RequestMethod.GET, value="/libraries")
+	public Map<String, Object> getLibraries() {
+		return service.getLibraries();
+	}
+	
+	@ResponseBody
+	@RequestMapping(method=RequestMethod.GET, value="/libraries/{id}")
+	public Map<String, Object> getLibrary(@PathVariable String id) {
+		return service.getLibrary(id);
+	}
+	
+	@ResponseStatus(HttpStatus.ACCEPTED)
+	@RequestMapping(method=RequestMethod.POST, value="/libraries/{id}")
+	@ResponseBody
+	public Map<String, Object> addLibrary(@PathVariable String id, @RequestParam MultipartFile file) throws IOException {
+		service.addLibrary(id, file.getOriginalFilename(), file.getInputStream());
+		return getLibrary(id);
+	}
+	
+	@ResponseStatus(HttpStatus.ACCEPTED)
+	@RequestMapping(method = RequestMethod.POST, value = "/libraries/{id}/stages/{stageName}")
+	@ResponseBody
+	public Map<String, Object> addStage(
+			@PathVariable(value = "id") String libraryId,
+			@PathVariable(value = "stageName") String stageName,
+			@RequestBody String jsonConfig) throws JsonException, IOException {
+		return stagesService.addStage(libraryId, stageName, jsonConfig);
+	}
+
+
+	@ResponseBody
+	@RequestMapping(method = RequestMethod.GET, value = "/stages")
+	public Map<String,List<Stage>> getStages() {
+		return stagesService.getStages();
+	}
+	
+	@ResponseBody
+	@RequestMapping(method = RequestMethod.GET, value = "/stages/{stageName}")
+	public Stage getStageInfo(@PathVariable(value = "stageName") String stageName) {
+		return stagesService.getStageInfo(stageName);
+	}
 
 	@ResponseBody
 	@RequestMapping(method = RequestMethod.GET, value = "/documents/count")
@@ -75,11 +108,21 @@ public class ConfigurationController {
 	}
 
 	@ResponseBody
-	@RequestMapping(method = RequestMethod.GET, value = "/documents/list")
+	@RequestMapping(method = RequestMethod.GET, value = "/documents")
 	public Map<String, Object> getDocuments(
 			@RequestParam(required = false, defaultValue = "{}", value = "q") String jsonQuery,
 			@RequestParam(required = false, defaultValue = "10", value = "limit") int limit,
 			@RequestParam(required = false, defaultValue = "0", value = "skip") int skip) {
 		return documentService.getDocuments(jsonQuery, limit, skip);
 	}
+
+	@ResponseBody
+	@RequestMapping(method = RequestMethod.POST, value = "/documents/edit")
+	public Map<String, Object> editDocuments(
+			@RequestParam(required = false, defaultValue = "{}", value = "q") String jsonQuery,
+			@RequestParam(required = false, defaultValue = "1", value = "limit") int limit,
+			@RequestBody String changes) {
+		return documentService.updateDocuments(jsonQuery, limit, changes);
+	}
+	
 }

--- a/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
@@ -15,12 +15,23 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.findwise.hydra.admin.ConfigurationService;
+import com.findwise.hydra.admin.documents.DocumentsService;
 
 @Controller("/rest")
 public class ConfigurationController {
 	@Autowired
 	private ConfigurationService<?> service;
 	
+	@Autowired
+	private DocumentsService<?> documentService;
+
+	public DocumentsService<?> getDocumentService() {
+		return documentService;
+	}
+
+	public void setDocumentService(DocumentsService<?> documentService) {
+		this.documentService = documentService;
+	}
 	public ConfigurationService<?> getService() {
 		return service;
 	}
@@ -53,5 +64,22 @@ public class ConfigurationController {
 	@RequestMapping(method=RequestMethod.GET, value="") 
 	public Map<String, Object> getStats() {
 		return service.getStats();
+	}
+	
+
+	@ResponseBody
+	@RequestMapping(method = RequestMethod.GET, value = "/documents/count")
+	public Map<String, Object> getDocumentCount(
+			@RequestParam(required = false, defaultValue="{}", value = "q") String jsonQuery) {
+		return documentService.getNumberOfDocuments(jsonQuery);
+	}
+
+	@ResponseBody
+	@RequestMapping(method = RequestMethod.GET, value = "/documents/list")
+	public Map<String, Object> getDocuments(
+			@RequestParam(required = true, value = "q") String jsonQuery,
+			@RequestParam(required = false, defaultValue = "10", value = "limit") int limit,
+			@RequestParam(required = false, defaultValue = "0", value = "skip") int skip) {
+		return documentService.getDocuments(jsonQuery, limit, skip);
 	}
 }

--- a/admin-service/src/main/java/com/findwise/hydra/admin/stages/StagesService.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/stages/StagesService.java
@@ -1,0 +1,70 @@
+package com.findwise.hydra.admin.stages;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bson.types.ObjectId;
+
+import com.findwise.hydra.DatabaseConnector;
+import com.findwise.hydra.DatabaseFile;
+import com.findwise.hydra.DatabaseType;
+import com.findwise.hydra.Pipeline;
+import com.findwise.hydra.Stage;
+import com.findwise.hydra.common.JsonException;
+import com.findwise.hydra.common.SerializationUtils;
+
+public class StagesService<T extends DatabaseType> {
+
+	private DatabaseConnector<T> connector;
+
+	public StagesService(DatabaseConnector<T> connector) {
+		this.connector = connector;
+	}
+
+	public DatabaseConnector<T> getConnector() {
+		return connector;
+	}
+	
+	public Map<String, List<Stage>> getStages() {
+		Map<String, List<Stage>> ret = new HashMap<String, List<Stage>>();
+		ret.put("stages", connector.getPipelineReader().getPipeline().getStages());
+		return ret;
+	}
+
+	public Map<String, Object> addStage(String libraryId, String name,
+			String jsonConfig) throws JsonException, IOException {
+		Map<String, Object> ret = new HashMap<String, Object>();
+		addStage(libraryId, name, jsonConfig, false);
+		ret.put("stageStatus", "Added");
+		return ret;
+	}
+
+	public void addStage(String libraryId, String name, String jsonConfig,
+			boolean debug) throws JsonException, IOException {
+		DatabaseFile df = new DatabaseFile();
+		try {
+			df.setId(new ObjectId(libraryId));
+		} catch (Exception e) {
+			df.setId(libraryId);
+		}
+		Stage s = new Stage(name, df);
+		s.setProperties(SerializationUtils.fromJson(jsonConfig));
+		if (debug) {
+			s.setMode(Stage.Mode.DEBUG);
+		} else {
+			s.setMode(Stage.Mode.ACTIVE);
+		}
+
+		Pipeline<Stage> pipeline = connector.getPipelineReader().getPipeline();
+		pipeline.addStage(s);
+		connector.getPipelineWriter().write(pipeline);
+
+	}
+
+	public Stage getStageInfo(String stageName) {
+		return connector.getPipelineReader().getPipeline().getStage(stageName);
+	}
+
+}

--- a/api/src/main/java/com/findwise/hydra/common/Query.java
+++ b/api/src/main/java/com/findwise/hydra/common/Query.java
@@ -2,7 +2,7 @@ package com.findwise.hydra.common;
 
 import com.findwise.hydra.common.Document.Action;
 
-public interface Query extends JsonDeserializer {
+public interface Query extends JsonDeserializer, JsonSerializer {
 	String TOUCHED_KEY = "touched";
 	
 	void requireContentFieldExists(String fieldName);
@@ -14,6 +14,8 @@ public interface Query extends JsonDeserializer {
 	void requireNotTouchedByStage(String stageName);
 	
 	void requireContentFieldEquals(String fieldName, Object o);
+	
+	void requireContentFieldNotEquals(String fieldName, Object o);
 	
 	void requireAction(Action a);
 }

--- a/api/src/main/java/com/findwise/hydra/local/LocalQuery.java
+++ b/api/src/main/java/com/findwise/hydra/local/LocalQuery.java
@@ -12,12 +12,14 @@ import com.google.gson.JsonParseException;
 
 public class LocalQuery implements Query, JsonDeserializer {
 	private Map<String, Object> equals;
+	private Map<String, Object> notEquals;
 	private Map<String, Boolean> exists;
 	private Map<String, Boolean> touched;
 	private Action action = null;
 	
 	public LocalQuery() {
 		equals = new HashMap<String, Object>();
+		notEquals = new HashMap<String, Object>();
 		exists = new HashMap<String, Boolean>();
 		touched = new HashMap<String, Boolean>();
 	}
@@ -77,6 +79,7 @@ public class LocalQuery implements Query, JsonDeserializer {
 	public String toJson() {
 		Map<String, Object> x = new HashMap<String, Object>();
 		x.put("equals", equals);
+		x.put("notEquals", notEquals);
 		x.put("exists", exists);
 		x.put("touched", touched);
 		
@@ -94,6 +97,9 @@ public class LocalQuery implements Query, JsonDeserializer {
 			Map<String, Object> queryObject = (Map<String, Object>) SerializationUtils.fromJson(json);
 			if(queryObject.containsKey("equals")) {
 				equals = (Map<String, Object>) queryObject.get("equals");
+			}
+			if(queryObject.containsKey("notEquals")) {
+				notEquals = (Map<String, Object>) queryObject.get("notEquals");
 			}
 			if(queryObject.containsKey("exists")) {
 				exists = (Map<String, Boolean>) queryObject.get("exists");
@@ -114,5 +120,42 @@ public class LocalQuery implements Query, JsonDeserializer {
 	@Override
 	public String toString() {
 		return toJson();
+	}
+
+	@Override
+	public void requireContentFieldNotEquals(String fieldName, Object o) {
+		notEquals.put(fieldName, o);
+	}
+
+	public Map<String, Object> getEquals() {
+		return equals;
+	}
+
+	public void setEquals(Map<String, Object> equals) {
+		this.equals = equals;
+	}
+
+	public Map<String, Object> getNotEquals() {
+		return notEquals;
+	}
+
+	public void setNotEquals(Map<String, Object> notEquals) {
+		this.notEquals = notEquals;
+	}
+
+	public Map<String, Boolean> getExists() {
+		return exists;
+	}
+
+	public void setExists(Map<String, Boolean> exists) {
+		this.exists = exists;
+	}
+
+	public void setTouched(Map<String, Boolean> touched) {
+		this.touched = touched;
+	}
+
+	public void setAction(Action action) {
+		this.action = action;
 	}
 }

--- a/api/src/main/java/com/findwise/hydra/local/LocalQuery.java
+++ b/api/src/main/java/com/findwise/hydra/local/LocalQuery.java
@@ -42,6 +42,22 @@ public class LocalQuery implements Query, JsonDeserializer {
 		return equals;
 	}
 	
+	public Map<String, Object> getEquals() {
+		return equals;
+	}
+
+	public Map<String, Object> getContentNotEquals() {
+		return notEquals;
+	}
+	
+	public Map<String, Object> getNotEquals() {
+		return notEquals;
+	}
+
+	public Map<String, Boolean> getExists() {
+		return exists;
+	}
+	
 	public Action getAction() {
 		return action;
 	}
@@ -59,6 +75,11 @@ public class LocalQuery implements Query, JsonDeserializer {
 	@Override
 	public void requireContentFieldEquals(String fieldName, Object o) {
 		getContentsEquals().put(fieldName, o);
+	}
+	
+	@Override
+	public void requireContentFieldNotEquals(String fieldName, Object o) {
+		getContentNotEquals().put(fieldName, o);
 	}
 
 	@Override
@@ -122,40 +143,5 @@ public class LocalQuery implements Query, JsonDeserializer {
 		return toJson();
 	}
 
-	@Override
-	public void requireContentFieldNotEquals(String fieldName, Object o) {
-		notEquals.put(fieldName, o);
-	}
 
-	public Map<String, Object> getEquals() {
-		return equals;
-	}
-
-	public void setEquals(Map<String, Object> equals) {
-		this.equals = equals;
-	}
-
-	public Map<String, Object> getNotEquals() {
-		return notEquals;
-	}
-
-	public void setNotEquals(Map<String, Object> notEquals) {
-		this.notEquals = notEquals;
-	}
-
-	public Map<String, Boolean> getExists() {
-		return exists;
-	}
-
-	public void setExists(Map<String, Boolean> exists) {
-		this.exists = exists;
-	}
-
-	public void setTouched(Map<String, Boolean> touched) {
-		this.touched = touched;
-	}
-
-	public void setAction(Action action) {
-		this.action = action;
-	}
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -164,7 +164,7 @@
 		<dependency>
 			<groupId>com.findwise.hydra</groupId>
 			<artifactId>hydra-memorydb</artifactId>
-			<version>0.2.0</version>
+			<version>0.3.0-SNAPSHOT</version>
 			<type>jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryConnector.java
+++ b/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryConnector.java
@@ -84,6 +84,17 @@ public class MemoryConnector implements DatabaseConnector<MemoryType> {
 	}
 
 	@Override
+	public DatabaseDocument<MemoryType> convert(DatabaseDocument<?> document) {
+		MemoryDocument md = new MemoryDocument();
+		try {
+			md.fromJson(document.toJson());
+		} catch (JsonException e) {
+			e.printStackTrace();
+		}
+		return md;
+	}
+	
+	@Override
 	public boolean isConnected() {
 		return true;
 	}
@@ -97,5 +108,17 @@ public class MemoryConnector implements DatabaseConnector<MemoryType> {
 	public StatusReader<MemoryType> getStatusReader() {
 		return statusio;
 	}
+
+	@Override
+	public DatabaseQuery<MemoryType> convert(DatabaseQuery<?> query) {
+		try {
+			MemoryQuery memQuery = new MemoryQuery();
+			memQuery.fromJson(query.toJson());
+			return memQuery;
+		} catch (JsonException e) {
+			return null;
+		}
+	}
+
 
 }

--- a/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryConnector.java
+++ b/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryConnector.java
@@ -11,9 +11,9 @@ import com.findwise.hydra.PipelineReader;
 import com.findwise.hydra.PipelineWriter;
 import com.findwise.hydra.StatusReader;
 import com.findwise.hydra.StatusWriter;
+import com.findwise.hydra.common.Document;
 import com.findwise.hydra.common.JsonException;
-import com.findwise.hydra.local.LocalDocument;
-import com.findwise.hydra.local.LocalQuery;
+import com.findwise.hydra.common.Query;
 
 public class MemoryConnector implements DatabaseConnector<MemoryType> {
 
@@ -62,7 +62,7 @@ public class MemoryConnector implements DatabaseConnector<MemoryType> {
 	}
 
 	@Override
-	public DatabaseQuery<MemoryType> convert(LocalQuery query) {
+	public DatabaseQuery<MemoryType> convert(Query query) {
 		MemoryQuery mq = new MemoryQuery();
 		try {
 			mq.fromJson(query.toJson());
@@ -73,7 +73,7 @@ public class MemoryConnector implements DatabaseConnector<MemoryType> {
 	}
 
 	@Override
-	public DatabaseDocument<MemoryType> convert(LocalDocument document) {
+	public DatabaseDocument<MemoryType> convert(Document document) {
 		MemoryDocument md = new MemoryDocument();
 		try {
 			md.fromJson(document.toJson());
@@ -83,17 +83,6 @@ public class MemoryConnector implements DatabaseConnector<MemoryType> {
 		return md;
 	}
 
-	@Override
-	public DatabaseDocument<MemoryType> convert(DatabaseDocument<?> document) {
-		MemoryDocument md = new MemoryDocument();
-		try {
-			md.fromJson(document.toJson());
-		} catch (JsonException e) {
-			e.printStackTrace();
-		}
-		return md;
-	}
-	
 	@Override
 	public boolean isConnected() {
 		return true;
@@ -108,17 +97,5 @@ public class MemoryConnector implements DatabaseConnector<MemoryType> {
 	public StatusReader<MemoryType> getStatusReader() {
 		return statusio;
 	}
-
-	@Override
-	public DatabaseQuery<MemoryType> convert(DatabaseQuery<?> query) {
-		try {
-			MemoryQuery memQuery = new MemoryQuery();
-			memQuery.fromJson(query.toJson());
-			return memQuery;
-		} catch (JsonException e) {
-			return null;
-		}
-	}
-
 
 }

--- a/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryDocument.java
+++ b/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryDocument.java
@@ -120,4 +120,15 @@ public class MemoryDocument extends LocalDocument implements DatabaseDocument<Me
 	public Object getID() {
 		return getDocumentMap().get(ID_KEY);
 	}
+
+	@Override
+	public boolean removeFetchedBy(String stage) {
+		return getMetadataSubMap(FETCHED_METADATA_TAG).remove(stage) != null;
+	}
+	
+	@Override
+	public boolean removeTouchedBy(String stage) {
+		return getMetadataSubMap(TOUCHED_METADATA_TAG).remove(stage) != null;
+	}
+	
 }

--- a/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryDocumentIO.java
+++ b/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryDocumentIO.java
@@ -89,19 +89,42 @@ public class MemoryDocumentIO implements DocumentWriter<MemoryType>,
 	@SuppressWarnings("unchecked")
 	@Override
 	public List<DatabaseDocument<MemoryType>> getDocuments(
-			DatabaseQuery<MemoryType> q, int limit) {
+			DatabaseQuery<MemoryType> q, int limit, int skip) {
 		ArrayList<MemoryDocument> list = new ArrayList<MemoryDocument>();
-		
-		for (MemoryDocument d : set) {
-			if (list.size() >= limit) {
-				break;
-			}
 
-			if(d.matches((MemoryQuery) q)) {
-				list.add(d);
+		int matching = 0;
+		for (MemoryDocument doc : set) {
+			if (list.size() >= limit)
+				break;
+			
+			if (doc.matches((MemoryQuery) q)) {
+				if (matching >= skip) {
+					list.add(doc);
+				}
+				matching++;
 			}
 		}
+
 		return (List<DatabaseDocument<MemoryType>>) (Object) list;
+	}
+	
+	@Override
+	public List<DatabaseDocument<MemoryType>> getDocuments(
+			DatabaseQuery<MemoryType> q, int limit) {
+		return getDocuments(q, limit, 0);
+	}
+
+	@Override
+	public long getNumberOfDocuments(DatabaseQuery<MemoryType> q) {
+		long matching = 0;
+
+		for (MemoryDocument doc : set) {
+			if (doc.matches((MemoryQuery) q)) {
+				matching++;
+			}
+		}
+
+		return matching;
 	}
 
 	@Override
@@ -312,4 +335,5 @@ public class MemoryDocumentIO implements DocumentWriter<MemoryType>,
 	public TailableIterator<MemoryType> getInactiveIterator(DatabaseQuery<MemoryType> query) {
 		return new MemoryTailableIterator(inactive, b, new MemoryQuery());
 	}
+
 }

--- a/database-impl/inmemory/src/test/java/com/findwise/hydra/memorydb/MemoryDocumentIOTest.java
+++ b/database-impl/inmemory/src/test/java/com/findwise/hydra/memorydb/MemoryDocumentIOTest.java
@@ -156,6 +156,10 @@ public class MemoryDocumentIOTest {
 		dbq.requireContentFieldEquals("number", 2);
 		Document d = io.getDocument(dbq);
 		
+		if (d == null) {
+			fail("Did not find any documents matching query");
+		}
+		
 		if(d.isEqual(test) || !d.isEqual(test2)) {
 			fail("Incorrect document returned");
 		}

--- a/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoConnector.java
+++ b/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoConnector.java
@@ -10,10 +10,11 @@ import org.slf4j.LoggerFactory;
 import com.findwise.hydra.DatabaseConfiguration;
 import com.findwise.hydra.DatabaseConnector;
 import com.findwise.hydra.DatabaseDocument;
-import com.findwise.hydra.DatabaseQuery;
 import com.findwise.hydra.PipelineReader;
 import com.findwise.hydra.StatusUpdater;
+import com.findwise.hydra.common.Document;
 import com.findwise.hydra.common.JsonException;
+import com.findwise.hydra.common.Query;
 import com.findwise.hydra.local.LocalDocument;
 import com.findwise.hydra.local.LocalQuery;
 import com.google.inject.Inject;
@@ -155,15 +156,15 @@ public class MongoConnector implements DatabaseConnector<MongoType> {
 	}
 
 	@Override
-	public MongoQuery convert(LocalQuery query) {
-		return staticConvert(query);
+	public MongoQuery convert(Query query) {
+		try {
+			return new MongoQuery(query.toJson());
+		} catch (JsonException e) {
+			return null;
+		}
 	}
 
-	@Override
-	public MongoDocument convert(LocalDocument document) {
-		return staticConvert(document);
-	}
-
+	
 	public static MongoDocument staticConvert(LocalDocument document) {
 		MongoDocument doc;
 		try {
@@ -226,7 +227,7 @@ public class MongoConnector implements DatabaseConnector<MongoType> {
 	}
 
 	@Override
-	public DatabaseDocument<MongoType> convert(DatabaseDocument<?> document) {
+	public DatabaseDocument<MongoType> convert(Document document) {
 		try {
 			return new MongoDocument(document.toJson());
 		} catch (JsonException e) {
@@ -234,13 +235,4 @@ public class MongoConnector implements DatabaseConnector<MongoType> {
 		}
 	}
 
-	@Override
-	public DatabaseQuery<MongoType> convert(DatabaseQuery<?> query) {
-		try {
-			return new MongoQuery(query.toJson());
-		} catch (JsonException e) {
-			return null;
-		}
-		
-	}
 }

--- a/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoConnector.java
+++ b/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoConnector.java
@@ -9,6 +9,8 @@ import org.slf4j.LoggerFactory;
 
 import com.findwise.hydra.DatabaseConfiguration;
 import com.findwise.hydra.DatabaseConnector;
+import com.findwise.hydra.DatabaseDocument;
+import com.findwise.hydra.DatabaseQuery;
 import com.findwise.hydra.PipelineReader;
 import com.findwise.hydra.StatusUpdater;
 import com.findwise.hydra.common.JsonException;
@@ -221,5 +223,24 @@ public class MongoConnector implements DatabaseConnector<MongoType> {
 	@Override
 	public MongoStatusIO getStatusReader() {
 		return statusIO;
+	}
+
+	@Override
+	public DatabaseDocument<MongoType> convert(DatabaseDocument<?> document) {
+		try {
+			return new MongoDocument(document.toJson());
+		} catch (JsonException e) {
+			return null;
+		}
+	}
+
+	@Override
+	public DatabaseQuery<MongoType> convert(DatabaseQuery<?> query) {
+		try {
+			return new MongoQuery(query.toJson());
+		} catch (JsonException e) {
+			return null;
+		}
+		
 	}
 }

--- a/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocument.java
+++ b/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocument.java
@@ -179,6 +179,12 @@ public class MongoDocument implements DBObject, DatabaseDocument<MongoType> {
 		return getMetadata().toMap();
 	}
 
+	
+	@SuppressWarnings("unchecked")
+	public Map<String, Object> getContentsMap() {
+		return getContents().toMap();
+	}
+	
 	@Override
 	public final Object putMetadataField(String key, Object v) {
 		touchedMetadata.add(key);

--- a/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocument.java
+++ b/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocument.java
@@ -402,4 +402,18 @@ public class MongoDocument implements DBObject, DatabaseDocument<MongoType> {
 	public boolean fetchedBy(String stage) {
 		return getMetadataSubMap(FETCHED_METADATA_TAG).containsKey(stage);
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean removeFetchedBy(String stage) {
+		touchedMetadata.add(FETCHED_METADATA_TAG);
+		return ((Map<String,Object>)getMetadataMap().get(FETCHED_METADATA_TAG)).remove(stage)!=null;
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean removeTouchedBy(String stage) {
+		touchedMetadata.add(TOUCHED_METADATA_TAG);
+		return ((Map<String,Object>)getMetadataMap().get(TOUCHED_METADATA_TAG)).remove(stage)!=null;
+	}
 }

--- a/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocumentIO.java
+++ b/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocumentIO.java
@@ -192,16 +192,7 @@ public class MongoDocumentIO implements DocumentReader<MongoType>, DocumentWrite
 	 */
 	@Override
 	public List<DatabaseDocument<MongoType>> getDocuments(DatabaseQuery<MongoType> dbq, int limit) {
-		DBCursor cursor = documents.find(((MongoQuery)dbq).toDBObject());
-
-		List<DatabaseDocument<MongoType>> list = new ArrayList<DatabaseDocument<MongoType>>();
-		while(list.size()<limit && cursor.hasNext()) {
-			cursor.next();
-			
-			list.add((MongoDocument)cursor.curr());
-		}
-		
-		return list;
+		return getDocuments(dbq, limit, 0);
 	}
 
 	public DBCollection getDocumentCollection() {
@@ -558,5 +549,25 @@ public class MongoDocumentIO implements DocumentReader<MongoType>, DocumentWrite
 			logger.error("Unable to get Tailable Iterator!", e);
 			return null;
 		}
+	}
+
+	@Override
+	public List<DatabaseDocument<MongoType>> getDocuments(
+			DatabaseQuery<MongoType> dbq, int limit, int skip) {
+		DBCursor cursor = documents.find(((MongoQuery)dbq).toDBObject()).skip(skip).limit(limit);
+
+		List<DatabaseDocument<MongoType>> list = new ArrayList<DatabaseDocument<MongoType>>();
+		while(cursor.hasNext()) {
+			cursor.next();
+			
+			list.add((MongoDocument)cursor.curr());
+		}
+		
+		return list;
+	}
+
+	@Override
+	public long getNumberOfDocuments(DatabaseQuery<MongoType> q) {
+		return documents.getCount(((MongoQuery)q).toDBObject());
 	}
 }

--- a/database/src/main/java/com/findwise/hydra/DatabaseConnector.java
+++ b/database/src/main/java/com/findwise/hydra/DatabaseConnector.java
@@ -36,9 +36,12 @@ public interface DatabaseConnector<T extends DatabaseType> {
 	DocumentWriter<T> getDocumentWriter();
 	
 	DatabaseQuery<T> convert(LocalQuery query);
+	DatabaseQuery<T> convert(DatabaseQuery<?> query);
 
 	DatabaseDocument<T> convert(LocalDocument document);
 
+	DatabaseDocument<T> convert(DatabaseDocument<?> document);
+	
 	boolean isConnected();
 
 	StatusWriter<T> getStatusWriter();

--- a/database/src/main/java/com/findwise/hydra/DatabaseConnector.java
+++ b/database/src/main/java/com/findwise/hydra/DatabaseConnector.java
@@ -2,8 +2,8 @@ package com.findwise.hydra;
 
 import java.io.IOException;
 
-import com.findwise.hydra.local.LocalDocument;
-import com.findwise.hydra.local.LocalQuery;
+import com.findwise.hydra.common.Document;
+import com.findwise.hydra.common.Query;
 
 public interface DatabaseConnector<T extends DatabaseType> {
 	String DATABASE_URL_PARAM = "database_url";
@@ -35,12 +35,9 @@ public interface DatabaseConnector<T extends DatabaseType> {
 	
 	DocumentWriter<T> getDocumentWriter();
 	
-	DatabaseQuery<T> convert(LocalQuery query);
-	DatabaseQuery<T> convert(DatabaseQuery<?> query);
-
-	DatabaseDocument<T> convert(LocalDocument document);
-
-	DatabaseDocument<T> convert(DatabaseDocument<?> document);
+	DatabaseQuery<T> convert(Query query);
+	
+	DatabaseDocument<T> convert(Document document);
 	
 	boolean isConnected();
 

--- a/database/src/main/java/com/findwise/hydra/DatabaseDocument.java
+++ b/database/src/main/java/com/findwise/hydra/DatabaseDocument.java
@@ -5,6 +5,10 @@ import com.findwise.hydra.common.Document;
 public interface DatabaseDocument<T extends DatabaseType> extends Document {
 
 	Object putMetadataField(String key, Object value);
+
+	boolean removeTouchedBy(String stage);
+	
+	boolean removeFetchedBy(String stage);
 	
 	boolean touchedBy(String stage);
 	

--- a/database/src/main/java/com/findwise/hydra/DocumentReader.java
+++ b/database/src/main/java/com/findwise/hydra/DocumentReader.java
@@ -29,6 +29,8 @@ public interface DocumentReader<T extends DatabaseType> {
 	TailableIterator<T> getInactiveIterator(DatabaseQuery<T> query);
 	
 	List<DatabaseDocument<T>> getDocuments(DatabaseQuery<T> q, int limit);
+	List<DatabaseDocument<T>> getDocuments(DatabaseQuery<T> q, int limit, int skip);
+	long getNumberOfDocuments(DatabaseQuery<T> q);
 
 	DocumentFile getDocumentFile(DatabaseDocument<T> d, String fileName);
 	

--- a/database/src/main/java/com/findwise/hydra/Pipeline.java
+++ b/database/src/main/java/com/findwise/hydra/Pipeline.java
@@ -2,7 +2,6 @@ package com.findwise.hydra;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -17,9 +16,6 @@ public class Pipeline<T extends Stage> {
 	}
 	
 	public boolean removeStage(T s) {
-		if(!stages.containsKey(s.getName())) {
-			return false;
-		}
 		return stages.remove(s.getName())!=null;
 	}
 	
@@ -41,14 +37,7 @@ public class Pipeline<T extends Stage> {
 	}
 
 	public List<T> getStages() {
-		List<T> stageList = new ArrayList<T>();
-		
-		Iterator<T> it = stages.values().iterator();
-		while(it.hasNext()) {
-			stageList.add(it.next());
-		}
-		
-		return stageList;
+		return new ArrayList<T>(stages.values());
 	}
 	
 	protected Map<String, T> getStageMap() {

--- a/examples/src/main/java/com/findwise/hydra/ExampleModule.java
+++ b/examples/src/main/java/com/findwise/hydra/ExampleModule.java
@@ -54,6 +54,8 @@ public class ExampleModule extends AbstractModule {
 		bindConstant().annotatedWith(Names.named(DatabaseConnector.DATABASE_URL_PARAM)).to(c.getDatabaseUrl());
 		bindConstant().annotatedWith(Names.named(DatabaseConnector.DATABASE_USER)).to(c.getDatabaseUser());
 		bindConstant().annotatedWith(Names.named(DatabaseConnector.DATABASE_PASSWORD)).to(c.getDatabasePassword());
+		bindConstant().annotatedWith(Names.named(DatabaseConnector.OLD_MAX_COUNT)).to(c.getOldMaxCount());
+		bindConstant().annotatedWith(Names.named(DatabaseConnector.OLD_MAX_SIZE_MB)).to(c.getOldMaxSize());
 
 		bind(DatabaseConnector.class).to(MongoConnector.class);
 	}
@@ -84,12 +86,12 @@ public class ExampleModule extends AbstractModule {
 
 			@Override
 			public int getOldMaxSize() {
-				return 100;
+				return 200;
 			}
 
 			@Override
 			public int getOldMaxCount() {
-				return 1000;
+				return 2000;
 			}
 		};
 	}

--- a/stages/in/json-in/pom.xml
+++ b/stages/in/json-in/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.findwise.hydra</groupId>
     <artifactId>hydra-json-input</artifactId>
     <packaging>jar</packaging>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <url>http://maven.apache.org</url>
 
@@ -15,13 +15,13 @@
         <dependency>
             <groupId>com.findwise.hydra</groupId>
             <artifactId>hydra-api</artifactId>
-            <version>0.2.0-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.findwise.hydra</groupId>
             <artifactId>hydra-input-server</artifactId>
-            <version>0.2.0-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>

--- a/stages/in/server/pom.xml
+++ b/stages/in/server/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.findwise.hydra</groupId>
     <artifactId>hydra-input-server</artifactId>
     <packaging>jar</packaging>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <url>http://maven.apache.org</url>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.findwise.hydra</groupId>
             <artifactId>hydra-api</artifactId>
-            <version>0.2.0-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/stages/processing/tika/pom.xml
+++ b/stages/processing/tika/pom.xml
@@ -5,7 +5,7 @@
 	<artifactId>hydra-tika-stages</artifactId>
 	<version>0.3.0-SNAPSHOT</version>
 	<description>Tika Text Extraction Stage</description>
-        <name>${project.artifactId}</name>
+    <name>${project.artifactId}</name>
 	<url>http://findwise.github.com/Hydra</url>
 
 	<licenses>

--- a/stages/processing/tika/pom.xml
+++ b/stages/processing/tika/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.findwise.hydra</groupId>
 	<artifactId>hydra-tika-stages</artifactId>
 	<version>0.3.0-SNAPSHOT</version>
-	<description>Solr Output Stage</description>
+	<description>Tika Text Extraction Stage</description>
         <name>${project.artifactId}</name>
 	<url>http://findwise.github.com/Hydra</url>
 

--- a/stages/processing/tika/pom.xml
+++ b/stages/processing/tika/pom.xml
@@ -5,6 +5,7 @@
 	<artifactId>hydra-tika-stages</artifactId>
 	<version>0.3.0-SNAPSHOT</version>
 	<description>Solr Output Stage</description>
+        <name>${project.artifactId}</name>
 	<url>http://findwise.github.com/Hydra</url>
 
 	<licenses>
@@ -31,7 +32,7 @@
 		<dependency>
 			<groupId>com.findwise.hydra</groupId>
 			<artifactId>hydra-api</artifactId>
-			<version>0.2.0</version>
+			<version>0.3.0-SNAPSHOT</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>

--- a/stages/processing/web/pom.xml
+++ b/stages/processing/web/pom.xml
@@ -10,8 +10,8 @@
 	<dependencies>
 		<dependency>
 			<groupId>com.findwise.hydra</groupId>
-			<artifactId>hydra-basic-stages</artifactId>
-			<version>0.2.0</version>
+			<artifactId>hydra-api</artifactId>
+			<version>0.3.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jsoup</groupId>


### PR DESCRIPTION
- Added two endpoints /documents/count and /documents/list 
- The first returns the number of documents matching a query (by adding for example ?q={fetched:true})
- The second returns the documents matching a query (by adding for example ?q={fetched:true}). You can also specify the number of documents to return (by adding for example &limit=10) and skip a number of documents for pagination (by adding for example &skip=10)
- I no query is specified, all documents are considered matches.
