### PR TITLE
Adds resource.properties to bin folder alongside built hydra-core.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -176,6 +176,24 @@
 
 		<plugins>
 			<plugin>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>1.4</version>
+				<executions>
+					<execution>
+						<id>copy</id>
+						<phase>compile</phase>
+						<configuration>
+							<tasks>
+								<copy file="src/main/resources/resource.properties" tofile="target/resource.properties" />
+							</tasks>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>

--- a/core/src/main/resources/resource.properties
+++ b/core/src/main/resources/resource.properties
@@ -1,8 +1,15 @@
-database_url = localhost
-polling_interval = 10
+# Core
 namespace = pipeline
+polling_interval = 10
+performance_logging = false
+# Port for Hydra core-to-stage communication
+#rest_port = 12001
+
+# Backing database
+database_url = localhost
 database_user = admin
 database_password = changeme
+
+# oldDocuments
 old_max_count = 2000
 old_max_size_mb = 200
-performance_logging = false

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
           <configuration>
             <tasks>
               <copy file="core/target/hydra-core-jar-with-dependencies.jar" tofile="bin/hydra-core.jar"/>
+              <copy file="core/target/resource.properties" tofile="bin/resource.properties"/>
             </tasks>
           </configuration>
           <goals>


### PR DESCRIPTION
Adds some comments to properties file, and the missing `rest_port` configuration option. This should be all required in #133.
