### PR TITLE
Fixes admin-service compilation error due to changes in DatabaseQuery

### DIFF
--- a/admin-service/src/main/java/com/findwise/hydra/admin/database/AdminServiceQuery.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/database/AdminServiceQuery.java
@@ -92,5 +92,9 @@ public class AdminServiceQuery extends LocalQuery implements DatabaseQuery<Admin
 	public void requireMetadataFieldNotExists(String fieldName) {
 		requireMetadataFieldExists.put(fieldName, false);
 	}
-	
+
+	@Override
+	public void requireNotFetchedByStage(String tag) {
+		fetched.put(tag, false);
+	}
 }


### PR DESCRIPTION
This adds the missing `requireNotFetchedByStage()` method to AdminServiceQuery.
