### PR TITLE
Makes all children modules use parent pom

### DIFF
--- a/admin-service/pom.xml
+++ b/admin-service/pom.xml
@@ -24,18 +24,6 @@
 	
 	<build>
 		<finalName>hydra</finalName>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-					<encoding>UTF-8</encoding>
-				</configuration>
-			</plugin>
-		</plugins>
 	</build>
 
 	<dependencies>

--- a/admin-service/pom.xml
+++ b/admin-service/pom.xml
@@ -14,14 +14,6 @@
 		<cglib.version>2.2.2</cglib.version>
 	</properties>
 
-	<developers>
-		<developer>
-			<id>findwise</id>
-			<name>Findwise</name>
-			<email>hydra-processing@googlegroups.com</email>
-		</developer>
-	</developers>
-	
 	<build>
 		<finalName>hydra</finalName>
 	</build>

--- a/admin-service/pom.xml
+++ b/admin-service/pom.xml
@@ -1,9 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.findwise.hydra</groupId>
+	<parent>
+		<groupId>com.findwise.hydra</groupId>
+		<artifactId>hydra-parent</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+	</parent>
 	<artifactId>hydra-admin-service</artifactId>
-	<version>0.4.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 
 	<properties>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -11,14 +11,6 @@
 	<name>${project.artifactId}</name>
 	<description>Hydra API</description>
 
-	<developers>
-		<developer>
-			<id>findwise</id>
-			<name>Findwise</name>
-			<email>hydra-processing@googlegroups.com</email>
-		</developer>
-	</developers>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -11,14 +11,6 @@
 	<name>${project.artifactId}</name>
 	<description>Hydra API</description>
 
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
-
 	<scm>
 		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
 		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -11,12 +11,6 @@
 	<name>${project.artifactId}</name>
 	<description>Hydra API</description>
 
-	<scm>
-		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
-		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>
-		<url>https://github.com/Findwise/Hydra</url>
-	</scm>
-
 	<developers>
 		<developer>
 			<id>findwise</id>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,10 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.findwise.hydra</groupId>
+	<parent>
+		<groupId>com.findwise.hydra</groupId>
+		<artifactId>hydra-parent</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+	</parent>
 	<artifactId>hydra-api</artifactId>
 	<packaging>jar</packaging>
-	<version>0.4.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>Hydra API</description>
 	<url>http://findwise.github.com/Hydra</url>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -26,10 +26,6 @@
 		<url>https://github.com/Findwise/Hydra</url>
 	</scm>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
-
 	<developers>
 		<developer>
 			<id>findwise</id>
@@ -76,14 +72,6 @@
 	<build>
 		<finalName>${project.name}</finalName>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -10,7 +10,6 @@
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
 	<description>Hydra API</description>
-	<url>http://findwise.github.com/Hydra</url>
 
 	<licenses>
 		<license>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,9 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.findwise.hydra</groupId>
+	<parent>
+		<groupId>com.findwise.hydra</groupId>
+		<artifactId>hydra-parent</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+	</parent>
 	<artifactId>hydra-core</artifactId>
 	<packaging>jar</packaging>
-	<version>0.4.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>Hydra Core - The main runnable artifact of Hydra</description>
 	<url>http://findwise.github.com/Hydra</url>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,12 +10,6 @@
 	<name>${project.artifactId}</name>
 	<description>Hydra Core - The main runnable artifact of Hydra</description>
 
-	<scm>
-		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
-		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>
-		<url>https://github.com/Findwise/Hydra</url>
-	</scm>
-
 	<properties>
 		<surefire.version>2.9</surefire.version>
 		<failsafe.version>2.9</failsafe.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -9,7 +9,6 @@
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
 	<description>Hydra Core - The main runnable artifact of Hydra</description>
-	<url>http://findwise.github.com/Hydra</url>
 
 	<licenses>
 		<license>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,14 +10,6 @@
 	<name>${project.artifactId}</name>
 	<description>Hydra Core - The main runnable artifact of Hydra</description>
 
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
-
 	<scm>
 		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
 		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,15 +14,7 @@
 		<surefire.version>2.9</surefire.version>
 		<failsafe.version>2.9</failsafe.version>
 	</properties>
-	
-	<developers>
-		<developer>
-			<id>findwise</id>
-			<name>Findwise</name>
-			<email>hydra-processing@googlegroups.com</email>
-		</developer>
-	</developers>
-	
+
 	<profiles>
 		<profile>
 			<id>stresstest</id>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,7 +26,6 @@
 	</scm>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<surefire.version>2.9</surefire.version>
 		<failsafe.version>2.9</failsafe.version>
 	</properties>
