### PR TITLE
New document endpoint

### DIFF
--- a/admin-service/README.md
+++ b/admin-service/README.md
@@ -371,3 +371,23 @@ Available endpoints
 	    "changedDocuments": [...] (a list of documents as described above)
 	}
 	```
+
+* **/documents/new** - Method: POST
+
+	Inserts a document.
+
+	Available parameters:
+
+		- action: The document action (`ADD`, `UPDATE`, `DELETE`)
+
+	Request content: A document as flat json, containing the content fields.
+
+	Sample document:
+	```
+	{
+		"title" : "A document",
+		"abstract" : "This document is short and contains little information.",
+		"linked_file" : "http://bogus.url/document.xml",
+		"document_id" : "23432451"
+	}
+	```

--- a/admin-service/src/main/java/com/findwise/hydra/admin/documents/DocumentsService.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/documents/DocumentsService.java
@@ -168,7 +168,8 @@ public class DocumentsService<T extends DatabaseType> {
 			
 			DatabaseDocument<T> dbDoc = connector.convert(doc);
 			
-			connector.getDocumentWriter().insert(dbDoc);
+			boolean success = connector.getDocumentWriter().insert(dbDoc);
+			ret.put("success", success);
 		} catch (IllegalArgumentException e) {
 			Map<String, Object> error = new HashMap<String, Object>();
 			error.put("Invalid action", action);

--- a/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
@@ -87,35 +87,22 @@ public class ConfigurationController {
 			@RequestBody String jsonConfig) throws JsonException, IOException {
 		return stagesService.addStage(libraryId, null, stageName, jsonConfig);
 	}
-        
-        @ResponseStatus(HttpStatus.ACCEPTED)
+
+	@ResponseStatus(HttpStatus.ACCEPTED)
 	@RequestMapping(method = RequestMethod.POST, value = "/libraries/{id}/stages/{groupName}/{stageName}")
 	@ResponseBody
 	public Map<String, Object> addStageToGroup(
 			@PathVariable(value = "id") String libraryId,
 			@PathVariable(value = "stageName") String stageName,
-                        @PathVariable(value = "groupName") String groupName,
+			@PathVariable(value = "groupName") String groupName,
 			@RequestBody String jsonConfig) throws JsonException, IOException {
 		return stagesService.addStage(libraryId, groupName, stageName, jsonConfig);
 	}
-
 
 	@ResponseBody
 	@RequestMapping(method = RequestMethod.GET, value = "/stages")
 	public Map<String,List<Stage>> getStages() {
 		return stagesService.getStages();
-	}
-        
-        @ResponseBody
-	@RequestMapping(method = RequestMethod.GET, value = "/stagegroups")
-	public Map<String,List<StageGroup>> getStageGroups() {
-		return stagesService.getStageGroups();
-	}
-        
-        @ResponseBody
-	@RequestMapping(method = RequestMethod.GET, value = "/stagegroups/{stageGroup}")
-	public StageGroup getStageGroup(@PathVariable(value = "stageGroup") String stageGroup) {
-		return stagesService.getStageGroup(stageGroup);
 	}
 	
 	@ResponseBody
@@ -131,6 +118,18 @@ public class ConfigurationController {
 		return stagesService.deleteStage(stageName);
 	}
 
+	@ResponseBody
+	@RequestMapping(method = RequestMethod.GET, value = "/stagegroups")
+	public Map<String,List<StageGroup>> getStageGroups() {
+		return stagesService.getStageGroups();
+	}
+	
+	@ResponseBody
+	@RequestMapping(method = RequestMethod.GET, value = "/stagegroups/{stageGroup}")
+	public StageGroup getStageGroup(@PathVariable(value = "stageGroup") String stageGroup) {
+		return stagesService.getStageGroup(stageGroup);
+	}
+	
 	@ResponseBody
 	@RequestMapping(method = RequestMethod.GET, value = "/documents/count")
 	public Map<String, Object> getDocumentCount(
@@ -154,6 +153,15 @@ public class ConfigurationController {
 			@RequestParam(required = false, defaultValue = "1", value = "limit") int limit,
 			@RequestBody String changes) {
 		return documentService.updateDocuments(jsonQuery, limit, changes);
+	}
+	
+	@ResponseStatus(HttpStatus.ACCEPTED)
+	@ResponseBody
+	@RequestMapping(method = RequestMethod.POST, value = "/documents/new")
+	public Map<String, Object> newDocument(
+			@RequestParam(required = true, defaultValue = "ADD", value = "_action") String action,
+			@RequestBody String content) {
+		return documentService.putDocument(action, content);
 	}
 	
 }


### PR DESCRIPTION
First implementation of an Admin Service endpoint for inserting documents (#109).

The endpoint is `documents/new`. Documents are json and can be POSTed to this endpoint, along with an optional `action` request parameter that sets the document action.

(ugly diff due to differing line endings)
