### PR TITLE
postfix/prefix conditions added to copyStage and prioritizedCopyStage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,7 @@
   <artifactId>hydra-parent</artifactId>
   <version>0.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
+  <name>hydra-parent</name>
   
   <modules>
 	<module>api</module>

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/CopyStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/CopyStage.java
@@ -8,13 +8,15 @@ import com.findwise.hydra.local.LocalDocument;
  */
 @Stage(description = "Copies values from one field to another.")
 public class CopyStage extends AbstractMappingProcessStage {
+
     @Parameter(name = "prefix", description = "Input field prefix")
     private String prefix = "";
     @Parameter(name = "postfix", description = "Input field postfix")
     private String postfix = "";
-    
+
     @Override
-    public void stageInit() throws RequiredArgumentMissingException { }
+    public void stageInit() throws RequiredArgumentMissingException {
+    }
 
     @Override
     public void processField(LocalDocument doc, String fromField, String toField)
@@ -24,9 +26,9 @@ public class CopyStage extends AbstractMappingProcessStage {
         doc.putContentField(toField, val);
         String valString = (val == null) ? null : val.toString();
         Logger.debug("Copying field " + fromFieldStr + " to field " + toField
-            + " value: " + valString);
+                + " value: " + valString);
     }
-    
+
     public void setPostfix(String postfix) {
         this.postfix = postfix;
     }

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/CopyStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/CopyStage.java
@@ -4,13 +4,13 @@ import com.findwise.hydra.common.Logger;
 import com.findwise.hydra.local.LocalDocument;
 
 /**
- * A basic Copy-stage
+ * A basic Copy-stage.
  */
 @Stage(description = "Copies values from one field to another.")
 public class CopyStage extends AbstractMappingProcessStage {
-    @Parameter(name = "prefix", description = "Prefix condition")
+    @Parameter(name = "prefix", description = "Input field prefix")
     private String prefix = "";
-    @Parameter(name = "postfix", description = "Postfix condition")
+    @Parameter(name = "postfix", description = "Input field postfix")
     private String postfix = "";
     
     @Override

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/CopyStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/CopyStage.java
@@ -8,16 +8,30 @@ import com.findwise.hydra.local.LocalDocument;
  */
 @Stage(description = "Copies values from one field to another.")
 public class CopyStage extends AbstractMappingProcessStage {
-	@Override
-	public void stageInit() throws RequiredArgumentMissingException { }
+    @Parameter(name = "prefix", description = "Prefix condition")
+    private String prefix = "";
+    @Parameter(name = "postfix", description = "Postfix condition")
+    private String postfix = "";
+    
+    @Override
+    public void stageInit() throws RequiredArgumentMissingException { }
 
-	@Override
-	public void processField(LocalDocument doc, String fromField, String toField)
-			throws ProcessException {
-		Object val = doc.getContentField(fromField);
-		doc.putContentField(toField, val);
-		String valString = (val == null) ? null : val.toString();
-		Logger.debug("Copying field " + fromField + " to field " + toField
-				+ " value: " + valString);
-	}
+    @Override
+    public void processField(LocalDocument doc, String fromField, String toField)
+            throws ProcessException {
+        String fromFieldStr = prefix + fromField + postfix;
+        Object val = doc.getContentField(fromFieldStr);
+        doc.putContentField(toField, val);
+        String valString = (val == null) ? null : val.toString();
+        Logger.debug("Copying field " + fromFieldStr + " to field " + toField
+            + " value: " + valString);
+    }
+    
+    public void setPostfix(String postfix) {
+        this.postfix = postfix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
 }

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/PrioritizedCopyStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/PrioritizedCopyStage.java
@@ -45,6 +45,10 @@ public class PrioritizedCopyStage extends AbstractProcessStage {
     @Parameter(name = "overWrite", description = "if set to true, will overwrite the contents of "
             + "the outputField even if it alrady has a value. Default false")
     private boolean overWrite = false;
+    @Parameter(name = "prefix", description = "Prefix condition")
+    private String prefix = "";
+    @Parameter(name = "postfix", description = "Postfix condition")
+    private String postfix = "";
 
     @Override
     public void init() throws RequiredArgumentMissingException {
@@ -61,10 +65,11 @@ public class PrioritizedCopyStage extends AbstractProcessStage {
         }
 
         for (String field : inputFields) {
-            if (hasValueAndNotEmptyString(doc, field)) {
-                if (meetsCondition(doc, field)) {
-                    Logger.debug("Found value in field: " + field);
-                    doc.putContentField(outputField, doc.getContentField(field));
+            String fromFieldStr = prefix + field + postfix;
+            if (hasValueAndNotEmptyString(doc, fromFieldStr)) {
+                if (meetsCondition(doc, fromFieldStr)) {
+                    Logger.debug("Found value in field: " + fromFieldStr);
+                    doc.putContentField(outputField, doc.getContentField(fromFieldStr));
                     return;
                 } else {
                     Logger.debug("Field" + outputField + " doesn't meet the condition of "+conditionField + "being" + conditionValue);
@@ -128,5 +133,13 @@ public class PrioritizedCopyStage extends AbstractProcessStage {
             }
             else return false;
         }
+    }
+    
+    public void setPostfix(String postfix) {
+        this.postfix = postfix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
     }
 }

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/PrioritizedCopyStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/PrioritizedCopyStage.java
@@ -2,11 +2,6 @@ package com.findwise.hydra.stage;
 
 import com.findwise.hydra.common.Logger;
 import com.findwise.hydra.local.LocalDocument;
-import com.findwise.hydra.stage.AbstractProcessStage;
-import com.findwise.hydra.stage.Parameter;
-import com.findwise.hydra.stage.ProcessException;
-import com.findwise.hydra.stage.RequiredArgumentMissingException;
-import com.findwise.hydra.stage.Stage;
 import java.util.List;
 
 /**
@@ -23,8 +18,9 @@ import java.util.List;
  * weiter
  *
  * If no value at all is found the value from defaultvalue is used if set
- * 
- * If the output field already has a value, don't overwrite unless overWrite is true
+ *
+ * If the output field already has a value, don't overwrite unless overWrite is
+ * true
  *
  * @author Sture Svensson
  * @author Roar Granevang
@@ -43,7 +39,7 @@ public class PrioritizedCopyStage extends AbstractProcessStage {
     @Parameter(name = "defaultValue", description = "the default value if nothing is found")
     private String defaultValue = null;
     @Parameter(name = "overWrite", description = "if set to true, will overwrite the contents of "
-            + "the outputField even if it alrady has a value. Default false")
+    + "the outputField even if it alrady has a value. Default false")
     private boolean overWrite = false;
     @Parameter(name = "prefix", description = "Prefix condition")
     private String prefix = "";
@@ -72,7 +68,7 @@ public class PrioritizedCopyStage extends AbstractProcessStage {
                     doc.putContentField(outputField, doc.getContentField(fromFieldStr));
                     return;
                 } else {
-                    Logger.debug("Field" + outputField + " doesn't meet the condition of "+conditionField + "being" + conditionValue);
+                    Logger.debug("Field" + outputField + " doesn't meet the condition of " + conditionField + "being" + conditionValue);
                 }
 
             }
@@ -115,26 +111,23 @@ public class PrioritizedCopyStage extends AbstractProcessStage {
 
     public void setOverWrite(boolean overWrite) {
         this.overWrite = overWrite;
-    }        
-    
-    
+    }
 
     private boolean meetsCondition(LocalDocument doc, String field) {
-        if (conditionField == null && conditionValue == null){
+        if (conditionField == null && conditionValue == null) {
             return true;
-        }
-        else if (doc.getContentField(conditionField) == null){
-            Logger.debug("conditionfield "+conditionField +" is empty....skipping");            
+        } else if (doc.getContentField(conditionField) == null) {
+            Logger.debug("conditionfield " + conditionField + " is empty....skipping");
             return true;
-        }
-        else{
-            if (doc.getContentField(conditionField).equals(conditionValue)){
+        } else {
+            if (doc.getContentField(conditionField).equals(conditionValue)) {
                 return true;
+            } else {
+                return false;
             }
-            else return false;
         }
     }
-    
+
     public void setPostfix(String postfix) {
         this.postfix = postfix;
     }

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/CopyStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/CopyStageTest.java
@@ -16,11 +16,10 @@
 package com.findwise.hydra.stage;
 
 import com.findwise.hydra.local.LocalDocument;
+import static org.junit.Assert.assertEquals;
 import org.junit.*;
-import static org.junit.Assert.*;
 
 /**
- *
  * @author thomas.gabrielsen
  */
 public class CopyStageTest {
@@ -45,11 +44,11 @@ public class CopyStageTest {
     }
 
     /**
-     * 
+     * Tests whether the input field can be successfully copied to the output
+     * field (without the use of pre-/postfixes).
      */
     @Test
     public void testCopyField() throws Exception {
-        System.out.println("processField");
         LocalDocument doc = new LocalDocument();
         doc.putContentField("test_content", "TESTING 1-2-3!");
         String fromField = "test_content";
@@ -60,11 +59,10 @@ public class CopyStageTest {
     }
     
     /**
-     * 
+     * Tests a field copy with added prefix.
      */
     @Test
     public void testCopyFieldWithPrefix() throws Exception {
-        System.out.println("processField");
         LocalDocument doc = new LocalDocument();
         doc.putContentField("test_content", "TESTING 1-2-3!");
         String fromField = "content";
@@ -76,11 +74,10 @@ public class CopyStageTest {
     }
     
     /**
-     * 
+     * Tests a field copy with added postfix.
      */
     @Test
     public void testCopyFieldWithPostfix() throws Exception {
-        System.out.println("processField");
         LocalDocument doc = new LocalDocument();
         doc.putContentField("test_content", "TESTING 1-2-3!");
         String fromField = "test_";

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/CopyStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/CopyStageTest.java
@@ -1,6 +1,4 @@
 /*
- * Copyright 2012 thomas.gabrielsen.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -23,24 +21,8 @@ import org.junit.*;
  * @author thomas.gabrielsen
  */
 public class CopyStageTest {
-    
+
     public CopyStageTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-    }
-    
-    @Before
-    public void setUp() {
-    }
-    
-    @After
-    public void tearDown() {
     }
 
     /**
@@ -57,7 +39,7 @@ public class CopyStageTest {
         instance.processField(doc, fromField, toField);
         assertEquals("TESTING 1-2-3!", doc.getContentField(toField));
     }
-    
+
     /**
      * Tests a field copy with added prefix.
      */
@@ -72,7 +54,7 @@ public class CopyStageTest {
         instance.processField(doc, fromField, toField);
         assertEquals("TESTING 1-2-3!", doc.getContentField(toField));
     }
-    
+
     /**
      * Tests a field copy with added postfix.
      */

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/CopyStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/CopyStageTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2012 thomas.gabrielsen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.findwise.hydra.stage;
+
+import com.findwise.hydra.local.LocalDocument;
+import org.junit.*;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author thomas.gabrielsen
+ */
+public class CopyStageTest {
+    
+    public CopyStageTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+    
+    @Before
+    public void setUp() {
+    }
+    
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * 
+     */
+    @Test
+    public void testCopyField() throws Exception {
+        System.out.println("processField");
+        LocalDocument doc = new LocalDocument();
+        doc.putContentField("test_content", "TESTING 1-2-3!");
+        String fromField = "test_content";
+        String toField = "content";
+        CopyStage instance = new CopyStage();
+        instance.processField(doc, fromField, toField);
+        assertEquals("TESTING 1-2-3!", doc.getContentField(toField));
+    }
+    
+    /**
+     * 
+     */
+    @Test
+    public void testCopyFieldWithPrefix() throws Exception {
+        System.out.println("processField");
+        LocalDocument doc = new LocalDocument();
+        doc.putContentField("test_content", "TESTING 1-2-3!");
+        String fromField = "content";
+        String toField = "content";
+        CopyStage instance = new CopyStage();
+        instance.setPrefix("test_");
+        instance.processField(doc, fromField, toField);
+        assertEquals("TESTING 1-2-3!", doc.getContentField(toField));
+    }
+    
+    /**
+     * 
+     */
+    @Test
+    public void testCopyFieldWithPostfix() throws Exception {
+        System.out.println("processField");
+        LocalDocument doc = new LocalDocument();
+        doc.putContentField("test_content", "TESTING 1-2-3!");
+        String fromField = "test_";
+        String toField = "content";
+        CopyStage instance = new CopyStage();
+        instance.setPostfix("content");
+        instance.processField(doc, fromField, toField);
+        assertEquals("TESTING 1-2-3!", doc.getContentField(toField));
+    }
+}

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/DocumentDiscardStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/DocumentDiscardStageTest.java
@@ -8,19 +8,15 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.codec.binary.StringUtils;
 import org.apache.http.HttpException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.mockito.internal.util.ListUtil;
 
 import com.findwise.hydra.local.LocalDocument;
 import com.findwise.hydra.local.RemotePipeline;

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/MergeListsStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/MergeListsStageTest.java
@@ -1,18 +1,14 @@
 package com.findwise.hydra.stage;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import com.findwise.hydra.local.LocalDocument;
-import junit.framework.Assert;
 
 public class MergeListsStageTest {
 

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/PrioritizedCopyStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/PrioritizedCopyStageTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 
 public class PrioritizedCopyStageTest {
+
     @Test
     public void testConditionalCopyFalse() throws ProcessException {
 
@@ -35,6 +36,7 @@ public class PrioritizedCopyStageTest {
             fail();
         }
     }
+
     @Test
     public void testConditionalCopyTrue() throws ProcessException {
 
@@ -61,6 +63,7 @@ public class PrioritizedCopyStageTest {
             fail();
         }
     }
+
     @Test
     public void testOverwriteEmptyString() throws ProcessException {
 
@@ -77,12 +80,12 @@ public class PrioritizedCopyStageTest {
         ld.putContentField("emptyfield", "");
         ld.putContentField("copyThis", "stuff_to_be_copied");
         ld.putContentField("copyThis2", "more_stuff_to_be_copied");
-        
+
         s.process(ld);
 
         Assert.assertEquals("stuff_to_be_copied", ld.getContentField("emptyfield"));
     }
-    
+
     @Test
     public void testCopyAlreadyExist() throws ProcessException {
 
@@ -102,7 +105,7 @@ public class PrioritizedCopyStageTest {
         if (!ld.getContentField("a").equals("a")) {
             fail();
         }
-    
+
 
     }
 
@@ -117,7 +120,7 @@ public class PrioritizedCopyStageTest {
 
         s.setInputFields(input);
         s.setOutputField("out1");
-        
+
         s.setOverWrite(true);
 
         LocalDocument ld = new LocalDocument();
@@ -127,10 +130,10 @@ public class PrioritizedCopyStageTest {
         s.process(ld);
 
         Assert.assertEquals("this_is_added", ld.getContentField("out1"));
-    
+
 
     }
-    
+
     @Test
     public void testFoundInFirst() throws ProcessException {
 
@@ -173,7 +176,7 @@ public class PrioritizedCopyStageTest {
             fail();
         }
     }
-    
+
     @Test
     public void testNotFound() throws ProcessException {
 
@@ -194,7 +197,7 @@ public class PrioritizedCopyStageTest {
             fail();
         }
     }
-    
+
     /**
      * Tests a field copy with added prefix.
      */
@@ -212,7 +215,7 @@ public class PrioritizedCopyStageTest {
         instance.process(doc);
         assertEquals("TESTING 1-2-3!", doc.getContentField(outField));
     }
-    
+
     /**
      * Tests a field copy with added postfix.
      */

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/PrioritizedCopyStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/PrioritizedCopyStageTest.java
@@ -1,13 +1,12 @@
 package com.findwise.hydra.stage;
 
-import static org.junit.Assert.fail;
-import org.junit.Test;
-
 import com.findwise.hydra.local.LocalDocument;
-import com.findwise.hydra.stage.ProcessException;
 import java.util.LinkedList;
 import java.util.List;
 import junit.framework.Assert;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import org.junit.Test;
 
 public class PrioritizedCopyStageTest {
     @Test
@@ -175,7 +174,7 @@ public class PrioritizedCopyStageTest {
         }
     }
     
-        @Test
+    @Test
     public void testNotFound() throws ProcessException {
 
         PrioritizedCopyStage s = new PrioritizedCopyStage();
@@ -195,5 +194,40 @@ public class PrioritizedCopyStageTest {
             fail();
         }
     }
-        
+    
+    /**
+     * Tests a field copy with added prefix.
+     */
+    @Test
+    public void testCopyFieldWithPrefix() throws Exception {
+        LocalDocument doc = new LocalDocument();
+        doc.putContentField("test_content", "TESTING 1-2-3!");
+        List<String> inFields = new LinkedList<String>();
+        inFields.add("content");
+        String outField = "content";
+        PrioritizedCopyStage instance = new PrioritizedCopyStage();
+        instance.setPrefix("test_");
+        instance.setInputFields(inFields);
+        instance.setOutputField(outField);
+        instance.process(doc);
+        assertEquals("TESTING 1-2-3!", doc.getContentField(outField));
+    }
+    
+    /**
+     * Tests a field copy with added postfix.
+     */
+    @Test
+    public void testCopyFieldWithPostfix() throws Exception {
+        LocalDocument doc = new LocalDocument();
+        doc.putContentField("test_content", "TESTING 1-2-3!");
+        List<String> inFields = new LinkedList<String>();
+        inFields.add("test_");
+        String outField = "content";
+        PrioritizedCopyStage instance = new PrioritizedCopyStage();
+        instance.setPostfix("content");
+        instance.setInputFields(inFields);
+        instance.setOutputField(outField);
+        instance.process(doc);
+        assertEquals("TESTING 1-2-3!", doc.getContentField(outField));
+    }
 }

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/RegexStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/RegexStageTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
It is not possible to add wildcard postfix and prefix arguments to copyField. That is you can tell it to copy ANYTHING_content to body, for example.  Or phone_ANYTHING to phone_number. 

Also removed some unused imports from basic stages.