@@ -222,8 +221,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
 					<archive>
 						<manifest>
 							<addClasspath>true</addClasspath>

--- a/database-impl/inmemory/pom.xml
+++ b/database-impl/inmemory/pom.xml
@@ -12,14 +12,6 @@
 	<name>${project.artifactId}</name>
 	<description>Hydra Inmemory database implementation</description>
 
-	<developers>
-		<developer>
-			<id>findwise</id>
-			<name>Findwise</name>
-			<email>hydra-processing@googlegroups.com</email>
-		</developer>
-	</developers>
-
 	<dependencies>
 		<dependency>
 			<groupId>com.findwise.hydra</groupId>

--- a/database-impl/inmemory/pom.xml
+++ b/database-impl/inmemory/pom.xml
@@ -1,10 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.findwise.hydra</groupId>
+	<parent>
+		<groupId>com.findwise.hydra</groupId>
+		<artifactId>hydra-parent</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+	</parent>
 	<artifactId>hydra-memorydb</artifactId>
 	<packaging>jar</packaging>
-	<version>0.4.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>Hydra Inmemory database implementation</description>
 	<url>http://findwise.github.com/Hydra</url>

--- a/database-impl/inmemory/pom.xml
+++ b/database-impl/inmemory/pom.xml
@@ -11,7 +11,6 @@
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
 	<description>Hydra Inmemory database implementation</description>
-	<url>http://findwise.github.com/Hydra</url>
 
 	<licenses>
 		<license>

--- a/database-impl/inmemory/pom.xml
+++ b/database-impl/inmemory/pom.xml
@@ -12,12 +12,6 @@
 	<name>${project.artifactId}</name>
 	<description>Hydra Inmemory database implementation</description>
 
-	<scm>
-		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
-		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>
-		<url>https://github.com/Findwise/Hydra</url>
-	</scm>
-
 	<developers>
 		<developer>
 			<id>findwise</id>

--- a/database-impl/inmemory/pom.xml
+++ b/database-impl/inmemory/pom.xml
@@ -5,6 +5,7 @@
 		<groupId>com.findwise.hydra</groupId>
 		<artifactId>hydra-parent</artifactId>
 		<version>0.4.0-SNAPSHOT</version>
+		<relativePath>../..</relativePath>
 	</parent>
 	<artifactId>hydra-memorydb</artifactId>
 	<packaging>jar</packaging>

--- a/database-impl/inmemory/pom.xml
+++ b/database-impl/inmemory/pom.xml
@@ -26,11 +26,7 @@
 		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>
 		<url>https://github.com/Findwise/Hydra</url>
 	</scm>
-	
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
-	
+
 	<developers>
 		<developer>
 			<id>findwise</id>
@@ -73,15 +69,6 @@
 		<finalName>${project.name}</finalName>
 
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>
-						1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>

--- a/database-impl/inmemory/pom.xml
+++ b/database-impl/inmemory/pom.xml
@@ -12,14 +12,6 @@
 	<name>${project.artifactId}</name>
 	<description>Hydra Inmemory database implementation</description>
 
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
-
 	<scm>
 		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
 		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>

--- a/database-impl/mongodb/pom.xml
+++ b/database-impl/mongodb/pom.xml
@@ -4,6 +4,7 @@
 		<groupId>com.findwise.hydra</groupId>
 		<artifactId>hydra-parent</artifactId>
 		<version>0.4.0-SNAPSHOT</version>
+		<relativePath>../..</relativePath>
 	</parent>
 	<artifactId>hydra-mongodb</artifactId>
 	<packaging>jar</packaging>

--- a/database-impl/mongodb/pom.xml
+++ b/database-impl/mongodb/pom.xml
@@ -26,10 +26,6 @@
 		<url>https://github.com/Findwise/Hydra</url>
 	</scm>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
-	
 	<developers>
 		<developer>
 			<id>findwise</id>
@@ -86,15 +82,6 @@
 		<finalName>${project.name}</finalName>
 
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>
-						1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>

--- a/database-impl/mongodb/pom.xml
+++ b/database-impl/mongodb/pom.xml
@@ -11,12 +11,6 @@
 	<name>${project.artifactId}</name>
 	<description>Hydra Database Package - Database interfaces AND MongoDB implementation</description>
 
