### PR TITLE
Cache expiration of documents

### DIFF
--- a/core/src/main/java/com/findwise/hydra/Main.java
+++ b/core/src/main/java/com/findwise/hydra/Main.java
@@ -35,6 +35,7 @@ public final class Main {
 		DatabaseConnector<MongoType> backing = new MongoConnector(conf);
 		DatabaseConnector<MemoryType> cache = new MemoryConnector();
 		
+		//NodeMaster nm = new NodeMaster(conf, backing, new Pipeline());
 		NodeMaster nm = new NodeMaster(conf, new CachingDatabaseConnector<MongoType, MemoryType>(backing, cache), new Pipeline());
 		RESTServer server = new RESTServer(conf, new HttpRESTHandler<DatabaseType>(nm.getDatabaseConnector(), conf.isPerformanceLogging()));
 

--- a/core/src/main/java/com/findwise/hydra/Main.java
+++ b/core/src/main/java/com/findwise/hydra/Main.java
@@ -35,7 +35,6 @@ public final class Main {
 		DatabaseConnector<MongoType> backing = new MongoConnector(conf);
 		DatabaseConnector<MemoryType> cache = new MemoryConnector();
 		
-		//NodeMaster nm = new NodeMaster(conf, backing, new Pipeline());
 		NodeMaster<MemoryType> nm = new NodeMaster<MemoryType>(conf, new CachingDatabaseConnector<MongoType, MemoryType>(backing, cache), new Pipeline());
 		RESTServer server = new RESTServer(conf, new HttpRESTHandler<MemoryType>(nm.getDatabaseConnector(), conf.isPerformanceLogging()));
 

--- a/core/src/main/java/com/findwise/hydra/Main.java
+++ b/core/src/main/java/com/findwise/hydra/Main.java
@@ -36,8 +36,8 @@ public final class Main {
 		DatabaseConnector<MemoryType> cache = new MemoryConnector();
 		
 		//NodeMaster nm = new NodeMaster(conf, backing, new Pipeline());
-		NodeMaster nm = new NodeMaster(conf, new CachingDatabaseConnector<MongoType, MemoryType>(backing, cache), new Pipeline());
-		RESTServer server = new RESTServer(conf, new HttpRESTHandler<DatabaseType>(nm.getDatabaseConnector(), conf.isPerformanceLogging()));
+		NodeMaster<MemoryType> nm = new NodeMaster<MemoryType>(conf, new CachingDatabaseConnector<MongoType, MemoryType>(backing, cache), new Pipeline());
+		RESTServer server = new RESTServer(conf, new HttpRESTHandler<MemoryType>(nm.getDatabaseConnector(), conf.isPerformanceLogging()));
 
 		if (!server.blockingStart()) {
 			if (server.hasError()) {

--- a/core/src/main/java/com/findwise/hydra/NodeMaster.java
+++ b/core/src/main/java/com/findwise/hydra/NodeMaster.java
@@ -110,7 +110,7 @@ public final class NodeMaster<T extends DatabaseType> extends Thread {
 	}
 	
 	private void stopGroup(String group) {
-		if(sm.getRunner(group).isAlive()) {
+		if(sm.hasRunner(group) && sm.getRunner(group).isAlive()) {
 			sm.getRunner(group).destroy();
 		} else {
 			logger.debug("StageGroup "+group+" had already terminated");

--- a/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryDocumentIO.java
+++ b/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryDocumentIO.java
@@ -184,7 +184,7 @@ public class MemoryDocumentIO implements DocumentWriter<MemoryType>,
 
 	@Override
 	public MemoryDocument getAndTag(DatabaseQuery<MemoryType> query, String tag) {
-		((MemoryQuery)query).requireNotFetchedBy(tag);
+		((MemoryQuery)query).requireNotFetchedByStage(tag);
 		MemoryDocument d = getDocument(query);
 		if(d!=null) {
 			d.tag(Document.FETCHED_METADATA_TAG, tag);
@@ -194,7 +194,7 @@ public class MemoryDocumentIO implements DocumentWriter<MemoryType>,
 	
 	@Override
 	public Collection<DatabaseDocument<MemoryType>> getAndTag(DatabaseQuery<MemoryType> query, String tag, int n) {
-		((MemoryQuery)query).requireNotFetchedBy(tag);
+		((MemoryQuery)query).requireNotFetchedByStage(tag);
 		List<DatabaseDocument<MemoryType>> docs = getDocuments(query, n);
 		for(int i=0; i<docs.size() && i<n; i++) {
 			DatabaseDocument<MemoryType> d = docs.get(i);

--- a/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryQuery.java
+++ b/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryQuery.java
@@ -18,11 +18,6 @@ public class MemoryQuery extends LocalQuery implements DatabaseQuery<MemoryType>
 		metadataExistsMap = new HashMap<String, Boolean>();
 		fetchedByMap = new HashMap<String, Boolean>();
 	}
-	
-	@Override
-	public void requireContentFieldNotEquals(String fieldName, Object o) {
-		
-	}
 
 	@Override
 	public void requireMetadataFieldEquals(String fieldName, Object o) {
@@ -56,11 +51,11 @@ public class MemoryQuery extends LocalQuery implements DatabaseQuery<MemoryType>
 		return metadataExistsMap;
 	}
 	
-	public void requireFetchedBy(String tag) {
+	public void requireFetchedByStage(String tag) {
 		fetchedByMap.put(tag, true);
 	}
 
-	public void requireNotFetchedBy(String tag) {
+	public void requireNotFetchedByStage(String tag) {
 		fetchedByMap.put(tag, false);
 	}
 

--- a/database-impl/inmemory/src/test/java/com/findwise/hydra/memorydb/MemoryDocumentIOTest.java
+++ b/database-impl/inmemory/src/test/java/com/findwise/hydra/memorydb/MemoryDocumentIOTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 
 import junit.framework.Assert;
@@ -192,6 +193,34 @@ public class MemoryDocumentIOTest {
 		if(d!=null) {
 			fail("Expected all documents to be tagged, but found "+d);
 		}
+	}
+
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testFetchRemoval() throws Exception {
+		MemoryDocument md = new MemoryDocument();
+		md.putContentField("field", "value");
+		MemoryDocumentIO io = new MemoryDocumentIO();
+		io.insert(md);
+
+		io.getAndTag(new MemoryQuery(), "tag");
+
+		MemoryDocument d2 = io.getDocumentById(md.getID());
+		
+		Assert.assertTrue(d2.getMetadataMap().containsKey(MemoryDocument.FETCHED_METADATA_TAG));
+		Map<String, Object> fetched = (Map<String, Object>)d2.getMetadataMap().get(MemoryDocument.FETCHED_METADATA_TAG);
+		
+		Assert.assertTrue(fetched.containsKey("tag"));
+		fetched.remove("tag");
+		
+		MemoryDocument d3 = new MemoryDocument();
+		d3.fromJson(d2.toJson());
+		io.update(d3);
+
+		Assert.assertFalse((
+				(Map<String, Object>) io.getDocumentById(d2.getID()).getMetadataMap().get(MemoryDocument.FETCHED_METADATA_TAG))
+				.containsKey("tag"));
 	}
 
 	@Test

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOTest.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOTest.java
@@ -2,6 +2,7 @@ package com.findwise.hydra.mongodb;
 
 import static org.junit.Assert.fail;
 
+import java.util.Map;
 import java.util.Random;
 
 import junit.framework.Assert;
@@ -265,6 +266,32 @@ public class MongoDocumentIOTest {
 				fail("Processed document did not have the correct data in the content fields");
 			}
 		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testFetchRemoval() throws Exception {
+		MongoDocumentIO dw = (MongoDocumentIO) mdc.getDocumentWriter();
+		MongoDocument md = new MongoDocument();
+		md.putContentField("field", "value");
+		dw.insert(md);
+
+		dw.getAndTag(new MongoQuery(), "tag");
+
+		MongoDocument d2 = dw.getDocumentById(md.getID());
+		
+		System.out.println(d2);
+		Assert.assertTrue(d2.getMetadataMap().containsKey(MongoDocument.FETCHED_METADATA_TAG));
+		Map<String, Object> fetched = (Map<String, Object>)d2.getMetadataMap().get(MongoDocument.FETCHED_METADATA_TAG);
+		
+		Assert.assertTrue(fetched.containsKey("tag"));
+		fetched.remove("tag");
+		
+		dw.update(new MongoDocument(d2.toJson()));
+		
+		Assert.assertFalse((
+				(Map<String, Object>) dw.getDocumentById(d2.getID()).getMetadataMap().get(MongoDocument.FETCHED_METADATA_TAG))
+				.containsKey("tag"));
 	}
 	
 	@Ignore

--- a/database/src/main/java/com/findwise/hydra/CachingDatabaseConnector.java
+++ b/database/src/main/java/com/findwise/hydra/CachingDatabaseConnector.java
@@ -23,6 +23,7 @@ public class CachingDatabaseConnector<BackingType extends DatabaseType, CacheTyp
 		backing.connect();
 		cache.connect();
 		documentio = new CachingDocumentIO<CacheType, BackingType>(cache, backing);
+		documentio.prepare();
 	}
 
 	@Override

--- a/database/src/main/java/com/findwise/hydra/CachingDocumentIO.java
+++ b/database/src/main/java/com/findwise/hydra/CachingDocumentIO.java
@@ -21,6 +21,7 @@ public class CachingDocumentIO<CacheType extends DatabaseType, BackingType exten
 	private static final int DEFAULT_BATCH_SIZE = 10;
 	private static final int DEFAULT_DOCUMENT_TTL_MS = 10000; 
 	public static final String CACHED_TIME_METADATA_KEY = "cached";
+	public static final String CACHE_TAG = "_cache";
 	
 	private DocumentWriter<CacheType> cacheWriter;
 	private DocumentReader<CacheType> cacheReader;
@@ -30,8 +31,6 @@ public class CachingDocumentIO<CacheType extends DatabaseType, BackingType exten
 	private DatabaseConnector<CacheType> cacheConnector;
 	
 	private CacheMonitor monitor;
-	
-	private String cacheTag = "_cache";
 	
 	private int batchSize;
 	private int cacheTTL;
@@ -341,7 +340,7 @@ public class CachingDocumentIO<CacheType extends DatabaseType, BackingType exten
 			backQuery.requireNotFetchedByStage(tag);
 		}
 
-		for (DatabaseDocument<BackingType> dd : backingWriter.getAndTag(backQuery, cacheTag, batchSize)) {
+		for (DatabaseDocument<BackingType> dd : backingWriter.getAndTag(backQuery, CACHE_TAG, batchSize)) {
 			addToCache(convertToCache(dd));
 		}
 	}
@@ -386,8 +385,8 @@ public class CachingDocumentIO<CacheType extends DatabaseType, BackingType exten
 		cacheWriter.delete(doc);
 		@SuppressWarnings("unchecked")
 		Map<String, Object> fetched = (Map<String, Object>) doc.getMetadataMap().get(Document.FETCHED_METADATA_TAG);
-		if(fetched!=null && fetched.containsKey(cacheTag)) {
-			fetched.remove(cacheTag);
+		if(fetched!=null && fetched.containsKey(CACHE_TAG)) {
+			fetched.remove(CACHE_TAG);
 		}
 		backingWriter.update(convert(doc));
 	}

--- a/database/src/main/java/com/findwise/hydra/CachingDocumentIO.java
+++ b/database/src/main/java/com/findwise/hydra/CachingDocumentIO.java
@@ -15,7 +15,6 @@ import com.findwise.hydra.common.DocumentFile;
 import com.findwise.hydra.common.SerializationUtils;
 import com.findwise.hydra.local.LocalQuery;
 
-//TODO: _core tagging introduces a fetching problem. How do we not fill the cache over and over again with the same documents?
 public class CachingDocumentIO<CacheType extends DatabaseType, BackingType extends DatabaseType> implements DocumentReader<CacheType>, DocumentWriter<CacheType> {
 	private static final Logger logger = LoggerFactory.getLogger(CachingDocumentIO.class);
 

--- a/database/src/main/java/com/findwise/hydra/DatabaseQuery.java
+++ b/database/src/main/java/com/findwise/hydra/DatabaseQuery.java
@@ -13,4 +13,6 @@ public interface DatabaseQuery<T extends DatabaseType> extends Query {
 	void requireMetadataFieldExists(String fieldName);
 	
 	void requireMetadataFieldNotExists(String fieldName);
+
+	void requireNotFetchedByStage(String tag);
 }


### PR DESCRIPTION
Documents will now automatically expire periodically from the cache if left unused for a longer period of time (currently 10 seconds by default).

This fixes problems with documents getting stuck in the cache when stages crashed while working with them. It also eases debugging by quite a bit since all changes are now periodically persisted to MongoDB.
