### PR TITLE
Upgrades elasticsearch dependency to latest stable release

### DIFF
--- a/stages/out/elasticsearch-out/pom.xml
+++ b/stages/out/elasticsearch-out/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>org.elasticsearch</groupId>
 			<artifactId>elasticsearch</artifactId>
-			<version>0.20.0.RC1</version>
+			<version>0.20.5</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
The `ElasticsearchOutputStage` used a release candidate of 0.20.0 as dependency. It now uses 0.20.5 instead.
