### PR TITLE
Added stages as submodule to parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
 	<module>database-impl/inmemory</module>
 	<module>core</module>
 	<module>examples</module>
+    <module>stages</module>
   </modules>
 
   <build>

--- a/stages/pom.xml
+++ b/stages/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.findwise.hydra</groupId>
+    <artifactId>stages</artifactId>
+    <version>0.3.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>debugging/debugging</module>
+        <module>in/json-in</module>
+        <module>in/server</module>
+        <module>in/solr-in</module>
+        <module>out/elasticsearch-out</module>
+        <module>out/solr-out</module>
+        <module>out/solr-out-3.6</module>
+        <module>processing/basic</module>
+        <module>processing/hydra-groovy-runner</module>
+        <module>processing/tika</module>
+        <module>processing/web</module>
+    </modules>
+</project>


### PR DESCRIPTION
Now builds all stages as part of the primary build. This should help ensure that the components are built in the correct order, and that all stages are being tested when the core changes.