-	<scm>
-		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
-		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>
-		<url>https://github.com/Findwise/Hydra</url>
-	</scm>
-
 	<developers>
 		<developer>
 			<id>findwise</id>

--- a/database-impl/mongodb/pom.xml
+++ b/database-impl/mongodb/pom.xml
@@ -1,9 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.findwise.hydra</groupId>
+	<parent>
+		<groupId>com.findwise.hydra</groupId>
+		<artifactId>hydra-parent</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+	</parent>
 	<artifactId>hydra-mongodb</artifactId>
 	<packaging>jar</packaging>
-	<version>0.4.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>Hydra Database Package - Database interfaces AND MongoDB implementation</description>
 	<url>http://findwise.github.com/Hydra</url>

--- a/database-impl/mongodb/pom.xml
+++ b/database-impl/mongodb/pom.xml
@@ -11,14 +11,6 @@
 	<name>${project.artifactId}</name>
 	<description>Hydra Database Package - Database interfaces AND MongoDB implementation</description>
 
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
-
 	<scm>
 		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
 		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>

--- a/database-impl/mongodb/pom.xml
+++ b/database-impl/mongodb/pom.xml
@@ -10,7 +10,6 @@
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
 	<description>Hydra Database Package - Database interfaces AND MongoDB implementation</description>
-	<url>http://findwise.github.com/Hydra</url>
 
 	<licenses>
 		<license>

--- a/database-impl/mongodb/pom.xml
+++ b/database-impl/mongodb/pom.xml
@@ -11,14 +11,6 @@
 	<name>${project.artifactId}</name>
 	<description>Hydra Database Package - Database interfaces AND MongoDB implementation</description>
 
-	<developers>
-		<developer>
-			<id>findwise</id>
-			<name>Findwise</name>
-			<email>hydra-processing@googlegroups.com</email>
-		</developer>
-	</developers>
-
 	<dependencies>
 		<dependency>
 			<groupId>com.findwise.hydra</groupId>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -1,9 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.findwise.hydra</groupId>
+	<parent>
+		<groupId>com.findwise.hydra</groupId>
+		<artifactId>hydra-parent</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+	</parent>
 	<artifactId>hydra-database</artifactId>
 	<packaging>jar</packaging>
-	<version>0.4.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>Hydra Database Package - Database interfaces</description>
 	<url>http://findwise.github.com/Hydra</url>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -9,7 +9,6 @@
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
 	<description>Hydra Database Package - Database interfaces</description>
-	<url>http://findwise.github.com/Hydra</url>
 
 	<licenses>
 		<license>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -25,10 +25,6 @@
 		<url>https://github.com/Findwise/Hydra</url>
 	</scm>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
-	
 	<developers>
 		<developer>
 			<id>findwise</id>
@@ -71,14 +67,6 @@
 		<finalName>${project.name}</finalName>
 
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -10,12 +10,6 @@
 	<name>${project.artifactId}</name>
 	<description>Hydra Database Package - Database interfaces</description>
 
-	<scm>
-		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
-		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>
-		<url>https://github.com/Findwise/Hydra</url>
-	</scm>
-
 	<developers>
 		<developer>
 			<id>findwise</id>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -10,14 +10,6 @@
 	<name>${project.artifactId}</name>
 	<description>Hydra Database Package - Database interfaces</description>
 
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
-
 	<scm>
 		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
 		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -10,14 +10,6 @@
 	<name>${project.artifactId}</name>
 	<description>Hydra Database Package - Database interfaces</description>
 
-	<developers>
-		<developer>
-			<id>findwise</id>
-			<name>Findwise</name>
-			<email>hydra-processing@googlegroups.com</email>
-		</developer>
-	</developers>
-
 	<dependencies>
 		<dependency>
 			<groupId>com.findwise.hydra</groupId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.findwise.hydra</groupId>
+		<artifactId>hydra-parent</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>distribution</artifactId>
+	<packaging>pom</packaging>
+
+	<!-- By adding hydra-core as a dependency, we are guaranteed that it is built by the reactor before the
+	     antrun plugin below -->
+	<dependencies>
+		<dependency>
+			<groupId>com.findwise.hydra</groupId>
+			<artifactId>hydra-core</artifactId>
+			<version>0.4.0-SNAPSHOT</version>
+			<classifier>jar-with-dependencies</classifier>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>1.4</version>
+				<executions>
+					<execution>
+						<id>copy</id>
+						<phase>package</phase>
+						<inherited>false</inherited>
+						<configuration>
+							<tasks>
+								<copy file="../core/target/hydra-core-jar-with-dependencies.jar"
+								      tofile="bin/hydra-core.jar"/>
+								<copy file="../core/target/resource.properties" tofile="bin/resource.properties"/>
+							</tasks>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -15,11 +15,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.0.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                    <encoding>${project.build.sourceEncoding}</encoding>
                     <archive>
                         <manifest>
                             <addClasspath>true</addClasspath>
