### PR TITLE
Added support for "atomic" insert of documents with attachments

### DIFF
--- a/api/src/main/java/com/findwise/hydra/Document.java
+++ b/api/src/main/java/com/findwise/hydra/Document.java
@@ -15,6 +15,7 @@ public interface Document<Type> extends JsonDeserializer, JsonSerializer {
 	String ACTION_KEY = "_action";
 	String CONTENTS_KEY = "contents";
 	String METADATA_KEY = "metadata";
+	String COMMITTING_METADATA_FLAG = "committing";
 	String PENDING_METADATA_FLAG = "pending";
 	String PROCESSED_METADATA_FLAG = "processed";
 	String DISCARDED_METADATA_FLAG = "discarded";

--- a/database-impl/inmemory/pom.xml
+++ b/database-impl/inmemory/pom.xml
@@ -57,6 +57,12 @@
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.9.5</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryDocument.java
+++ b/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryDocument.java
@@ -251,6 +251,11 @@ public class MemoryDocument implements DatabaseDocument<MemoryType> {
 	}
 
 	@Override
+	public Object getMetadataField(String key) {
+		return getMetadataMap().get(key);
+	}
+
+	@Override
 	public Map<String, Object> getMetadataMap() {
 		return doc.getMetadataMap();
 	}

--- a/database-impl/mongodb/pom.xml
+++ b/database-impl/mongodb/pom.xml
@@ -56,6 +56,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.9.5</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>1.6.4</version>

--- a/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocument.java
+++ b/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocument.java
@@ -173,7 +173,8 @@ public class MongoDocument implements DBObject, DatabaseDocument<MongoType> {
 	public Object getContentField(String key) {
 		return getContents().get(key);
 	}
-	
+
+	@Override
 	public Object getMetadataField(String key) {
 		return getMetadata().get(key);
 	}

--- a/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocument.java
+++ b/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocument.java
@@ -169,7 +169,8 @@ public class MongoDocument implements DBObject, DatabaseDocument<MongoType> {
 		touchedContent.add(key);
 		return getContents().put(key, v);
 	}
-	
+
+	@Override
 	public Object getContentField(String key) {
 		return getContents().get(key);
 	}

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOTest.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOTest.java
@@ -289,11 +289,6 @@ public class MongoDocumentIOTest {
 		dw.update(new MongoDocument(d2.toJson()));
 		
 		Assert.assertFalse(dw.getDocumentById(d2.getID()).fetchedBy("tag"));
-		
-		d2 = dw.getAndTag(new MongoQuery(), "tag", "tag2");
-		d2.removeFetchedBy("tag");
-		
-		dw.update(d2);
 	}
 	
 	

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOTest.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOTest.java
@@ -275,7 +275,9 @@ public class MongoDocumentIOTest {
 		md.putContentField("field", "value");
 		dw.insert(md);
 
-		dw.getAndTag(new MongoQuery(), "tag");
+		MongoQuery mongoQuery = new MongoQuery();
+		mongoQuery.requireID(md.getID());
+		dw.getAndTag(mongoQuery, "tag");
 
 		MongoDocument d2 = dw.getDocumentById(md.getID());
 

--- a/database/src/main/java/com/findwise/hydra/CachingDocumentNIO.java
+++ b/database/src/main/java/com/findwise/hydra/CachingDocumentNIO.java
@@ -2,7 +2,9 @@ package com.findwise.hydra;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.Date;
 import java.util.List;
@@ -163,6 +165,11 @@ public class CachingDocumentNIO<T extends DatabaseType> implements
 	@Override
 	public boolean insert(DatabaseDocument<T> d) {
 		return writer.insert(d);
+	}
+
+	@Override
+	public boolean insert(DatabaseDocument<T> d, List<DocumentFile<T>> attachments) {
+		return writer.insert(d, attachments);
 	}
 
 	@Override

--- a/database/src/main/java/com/findwise/hydra/DatabaseDocument.java
+++ b/database/src/main/java/com/findwise/hydra/DatabaseDocument.java
@@ -9,6 +9,8 @@ public interface DatabaseDocument<T extends DatabaseType> extends Document<T> {
 
 	Object putMetadataField(String key, Object value);
 
+	Object getMetadataField(String key);
+
 	boolean removeTouchedBy(String stage);
 	
 	boolean removeFetchedBy(String stage);

--- a/database/src/main/java/com/findwise/hydra/DocumentWriter.java
+++ b/database/src/main/java/com/findwise/hydra/DocumentWriter.java
@@ -2,6 +2,7 @@ package com.findwise.hydra;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 
 import com.findwise.hydra.DocumentFile;
 
@@ -145,7 +146,7 @@ public interface DocumentWriter<T extends DatabaseType> {
 	 * Inserts a new document into the database. Will fail if the document
 	 * already has a non-null ID. The document's new ID will be applied to the
 	 * document.
-	 * 
+	 *
 	 * A field that is <pre>null</pre> is ignored.
 	 * 
 	 * @param d
@@ -153,7 +154,26 @@ public interface DocumentWriter<T extends DatabaseType> {
 	 * @return false if the document already has an id, true otherwise.
 	 */
 	boolean insert(DatabaseDocument<T> d);
-	
+
+	/**
+	 * Inserts a new document into the database. Will fail if the document
+	 * already has a non-null ID. The document's new ID will be applied to the
+	 * document. Until the attachments have been committed, the document will have
+	 * metadata field <pre>committing</pre> set to <pre>true</pre>; after they have been committed,
+	 * it will be set to <pre>false</pre>.
+	 *
+	 * A field that is <pre>null</pre> is ignored.
+	 *
+	 * @param d
+	 *            the document to insert
+	 * @param attachments
+	 *            Any number of DocumentFile attachments belonging to the document.
+	 *            The document ID for each DocumentFile will be overwritten using the
+	 *            new ID obtained for the document, before the document files are
+	 *            committed.
+	 * @return false if the document already has an id, true otherwise.
+	 */
+	boolean insert(DatabaseDocument<T> d, List<DocumentFile<T>> attachments);
 	/**
 	 * Updates the document in the database. If any field in document is 
 	 * <pre>null</pre>, this field will be ignored and removed. 

--- a/database/src/test/java/com/findwise/hydra/CachingDocumentNIOTest.java
+++ b/database/src/test/java/com/findwise/hydra/CachingDocumentNIOTest.java
@@ -228,6 +228,16 @@ public class CachingDocumentNIOTest {
 	}
 
 	@Test
+	public void testInsertWithAttachments() {
+		DocumentFile<TestType> mock = mock(DocumentFile.class);
+		List<DocumentFile<TestType>> attachments = Arrays.asList(mock);
+		io.insert(doc1, attachments);
+
+		verifyNoMoreInteractions(cache);
+		verify(writer, times(1)).insert(doc1, attachments);
+	}
+
+	@Test
 	public void testInsert() {
 		io.insert(doc1);
 


### PR DESCRIPTION
Hey,

Here's my suggestion of a fix for the race condition when adding documents with attachments (#198). Basically, here's what's been done:

1) Added new `DocumentWriter.insert`:

``` java
boolean insert(DatabaseDocument<T> d, List<DocumentFile<T>> attachments);
```

2) Changed corresponding implementation in `MongoDocumentIO` to set a metadata flag on the document to make `getAndTag` ignore it until all the attachments have been committed.

To understand the behaviour, I suggest looking at the new tests in `MongoDocumentIOTest`.

The other commits are basically a bit of cleaning to simplify the implementation.
