### PR TITLE
Deprecates input stages, fixes compilation errors for the same.

### DIFF
--- a/stages/in/json-in/src/main/java/com/findwise/hydra/input/JsonInputStage.java
+++ b/stages/in/json-in/src/main/java/com/findwise/hydra/input/JsonInputStage.java
@@ -8,8 +8,8 @@ import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpRequestHandler;
 import org.apache.http.util.EntityUtils;
 
-import com.findwise.hydra.common.JsonException;
-import com.findwise.hydra.common.Logger;
+import com.findwise.hydra.JsonException;
+import com.findwise.hydra.Logger;
 import com.findwise.hydra.local.LocalDocument;
 import com.findwise.hydra.stage.AbstractInputStage;
 import com.findwise.hydra.stage.Parameter;
@@ -27,6 +27,7 @@ import com.findwise.hydra.stage.Stage;
  * @author simon.stenstrom
  * 
  */
+@Deprecated
 @Stage
 public class JsonInputStage extends AbstractInputStage implements
 		HttpRequestHandler {

--- a/stages/in/server/src/main/java/com/findwise/hydra/input/HttpInputServer.java
+++ b/stages/in/server/src/main/java/com/findwise/hydra/input/HttpInputServer.java
@@ -27,13 +27,14 @@ import org.apache.http.protocol.ResponseContent;
 import org.apache.http.protocol.ResponseDate;
 import org.apache.http.protocol.ResponseServer;
 
-import com.findwise.hydra.common.Logger;
+import com.findwise.hydra.Logger;
 
 /**
  * Sets up a HTTP Input server on the specified port.
  * 
  * @author joel.westberg
  */
+@Deprecated
 public class HttpInputServer {
 
 	private static final int SOCKET_TIMEOUT_MS = 5000;

--- a/stages/in/solr-in/src/main/java/com/findwise/hydra/input/solr/SolrInputStage.java
+++ b/stages/in/solr-in/src/main/java/com/findwise/hydra/input/solr/SolrInputStage.java
@@ -24,9 +24,9 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-import com.findwise.hydra.common.Document.Action;
-import com.findwise.hydra.common.JsonException;
-import com.findwise.hydra.common.Logger;
+import com.findwise.hydra.Document.Action;
+import com.findwise.hydra.JsonException;
+import com.findwise.hydra.Logger;
 import com.findwise.hydra.input.HttpInputServer;
 import com.findwise.hydra.local.LocalDocument;
 import com.findwise.hydra.stage.AbstractInputStage;
@@ -34,6 +34,7 @@ import com.findwise.hydra.stage.Parameter;
 import com.findwise.hydra.stage.RequiredArgumentMissingException;
 import com.findwise.hydra.stage.Stage;
 
+@Deprecated
 @Stage
 public class SolrInputStage extends AbstractInputStage implements HttpRequestHandler {
 

--- a/stages/in/solr-in/src/test/java/com/findwise/hydra/input/solr/SolrInputStageTest.java
+++ b/stages/in/solr-in/src/test/java/com/findwise/hydra/input/solr/SolrInputStageTest.java
@@ -11,8 +11,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 
-import com.findwise.hydra.common.Document.Action;
-import com.findwise.hydra.common.JsonException;
+import com.findwise.hydra.Document.Action;
+import com.findwise.hydra.JsonException;
 import com.findwise.hydra.local.LocalDocument;
 import com.findwise.hydra.local.RemotePipeline;
 


### PR DESCRIPTION
This fixes compilation errors missed because the input stages are unused. The stages are also now deprecated and should be removed in a future release.
