### PR TITLE
Changes unit tests that test integration into actual integration tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,6 +24,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<surefire.version>2.9</surefire.version>
+		<failsafe.version>2.9</failsafe.version>
 	</properties>
 	
 	<developers>
@@ -42,13 +44,26 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
-						<version>2.9</version>
+						<version>${surefire.version}</version>
 						<configuration>
 							<includes>
 								<include>**/**/*.java</include>
 							</includes>
 							<forkMode>once</forkMode>
 						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<version>${surefire.version}</version>
+						<executions>
+							<execution>
+								<goals>
+									<goal>integration-test</goal>
+									<goal>verify</goal>
+								</goals>
+							</execution>
+						</executions>
 					</plugin>
 				</plugins>
 			</build>
@@ -65,12 +80,25 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
-						<version>2.9</version>
+						<version>${failsafe.version}</version>
 						<configuration>
 							<excludes>
 								<exclude>**/**/*StressTest.java</exclude>
 							</excludes>
 						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<version>${failsafe.version}</version>
+						<executions>
+							<execution>
+								<goals>
+									<goal>integration-test</goal>
+									<goal>verify</goal>
+								</goals>
+							</execution>
+						</executions>
 					</plugin>
 				</plugins>
 			</build>
@@ -207,7 +235,6 @@
 				<configuration>
 					<source>1.6</source>
 					<target>1.6</target>
-
 					<archive>
 						<manifest>
 							<addClasspath>true</addClasspath>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -55,7 +55,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-failsafe-plugin</artifactId>
-						<version>${surefire.version}</version>
+						<version>${failsafe.version}</version>
 						<executions>
 							<execution>
 								<goals>
@@ -80,7 +80,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
-						<version>${failsafe.version}</version>
+						<version>${surefire.version}</version>
 						<configuration>
 							<excludes>
 								<exclude>**/**/*StressTest.java</exclude>

--- a/core/src/test/java/com/findwise/hydra/net/RemotePipelineIT.java
+++ b/core/src/test/java/com/findwise/hydra/net/RemotePipelineIT.java
@@ -29,7 +29,7 @@ import com.findwise.hydra.mongodb.MongoDocumentID;
 import com.findwise.hydra.mongodb.MongoType;
 import com.mongodb.Mongo;
 
-public class RemotePipelineTest {
+public class RemotePipelineIT {
 	private static NodeMaster<MongoType> nm;
 	private MongoDocument test, test2;
 	private static MongoConnector dbc;

--- a/database-impl/mongodb/pom.xml
+++ b/database-impl/mongodb/pom.xml
@@ -105,6 +105,19 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>2.9</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 				<executions>
 					<execution>

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoConnectorIT.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoConnectorIT.java
@@ -31,7 +31,7 @@ import com.findwise.hydra.DocumentID;
 import com.findwise.hydra.local.LocalDocument;
 import com.mongodb.Mongo;
 
-public class MongoConnectorTest {
+public class MongoConnectorIT {
 	MongoConnector mdc;
 	MongoDocument test;
 	MongoDocument test2;

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOIT.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOIT.java
@@ -33,7 +33,7 @@ import com.mongodb.WriteConcern;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-public class MongoDocumentIOTest {
+public class MongoDocumentIOIT {
 	private MongoConnector mdc;
 	
 	private Random r = new Random(System.currentTimeMillis());

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoPipelineIOIT.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoPipelineIOIT.java
@@ -22,7 +22,7 @@ import com.findwise.hydra.StageGroup;
 import com.mongodb.Mongo;
 import com.mongodb.WriteConcern;
 
-public class MongoPipelineIOTest {
+public class MongoPipelineIOIT {
 	MongoConnector mdc;
 	
 	private void createAndConnect() throws Exception {

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoStatusIOIT.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoStatusIOIT.java
@@ -12,7 +12,7 @@ import com.mongodb.DB;
 import com.mongodb.Mongo;
 import com.mongodb.MongoException;
 
-public class MongoStatusIOTest {
+public class MongoStatusIOIT {
 	private DB db;
 	
 	@Before

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/QueryIT.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/QueryIT.java
@@ -23,7 +23,7 @@ import com.mongodb.Mongo;
  * @author joel.westberg
  *
  */
-public class QueryTest {
+public class QueryIT {
 
 	MongoConnector mdc;
 	DatabaseDocument<MongoType> test;

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/TaggingModelIT.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/TaggingModelIT.java
@@ -8,7 +8,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 
-public class TaggingModelTest {
+public class TaggingModelIT {
 	MongoConnector mdc;
 
 	private void createAndConnect() throws Exception {
@@ -36,7 +36,7 @@ public class TaggingModelTest {
 	
 	@AfterClass
 	public static void tearDown() throws Exception {
-		TaggingModelTest tmt = new TaggingModelTest();
+		TaggingModelIT tmt = new TaggingModelIT();
 		tmt.createAndConnect();
 		tmt.mdc.getDB().dropDatabase();
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
       <executions>
         <execution>
           <id>copy</id>
-          <phase>compile</phase>
+          <phase>package</phase>
           <configuration>
             <tasks>
               <copy file="core/target/hydra-core-jar-with-dependencies.jar" tofile="bin/hydra-core.jar"/>

--- a/stages/out/elasticsearch-out/pom.xml
+++ b/stages/out/elasticsearch-out/pom.xml
@@ -103,7 +103,19 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.9</version>
 			</plugin>
-
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>2.9</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
@@ -148,18 +160,6 @@
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>2.6</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>integration-test</goal>
-							<goal>verify</goal>
 						</goals>
 					</execution>
 				</executions>


### PR DESCRIPTION
Also moves the antrun task for copying `hydra-core.jar` into the binary folder to the `package` task, to allow running the `test` goal without hydra-parent failing.

Integration tests have the format `*IT.java`, and are run with `maven-failsafe-plugin`.

Some ways to build are now:
`mvn clean test`: Runs unit tests
`mvn clean verify`: Runs unit tests and integration tests
`mvn clean install`: Runs unit tests, integrations tests and installs the artifacts

This will partly resolve #112, but these integration tests should be replaced with mocking unit tests.