@@ -109,8 +105,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
 </project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,9 +1,12 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.findwise.hydra</groupId>
+	<parent>
+		<groupId>com.findwise.hydra</groupId>
+		<artifactId>hydra-parent</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+	</parent>
     <artifactId>hydra-examples</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
     <name>${artifactId}</name>
     <description>Contains scripts to perform certain manual tests</description>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -25,14 +25,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>2.4</version>
-                <configuration>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <finalName>inserter</finalName>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,14 @@
 		<url>https://github.com/Findwise/Hydra</url>
 	</scm>
 
+	<developers>
+		<developer>
+			<id>findwise</id>
+			<name>Findwise</name>
+			<email>hydra-processing@googlegroups.com</email>
+		</developer>
+	</developers>
+
 	<modules>
 		<module>admin-service</module>
 		<module>api</module>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,14 @@
 					<target>1.6</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>2.6</version>
+				<configuration>
+					<encoding>${project.build.sourceEncoding}</encoding>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,14 @@
 	<packaging>pom</packaging>
 	<url>http://findwise.github.com/Hydra</url>
 
+	<licenses>
+		<license>
+			<name>The Apache Software License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
 	<modules>
 		<module>admin-service</module>
 		<module>api</module>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,10 @@
 		<module>distribution</module>
 	</modules>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -25,6 +29,15 @@
 				<version>2.8.1</version>
 				<configuration>
 					<aggregate>true</aggregate>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,16 @@
 	<packaging>pom</packaging>
 	<url>http://findwise.github.com/Hydra</url>
 
+	<!--
+	To simplify deployment to Sonatype OSS we inherit from their pom.
+	https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide#SonatypeOSSMavenRepositoryUsageGuide-7a.1.POMandsettingsconfig
+	-->
+	<parent>
+		<groupId>org.sonatype.oss</groupId>
+		<artifactId>oss-parent</artifactId>
+		<version>7</version>
+	</parent>
+
 	<licenses>
 		<license>
 			<name>The Apache Software License, Version 2.0</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
   <packaging>pom</packaging>
   
   <modules>
+	<module>admin-service</module>
 	<module>api</module>
 	<module>database</module>
 	<module>database-impl/mongodb</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1,31 +1,32 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>com.findwise.hydra</groupId>
-  <artifactId>hydra-parent</artifactId>
-  <version>0.4.0-SNAPSHOT</version>
-  <packaging>pom</packaging>
-  
-  <modules>
-	<module>admin-service</module>
-	<module>api</module>
-	<module>database</module>
-	<module>database-impl/mongodb</module>
-	<module>database-impl/inmemory</module>
-	<module>core</module>
-	<module>examples</module>
-	<module>stages</module>
-	<module>distribution</module>
-  </modules>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.findwise.hydra</groupId>
+	<artifactId>hydra-parent</artifactId>
+	<version>0.4.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
 
-  <build>
-    <plugins>
-  <plugin>
-      <artifactId>maven-javadoc-plugin</artifactId>
-      <version>2.8.1</version>
-      <configuration>
-          <aggregate>true</aggregate>
-      </configuration>
-  </plugin> 
-    </plugins>
-  </build>
+	<modules>
+		<module>admin-service</module>
+		<module>api</module>
+		<module>database</module>
+		<module>database-impl/mongodb</module>
+		<module>database-impl/inmemory</module>
+		<module>core</module>
+		<module>examples</module>
+		<module>stages</module>
+		<module>distribution</module>
+	</modules>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.8.1</version>
+				<configuration>
+					<aggregate>true</aggregate>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
 	<artifactId>hydra-parent</artifactId>
 	<version>0.4.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
+	<url>http://findwise.github.com/Hydra</url>
 
 	<modules>
 		<module>admin-service</module>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,12 @@
 		</license>
 	</licenses>
 
+	<scm>
+		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
+		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>
+		<url>https://github.com/Findwise/Hydra</url>
+	</scm>
+
 	<modules>
 		<module>admin-service</module>
 		<module>api</module>

