### PR TITLE
Changes 'examples' to depend on api instead of basic-stages.

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.findwise.hydra</groupId>
     <artifactId>hydra-examples</artifactId>
     <version>0.3.0-SNAPSHOT</version>
-    <name>Hydra Test Setups</name>
+    <name>${artifactId}</name>
     <description>Contains scripts to perform certain manual tests</description>
 
     <build>
@@ -69,7 +69,7 @@
 
         <dependency>
             <groupId>com.findwise.hydra</groupId>
-            <artifactId>hydra-basic-stages</artifactId>
+            <artifactId>hydra-api</artifactId>
             <version>0.3.0-SNAPSHOT</version>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 	<module>database-impl/mongodb</module>
 	<module>database-impl/inmemory</module>
 	<module>core</module>
+	<module>examples</module>
   </modules>
 
   <build>


### PR DESCRIPTION
The dependency on basic-stages is due to old project structure where AbstractStage lived outside api.

Also adds examples to parent build.
