### PR TITLE
Disallowing NUL in MongoDocuments

### DIFF
--- a/core/src/main/java/com/findwise/hydra/net/MarkHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/MarkHandler.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.findwise.hydra.DatabaseConnector;
+import com.findwise.hydra.DatabaseConnector.ConversionException;
 import com.findwise.hydra.DatabaseDocument;
 import com.findwise.hydra.DatabaseType;
 import com.findwise.hydra.common.JsonException;
@@ -50,6 +51,10 @@ public class MarkHandler<T extends DatabaseType> implements ResponsibleHandler {
 			md = dbc.convert(new LocalDocument(requestContent));
 		} catch (JsonException e) {
 			HttpResponseWriter.printJsonException(response, e);
+			return;
+		} catch (ConversionException e) {
+			logger.error("Caught Exception when trying to convert "+requestContent, e);
+			HttpResponseWriter.printBadRequestContent(response);
 			return;
 		}
 		

--- a/core/src/main/java/com/findwise/hydra/net/WriteHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/WriteHandler.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.findwise.hydra.DatabaseConnector;
+import com.findwise.hydra.DatabaseConnector.ConversionException;
 import com.findwise.hydra.DatabaseDocument;
 import com.findwise.hydra.DatabaseType;
 import com.findwise.hydra.common.Document;
@@ -64,7 +65,11 @@ public class WriteHandler<T extends DatabaseType> implements ResponsibleHandler 
         catch(JsonException e) {
         	HttpResponseWriter.printJsonException(response, e);
         	return;
-        }
+        } catch (ConversionException e) {
+			logger.error("Caught Exception when trying to convert "+requestContent, e);
+			HttpResponseWriter.printBadRequestContent(response);
+			return;
+		}
         
         boolean saveRes;
         if(partial.equals("1")) {

--- a/database-impl/mongodb/pom.xml
+++ b/database-impl/mongodb/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>org.mongodb</groupId>
 			<artifactId>mongo-java-driver</artifactId>
-			<version>2.9.1</version>
+			<version>2.9.3</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoConnectorTest.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoConnectorTest.java
@@ -10,8 +10,11 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -21,9 +24,11 @@ import org.junit.Test;
 import com.findwise.hydra.DatabaseDocument;
 import com.findwise.hydra.DatabaseQuery;
 import com.findwise.hydra.TestModule;
+import com.findwise.hydra.DatabaseConnector.ConversionException;
 import com.findwise.hydra.common.Document;
 import com.findwise.hydra.common.DocumentFile;
 import com.findwise.hydra.common.Document.Status;
+import com.findwise.hydra.local.LocalDocument;
 import com.google.inject.Guice;
 import com.mongodb.Mongo;
 
@@ -364,5 +369,41 @@ public class MongoConnectorTest {
 		}
 	}
 	
+	@Test(expected = ConversionException.class)
+	public void testConversionWithNullCharacterInFieldName() throws ConversionException {
+		LocalDocument ld = new LocalDocument();
+		ld.putContentField("field\0000name", "field value");
+		mdc.convert(ld);
+	}
+	
+	@Test(expected = ConversionException.class)
+	public void testConversionWithNullCharacterInList() throws ConversionException {
+		LocalDocument ld = new LocalDocument();
+		ld.putContentField("fieldname", Arrays.asList(new String[] {"some", "string", "with", "null\u0000here"}));
+		mdc.convert(ld);
+	}
 
+	@Test(expected = ConversionException.class)
+	public void testConversionWithNullCharacterInString() throws ConversionException {
+		LocalDocument ld = new LocalDocument();
+		ld.putContentField("fieldname", "some\u0000null");
+		mdc.convert(ld);
+	}
+
+	@Test(expected = ConversionException.class)
+	public void testConversionWithNullCharacterInMap() throws ConversionException {
+		LocalDocument ld = new LocalDocument();
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("NUL \u0000 here", "");
+		ld.putContentField("field", map);
+		try {
+			mdc.convert(ld);
+		} catch (ConversionException e) {
+			map.clear();
+			map.put("nulvalue", "the \u0000 value");
+			ld.putContentField("field", map);
+			mdc.convert(ld);
+		}
+		fail("Was able to put in a map with a null in a field name");
+	}
 }

--- a/database/src/main/java/com/findwise/hydra/DatabaseConnector.java
+++ b/database/src/main/java/com/findwise/hydra/DatabaseConnector.java
@@ -16,7 +16,7 @@ public interface DatabaseConnector<T extends DatabaseType> {
 	/**
 	 * Connect to the database.
 	 */
-	void connect() throws IOException;
+	abstract void connect() throws IOException;
 
 	/**
 	 * Will block execution until the latest write has been pushed though.
@@ -37,7 +37,7 @@ public interface DatabaseConnector<T extends DatabaseType> {
 	
 	DatabaseQuery<T> convert(Query query);
 	
-	DatabaseDocument<T> convert(Document document);
+	DatabaseDocument<T> convert(Document document) throws ConversionException;
 	
 	boolean isConnected();
 
@@ -45,4 +45,19 @@ public interface DatabaseConnector<T extends DatabaseType> {
 	
 	StatusReader<T> getStatusReader();
 	
+	public class ConversionException extends Exception {
+		/**
+		 * Auto generated
+		 */
+		private static final long serialVersionUID = -5921377046346967643L;
+		
+		public ConversionException(String msg) {
+			super(msg);
+		}
+		
+		public ConversionException(String msg, Throwable t) {
+			super(msg, t);
+		}
+		
+	}
 }


### PR DESCRIPTION
Basically, due to https://jira.mongodb.org/browse/SERVER-7691, you can end up in situations where a stage produces a field in a document that contains the NUL-character which will crash your MongoDB instance.

This problem has manifested at one installation while TikaStage was parsing a Microsoft Visio .vsd-file.

convert(Document d)-method can now throw an exception (ConversionException) and the MongoConnector does exactly this if the document contains the NUL character \u0000. 