--- a/pom.xml
+++ b/pom.xml
@@ -13,31 +13,13 @@
 	<module>database-impl/inmemory</module>
 	<module>core</module>
 	<module>examples</module>
-    <module>stages</module>
+	<module>stages</module>
+	<module>distribution</module>
   </modules>
 
   <build>
     <plugins>
-    <plugin>
-      <artifactId>maven-antrun-plugin</artifactId>
-      <version>1.4</version>
-      <executions>
-        <execution>
-          <id>copy</id>
-          <phase>package</phase>
-          <configuration>
-            <tasks>
-              <copy file="core/target/hydra-core-jar-with-dependencies.jar" tofile="bin/hydra-core.jar"/>
-              <copy file="core/target/resource.properties" tofile="bin/resource.properties"/>
-            </tasks>
-          </configuration>
-          <goals>
-            <goal>run</goal>
-          </goals>
-        </execution> 
-      </executions>
-  </plugin>
-  <plugin> 
+  <plugin>
       <artifactId>maven-javadoc-plugin</artifactId>
       <version>2.8.1</version>
       <configuration>

--- a/stages/debugging/debugging/pom.xml
+++ b/stages/debugging/debugging/pom.xml
@@ -62,14 +62,6 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.9</version>
 			</plugin>

--- a/stages/debugging/debugging/pom.xml
+++ b/stages/debugging/debugging/pom.xml
@@ -11,14 +11,6 @@
 	<name>hydra-debugging-stage</name>
 	<description>Solr Debugging Stage</description>
 
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
-
 	<scm>
 		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
 		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>

--- a/stages/debugging/debugging/pom.xml
+++ b/stages/debugging/debugging/pom.xml
@@ -10,7 +10,6 @@
 	<packaging>jar</packaging>
 	<name>hydra-debugging-stage</name>
 	<description>Solr Debugging Stage</description>
-	<url>http://findwise.github.com/Hydra</url>
 
 	<licenses>
 		<license>

--- a/stages/debugging/debugging/pom.xml
+++ b/stages/debugging/debugging/pom.xml
@@ -11,13 +11,6 @@
 	<name>hydra-debugging-stage</name>
 	<description>Solr Debugging Stage</description>
 
-	<scm>
-		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
-		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>
-		<url>https://github.com/Findwise/Hydra</url>
-	</scm>
-	
-	
 	<developers>
 		<developer>
 			<id>findwise</id>

--- a/stages/debugging/debugging/pom.xml
+++ b/stages/debugging/debugging/pom.xml
@@ -11,14 +11,6 @@
 	<name>hydra-debugging-stage</name>
 	<description>Solr Debugging Stage</description>
 
-	<developers>
-		<developer>
-			<id>findwise</id>
-			<name>Findwise</name>
-			<email>hydra-processing@googlegroups.com</email>
-		</developer>
-	</developers>
-	
 	<dependencies>
 		<dependency>
 			<groupId>com.findwise.hydra</groupId>

--- a/stages/in/json-in/pom.xml
+++ b/stages/in/json-in/pom.xml
@@ -11,10 +11,6 @@
     <name>${project.artifactId}</name>
     <url>http://maven.apache.org</url>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>        
-    </properties>
-    
     <dependencies>
         <dependency>
             <groupId>com.findwise.hydra</groupId>
@@ -58,14 +54,6 @@
 		<finalName>${project.name}</finalName>
 
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/stages/in/server/pom.xml
+++ b/stages/in/server/pom.xml
@@ -11,10 +11,6 @@
     <name>${project.artifactId}</name>
     <url>http://maven.apache.org</url>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>        
-    </properties>
-    
     <dependencies>
         <dependency>
             <groupId>com.findwise.hydra</groupId>
@@ -44,14 +40,6 @@
 		<finalName>${project.name}</finalName>
 
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/stages/in/solr-in/pom.xml
+++ b/stages/in/solr-in/pom.xml
@@ -69,14 +69,6 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.9</version>
 			</plugin>

--- a/stages/out/elasticsearch-out/pom.xml
+++ b/stages/out/elasticsearch-out/pom.xml
@@ -11,12 +11,6 @@
 	<name>${project.artifactId}</name>
 	<description>Elasticsearch Output Stage</description>
 
-	<scm>
-		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
-		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>
-		<url>https://github.com/Findwise/Hydra</url>
-	</scm>
-	
 	<developers>
 		<developer>
 			<id>findwise</id>

