### PR TITLE
Added generic support for multiple instances of a single stage in JVM

### DIFF
--- a/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
+++ b/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
@@ -415,4 +415,8 @@ public class RemotePipeline {
 			return null;
 		}
 	}
+	
+	public String getStageName() {
+		return stageName;
+	}
 }


### PR DESCRIPTION
Particularly useful if using a stage that needs to fetch something over the network, e.g. SimpleFetchingTikaStage where a lot of time is spent idle, waiting for content.

Adds the Parameter `numberOfThreads` to AbstractStage.
