### PR TITLE
Fixing 2 bugs related to StageGroups

### DIFF
--- a/core/src/main/java/com/findwise/hydra/StageManager.java
+++ b/core/src/main/java/com/findwise/hydra/StageManager.java
@@ -33,6 +33,19 @@ public final class StageManager {
 		return getRunner(groupName)!=null;
 	}
 	
+	public StageRunner getRunnerForStage(String stageName) {
+		for(StageRunner runner : runnerMap.values()) {
+			if(runner.getStageGroup().hasStage(stageName)) {
+				return runner;
+			}
+		}
+		return null;
+	}
+	
+	public boolean hasRunnerForStage(String stage) {
+		return getRunnerForStage(stage)!=null;
+	}
+	
 	public void addRunner(StageRunner runner) {
 		runnerMap.put(runner.getStageGroup().getName(), runner);
 	}

--- a/core/src/main/java/com/findwise/hydra/StageRunner.java
+++ b/core/src/main/java/com/findwise/hydra/StageRunner.java
@@ -118,6 +118,11 @@ public class StageRunner extends Thread {
     		logger.error("The StageRunner was not prepared prior to being started. Aborting!");
     		return;
     	}
+    	
+    	if(stageGroup.getStages().size()<1) {
+    		logger.info("Stage group "+stageGroup.getName() + " has no stages, and can not be started.");
+    		return;
+    	}
 
         do {
             logger.info("Starting stage group " + stageGroup.getName()
@@ -175,6 +180,7 @@ public class StageRunner extends Thread {
         cmdLine.addArgument(startupArgsString);
         
         HashMap<String, Object> map = new HashMap<String, Object>();
+        
         map.put("file", files.get(0)); //Any of the files should do as a starting point
         map.put("classpath", classPathString);
         

--- a/core/src/main/java/com/findwise/hydra/net/QueryHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/QueryHandler.java
@@ -95,8 +95,9 @@ public class QueryHandler<T extends DatabaseType> implements ResponsibleHandler 
 	
 	private void reportQuery(String stage) {
 		StageManager sm = StageManager.getStageManager();
-		if(sm.hasRunner(stage)) {
-			sm.getRunner(stage).setHasQueried();
+		
+		if(sm.hasRunnerForStage(stage)) {
+			sm.getRunnerForStage(stage).setHasQueried();
 		}
 	}
 


### PR DESCRIPTION
1) An ArrayIndexOutOfBounds was thrown if a group was configured but did not have any active stages.
2) A stage group that did not have a name matching a stage in it, would never be correctly registered as "having queried" leading to that group never getting restarted, should it crash.
