### PR TITLE
Adds support for setting multivalued static fields.

### DIFF
--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/SetStaticFieldStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/SetStaticFieldStage.java
@@ -99,7 +99,7 @@ public class SetStaticFieldStage extends AbstractProcessStage {
 			valueList = new ArrayList<String>();
 		}
 		valueList.add(fieldValue);
-		doc.putContentField(fieldName, valueList.toArray());
+		doc.putContentField(fieldName, valueList.toArray(new String[valueList.size()]));
 
 	}
 

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/SetStaticFieldStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/SetStaticFieldStageTest.java
@@ -1,19 +1,28 @@
 package com.findwise.hydra.stage;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Adds a field with a specified value to the document.
- * 
- * @author simon.stenstrom
- */
+import com.findwise.hydra.local.LocalDocument;
+
 public class SetStaticFieldStageTest {
 
-
-
 	@Test
-	public void testOverwritePolicies() throws ProcessException {
-		
+	public void testSetMultiValuedStaticField() throws Exception {
+		SetStaticFieldStage stage = new SetStaticFieldStage();
+		Map<String, Object> parameters = new HashMap<String, Object>();
+		String fieldName = "field_name";
+		parameters.put("fieldNames", Arrays.asList(fieldName, fieldName));
+		List<String> values = Arrays.asList("value1", "value1");
+		parameters.put("fieldValues", values);
+		stage.setParameters(parameters);
+		LocalDocument doc = new LocalDocument();
+		stage.process(doc);
+		Assert.assertArrayEquals(values.toArray(), (Object[]) doc.getContentField(fieldName));
 	}
-
 }


### PR DESCRIPTION
This looked like a bug to me. When the same field name was present more than once in fieldNames, only the last corresponding value in fieldValues was added to the document.
