### PR TITLE
JVM selection

### DIFF
--- a/core/src/main/java/com/findwise/hydra/StageRunner.java
+++ b/core/src/main/java/com/findwise/hydra/StageRunner.java
@@ -28,6 +28,7 @@ public class StageRunner extends Thread {
     private int timesStarted;
     private boolean loggingEnabled;
     private String jvmParameters;
+    private String java;
     private String startupArgsString;
     private boolean hasQueried = false;
     private int pipelinePort;
@@ -47,6 +48,11 @@ public class StageRunner extends Thread {
             jvmParameters = (String) conf.get("jvm_parameters");
         } else {
             jvmParameters = null;
+        }
+        if (conf.containsKey("java_location")) {
+            java = (String) conf.get("java_location");
+        } else {
+            java = "java";
         }
         if (conf.containsKey("retries")) {
             timesToRetry = (Integer) conf.get("retries");
@@ -105,7 +111,7 @@ public class StageRunner extends Thread {
      * @return true if the stage was killed by a call to the destroy()-method. false otherwise.
      */
     private boolean runStage() {
-        CommandLine cmdLine = new CommandLine("java");
+        CommandLine cmdLine = new CommandLine(java);
         cmdLine.addArgument(jvmParameters, false);
         cmdLine.addArgument("-jar");
         cmdLine.addArgument("${file}");

--- a/core/src/main/java/com/findwise/hydra/net/RESTServer.java
+++ b/core/src/main/java/com/findwise/hydra/net/RESTServer.java
@@ -67,6 +67,7 @@ public class RESTServer extends Thread {
 		requestHandler.setRestId(id);
 		this.port = port;
 		executing = false;
+		setDaemon(true);
 	}
 	
 	@SuppressWarnings("rawtypes")


### PR DESCRIPTION
Adding support for specifying a JVM installation for a stage by specifying java_location property.

Also, made RESTServer a Daemon to ensure Hydra process exits properly if NodeMaster fails to start (usually due to Mongo not being available)