--- a/stages/out/elasticsearch-out/pom.xml
+++ b/stages/out/elasticsearch-out/pom.xml
@@ -91,14 +91,6 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.9</version>
 			</plugin>

--- a/stages/out/elasticsearch-out/pom.xml
+++ b/stages/out/elasticsearch-out/pom.xml
@@ -11,14 +11,6 @@
 	<name>${project.artifactId}</name>
 	<description>Elasticsearch Output Stage</description>
 
-	<developers>
-		<developer>
-			<id>findwise</id>
-			<name>Findwise</name>
-			<email>hydra-processing@googlegroups.com</email>
-		</developer>
-	</developers>
-	
 	<dependencies>
 		<dependency>
 			<groupId>com.findwise.hydra</groupId>

--- a/stages/out/elasticsearch-out/pom.xml
+++ b/stages/out/elasticsearch-out/pom.xml
@@ -10,7 +10,6 @@
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
 	<description>Elasticsearch Output Stage</description>
-	<url>http://findwise.github.com/Hydra</url>
 
 	<licenses>
 		<license>

--- a/stages/out/elasticsearch-out/pom.xml
+++ b/stages/out/elasticsearch-out/pom.xml
@@ -11,14 +11,6 @@
 	<name>${project.artifactId}</name>
 	<description>Elasticsearch Output Stage</description>
 
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
-
 	<scm>
 		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
 		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>

--- a/stages/out/solr-out-3.6/pom.xml
+++ b/stages/out/solr-out-3.6/pom.xml
@@ -11,7 +11,6 @@
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
 	<description>Solr Output Stage</description>
-	<url>http://findwise.github.com/Hydra</url>
 
 	<licenses>
 		<license>

--- a/stages/out/solr-out-3.6/pom.xml
+++ b/stages/out/solr-out-3.6/pom.xml
@@ -91,14 +91,6 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.9</version>
 			</plugin>

--- a/stages/out/solr-out-3.6/pom.xml
+++ b/stages/out/solr-out-3.6/pom.xml
@@ -12,14 +12,6 @@
 	<name>${project.artifactId}</name>
 	<description>Solr Output Stage</description>
 
-	<developers>
-		<developer>
-			<id>findwise</id>
-			<name>Findwise</name>
-			<email>hydra-processing@googlegroups.com</email>
-		</developer>
-	</developers>
-	
 	<dependencies>
 		<dependency>
 			<groupId>com.findwise.hydra</groupId>

--- a/stages/out/solr-out-3.6/pom.xml
+++ b/stages/out/solr-out-3.6/pom.xml
@@ -12,12 +12,6 @@
 	<name>${project.artifactId}</name>
 	<description>Solr Output Stage</description>
 
-	<scm>
-		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
-		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>
-		<url>https://github.com/Findwise/Hydra</url>
-	</scm>
-	
 	<developers>
 		<developer>
 			<id>findwise</id>

--- a/stages/out/solr-out-3.6/pom.xml
+++ b/stages/out/solr-out-3.6/pom.xml
@@ -12,14 +12,6 @@
 	<name>${project.artifactId}</name>
 	<description>Solr Output Stage</description>
 
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
-
 	<scm>
 		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
 		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>

--- a/stages/out/solr-out/pom.xml
+++ b/stages/out/solr-out/pom.xml
@@ -11,7 +11,6 @@
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
 	<description>Solr Output Stage</description>
-	<url>http://findwise.github.com/Hydra</url>
 
 	<licenses>
 		<license>

--- a/stages/out/solr-out/pom.xml
+++ b/stages/out/solr-out/pom.xml
@@ -12,14 +12,6 @@
 	<name>${project.artifactId}</name>
 	<description>Solr Output Stage</description>
 
-	<developers>
-		<developer>
-			<id>findwise</id>
-			<name>Findwise</name>
-			<email>hydra-processing@googlegroups.com</email>
-		</developer>
-	</developers>
-	
 	<dependencies>
 		<dependency>
 			<groupId>com.findwise.hydra</groupId>

--- a/stages/out/solr-out/pom.xml
+++ b/stages/out/solr-out/pom.xml
@@ -12,12 +12,6 @@
 	<name>${project.artifactId}</name>
 	<description>Solr Output Stage</description>
 
-	<scm>
-		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
-		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>
-		<url>https://github.com/Findwise/Hydra</url>
-	</scm>
-	
 	<developers>
 		<developer>
 			<id>findwise</id>

