### PR TITLE
Fixes admin service not being able to remove stages in stagegroups.

### DIFF
--- a/admin-service/src/main/java/com/findwise/hydra/admin/stages/StagesService.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/stages/StagesService.java
@@ -115,7 +115,7 @@ public class StagesService<T extends DatabaseType> {
 		} else {
 			Pipeline pipeline = connector.getPipelineReader().getPipeline();
 			if(groupName == null) {
-				groupName = stageToDelete.getName();
+				groupName = getStageGroupForStage(stageToDelete);
 			}
 			if(!pipeline.hasGroup(groupName)) {
 				pipeline.addGroup(new StageGroup(groupName));
@@ -126,5 +126,14 @@ public class StagesService<T extends DatabaseType> {
 			ret.put("stageStatus", "Deleted stage " + stageName);
 		}
 		return ret;
+	}
+
+	private String getStageGroupForStage(Stage stageToDelete) {
+		StageGroup groupForStage = connector.getPipelineReader().getPipeline().getGroupForStage(stageToDelete.getName());
+		if (groupForStage != null) {
+			return groupForStage.getName();
+		} else {
+			return stageToDelete.getName();
+		}
 	}
 }

--- a/database/src/main/java/com/findwise/hydra/Pipeline.java
+++ b/database/src/main/java/com/findwise/hydra/Pipeline.java
@@ -86,6 +86,15 @@ public class Pipeline {
 		return null;
 	}
 	
+	public StageGroup getGroupForStage(String name) {
+		for (StageGroup g : getStageGroups()) {
+			if (g.hasStage(name)) {
+				return g;
+			}
+		}
+		return null;
+	}
+	
 	public boolean hasStage(String name) {
 		return getStage(name) != null;
 	}


### PR DESCRIPTION
Changes `/stages/{stagename}/delete` to get hold of the stage group instead of always using the stage name as the group.

Fixes #141 
