### PR TITLE
Filtering of Tika output to remove garbage output from documents

### DIFF
--- a/stages/processing/tika/src/main/java/com/findwise/hydra/stage/tika/utils/TikaUtils.java
+++ b/stages/processing/tika/src/main/java/com/findwise/hydra/stage/tika/utils/TikaUtils.java
@@ -51,7 +51,7 @@ public class TikaUtils {
 
 	public static void addTextToDocument(LocalDocument doc, String fieldPrefix,
             StringWriter textData) {
-        doc.putContentField(fieldPrefix + "content", textData.toString());
+        doc.putContentField(fieldPrefix + "content", filterInvalidChars(textData.toString()));
     }
 
     public static void addMetadataToDocument(LocalDocument doc, String fieldPrefix,
@@ -59,14 +59,14 @@ public class TikaUtils {
         for (String name : metadata.names()) {
             if (metadata.getValues(name).length > 1) {
                 doc.putContentField(fieldPrefix + name,
-                        Arrays.asList(metadata.getValues(name)));
+                        filterInvalidChars(Arrays.asList(metadata.getValues(name))));
             } else {
-                doc.putContentField(fieldPrefix + name, metadata.get(name));
+                doc.putContentField(fieldPrefix + name, filterInvalidChars(metadata.get(name)));
             }
         }
     }
-    
-    public static void addLanguageToDocument(LocalDocument doc,
+
+	public static void addLanguageToDocument(LocalDocument doc,
 			String fieldPrefix, String text) {
 		doc.putContentField(fieldPrefix + "language", new LanguageIdentifier(text).getLanguage());
 	}
@@ -159,4 +159,29 @@ public class TikaUtils {
 
     	return new URI(scheme, userinfo, host, port, path, query, fragment);
     }
+    
+    public static String filterInvalidChars(String s) {
+    	if (s == null) return null;
+
+        StringBuilder result = new StringBuilder();
+
+        for (int i = 0; i < s.length(); i++) {
+          char c = s.charAt(i);
+          if(Character.isDefined(c) && c!='\uFFFD') {
+        	  result.append(c);
+          }
+        }
+
+        return result.toString();
+    }
+    
+    /**
+     * Modifies list in place, but also returns it for convenience.
+     */
+    public static List<String> filterInvalidChars(List<String> list) {
+		for(int i=0; i<list.size(); i++) {
+			list.set(i, filterInvalidChars(list.get(i)));
+		}
+		return list;
+	}
 }

--- a/stages/processing/tika/src/test/java/com/findwise/hydra/stage/tika/utils/TikaUtilsTest.java
+++ b/stages/processing/tika/src/test/java/com/findwise/hydra/stage/tika/utils/TikaUtilsTest.java
@@ -7,6 +7,7 @@ import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -179,5 +180,21 @@ public class TikaUtilsTest {
 		
 		Assert.assertTrue(doc.hasContentField("x_language"));
 		Assert.assertEquals("en", doc.getContentField("x_language"));
+	}
+	
+	@Test
+	public void testFilterString() throws Exception {
+		String s = new String(new byte[] {-53});
+		System.out.println("char: "+s);
+		Assert.assertEquals("", TikaUtils.filterInvalidChars(s));
+		
+		List<String> list = new ArrayList<String>();
+		list.add("normal");
+		list.add("string with some cool unicode\u0000");
+		list.add("broken"+new String(new byte[]{-30, -3, -123}));
+
+		Assert.assertEquals("normal", TikaUtils.filterInvalidChars(list).get(0));
+		Assert.assertEquals("string with some cool unicode\u0000", TikaUtils.filterInvalidChars(list).get(1));
+		Assert.assertEquals("broken", TikaUtils.filterInvalidChars(list).get(2));
 	}
 }


### PR DESCRIPTION
Tika often decides to include "nonsense" characters that aren't even valid unicode. This adds a filtering function before returning from TikaUtils.