--- a/stages/out/solr-out/pom.xml
+++ b/stages/out/solr-out/pom.xml
@@ -12,14 +12,6 @@
 	<name>${project.artifactId}</name>
 	<description>Solr Output Stage</description>
 
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
-
 	<scm>
 		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
 		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>

--- a/stages/out/solr-out/pom.xml
+++ b/stages/out/solr-out/pom.xml
@@ -72,14 +72,6 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.9</version>
 			</plugin>

--- a/stages/pom.xml
+++ b/stages/pom.xml
@@ -1,8 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.findwise.hydra</groupId>
+	<parent>
+		<groupId>com.findwise.hydra</groupId>
+		<artifactId>hydra-parent</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+	</parent>
     <artifactId>stages</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/stages/processing/basic/pom.xml
+++ b/stages/processing/basic/pom.xml
@@ -31,7 +31,6 @@
 
     <properties>
         <main.class>com.findwise.hydra.stage.AbstractStage</main.class>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 	
 	<developers>
@@ -87,14 +86,6 @@
             </resource>
         </resources>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>

--- a/stages/processing/basic/pom.xml
+++ b/stages/processing/basic/pom.xml
@@ -17,14 +17,6 @@
     <properties>
         <main.class>com.findwise.hydra.stage.AbstractStage</main.class>
     </properties>
-	
-	<developers>
-		<developer>
-			<id>findwise</id>
-			<name>Findwise</name>
-			<email>hydra-processing@googlegroups.com</email>
-		</developer>
-	</developers>
 
     <dependencies>
         <dependency>

--- a/stages/processing/basic/pom.xml
+++ b/stages/processing/basic/pom.xml
@@ -13,7 +13,6 @@
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
     <description>Basic Stages - A package of basic stages for Hydra</description>
-    <url>http://findwise.github.com/Hydra</url>
 
     <licenses>
         <license>

--- a/stages/processing/basic/pom.xml
+++ b/stages/processing/basic/pom.xml
@@ -14,12 +14,6 @@
     <name>${project.artifactId}</name>
     <description>Basic Stages - A package of basic stages for Hydra</description>
 
-    <scm>
-        <connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
-        <developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>
-        <url>https://github.com/Findwise/Hydra</url>
-    </scm>
-
     <properties>
         <main.class>com.findwise.hydra.stage.AbstractStage</main.class>
     </properties>

--- a/stages/processing/basic/pom.xml
+++ b/stages/processing/basic/pom.xml
@@ -14,14 +14,6 @@
     <name>${project.artifactId}</name>
     <description>Basic Stages - A package of basic stages for Hydra</description>
 
-    <licenses>
-        <license>
-            <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
     <scm>
         <connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
         <developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>

--- a/stages/processing/hydra-groovy-runner/pom.xml
+++ b/stages/processing/hydra-groovy-runner/pom.xml
@@ -55,15 +55,6 @@
 					</execution>
 				</executions>
 			</plugin>
-		 <plugin>
-		  <groupId>org.apache.maven.plugins</groupId>
-		  <artifactId>maven-compiler-plugin</artifactId>
-		  <version>2.5.1</version>
-		  <configuration>
-		   <source>1.6</source>
-		   <target>1.6</target>
-		  </configuration>
-		 </plugin>
 		</plugins>
 	</build>
 </project>

--- a/stages/processing/tika/pom.xml
+++ b/stages/processing/tika/pom.xml
@@ -13,14 +13,6 @@
 	<description>Tika Text Extraction Stage</description>
 	<name>${project.artifactId}</name>
 
-	<developers>
-		<developer>
-			<id>findwise</id>
-			<name>Findwise</name>
-			<email>hydra-processing@googlegroups.com</email>
-		</developer>
-	</developers>
-
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>

--- a/stages/processing/tika/pom.xml
+++ b/stages/processing/tika/pom.xml
@@ -12,7 +12,6 @@
 	<artifactId>hydra-tika-stages</artifactId>
 	<description>Tika Text Extraction Stage</description>
 	<name>${project.artifactId}</name>
-	<url>http://findwise.github.com/Hydra</url>
 
 	<licenses>
 		<license>

--- a/stages/processing/tika/pom.xml
+++ b/stages/processing/tika/pom.xml
@@ -13,12 +13,6 @@
 	<description>Tika Text Extraction Stage</description>
 	<name>${project.artifactId}</name>
 
-	<scm>
-		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
-		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>
-		<url>https://github.com/Findwise/Hydra</url>
-	</scm>
-	
 	<developers>
 		<developer>
 			<id>findwise</id>

--- a/stages/processing/tika/pom.xml
+++ b/stages/processing/tika/pom.xml
@@ -13,14 +13,6 @@
 	<description>Tika Text Extraction Stage</description>
 	<name>${project.artifactId}</name>
 
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
-
 	<scm>
 		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
 		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>

--- a/stages/processing/tika/pom.xml
+++ b/stages/processing/tika/pom.xml
@@ -75,14 +75,6 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<version>1.7.1</version>
 				<configuration>
@@ -160,9 +152,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
-
 </project>

--- a/stages/processing/web/pom.xml
+++ b/stages/processing/web/pom.xml
@@ -9,7 +9,6 @@
 	<artifactId>hydra-web-stages</artifactId>
     <name>${project.artifactId}</name>
 	<description>Web Content processing stages</description>
-	<url>http://findwise.github.com/Hydra</url>
 
 	<licenses>
 		<license>
@@ -24,7 +23,7 @@
 		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>
 		<url>https://github.com/Findwise/Hydra</url>
 	</scm>
-	
+
 	<developers>
 		<developer>
 			<id>findwise</id>
@@ -32,7 +31,7 @@
 			<email>hydra-processing@googlegroups.com</email>
 		</developer>
 	</developers>
-	
+
 	<dependencies>
 		<dependency>
 			<groupId>com.findwise.hydra</groupId>

--- a/stages/processing/web/pom.xml
+++ b/stages/processing/web/pom.xml
@@ -10,14 +10,6 @@
     <name>${project.artifactId}</name>
 	<description>Web Content processing stages</description>
 
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
-
 	<scm>
 		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
 		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>

--- a/stages/processing/web/pom.xml
+++ b/stages/processing/web/pom.xml
@@ -11,11 +11,6 @@
 	<description>Web Content processing stages</description>
 	<url>http://findwise.github.com/Hydra</url>
 
-    <properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
-	
-	
 	<licenses>
 		<license>
 			<name>The Apache Software License, Version 2.0</name>
@@ -80,15 +75,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				    <encoding>${project.build.sourceEncoding}</encoding>
-				</configuration>
-			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>

--- a/stages/processing/web/pom.xml
+++ b/stages/processing/web/pom.xml
@@ -10,12 +10,6 @@
     <name>${project.artifactId}</name>
 	<description>Web Content processing stages</description>
 
-	<scm>
-		<connection>scm:git:git@github.com:Findwise/Hydra.git</connection>
-		<developerConnection>scm:git:git@github.com:Findwise/Hydra.git</developerConnection>
-		<url>https://github.com/Findwise/Hydra</url>
-	</scm>
-
 	<developers>
 		<developer>
 			<id>findwise</id>

--- a/stages/processing/web/pom.xml
+++ b/stages/processing/web/pom.xml
@@ -10,14 +10,6 @@
     <name>${project.artifactId}</name>
 	<description>Web Content processing stages</description>
 
-	<developers>
-		<developer>
-			<id>findwise</id>
-			<name>Findwise</name>
-			<email>hydra-processing@googlegroups.com</email>
-		</developer>
-	</developers>
-
 	<dependencies>
 		<dependency>
 			<groupId>com.findwise.hydra</groupId>

--- a/stages/processing/web/pom.xml
+++ b/stages/processing/web/pom.xml
@@ -99,14 +99,6 @@
 					</execution>
 				</executions>
 			</plugin>
-		    <plugin>
-		        <groupId>org.apache.maven.plugins</groupId>
-		        <artifactId>maven-resources-plugin</artifactId>
-		        <version>2.4.3</version>
-		        <configuration>
-		            <encoding>${project.build.sourceEncoding}</encoding>
-		        </configuration>
-		    </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
Hey,

To simplify releases and configuration, I've made all child modules inherit from the parent pom. I've also moved common configuration (such as sourceEncoding) to the parent, since this is now inherited by the children. Moreover, the parent pom inherits from sonatype oss to get distributionManagement tags etc.

I have _not_ done any pluginManagement or dependencyManagement stuff. But at least now its possible to do so (to enforce e.g. the same version of slf4j-api in all artifacts).

Have a look and see what you think. Once this has been merged, I will try to merge master into 0.3.x and perform a 0.3.1 release.
