### PR TITLE
Adds enum support to Parameter injection

### DIFF
--- a/api/src/test/java/com/findwise/hydra/stage/AbstractStageTest.java
+++ b/api/src/test/java/com/findwise/hydra/stage/AbstractStageTest.java
@@ -1,0 +1,60 @@
+package com.findwise.hydra.stage;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.findwise.hydra.Document.Action;
+import com.findwise.hydra.SerializationUtils;
+import com.findwise.hydra.local.LocalQuery;
+import com.findwise.hydra.stage.AbstractStageTest.TestStage.Enumerable;
+
+public class AbstractStageTest {
+
+	@Test
+	public void testSetParameters() throws Exception {
+		HashMap<String, Object> parameters = new HashMap<String, Object>();
+		parameters.put("string", "string");
+		parameters.put("integer", 100);
+		parameters.put("e1", "A");
+		parameters.put("e2", 1);
+		LocalQuery query = new LocalQuery();
+		query.requireAction(Action.ADD);
+		parameters.put("query", query);
+		
+		Map<String, Object> serialized = SerializationUtils.fromJson(SerializationUtils.toJson(parameters));
+		
+		TestStage stage = new TestStage();
+		stage.setParameters(serialized);
+		
+		assertEquals("string", stage.string);
+		assertEquals(100, stage.integer);
+		assertEquals(Enumerable.A, stage.e1);
+		assertEquals(Enumerable.B, stage.e2);
+		assertEquals(query.getAction(), stage.query.getAction());
+	}
+	
+	@Stage
+	static class TestStage extends AbstractStage {
+		@Parameter
+		private String string;
+		
+		@Parameter
+		private int integer;
+		
+		public enum Enumerable { A, B, C };
+		
+		@Parameter
+		private Enumerable e1;
+		
+		@Parameter
+		private Enumerable e2;
+		
+		@Parameter
+		private LocalQuery query;
+	}
+
+}

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/SetStaticFieldStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/SetStaticFieldStage.java
@@ -4,9 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.findwise.hydra.local.LocalDocument;
 
 /**
@@ -16,34 +13,15 @@ import com.findwise.hydra.local.LocalDocument;
  */
 @Stage(description = "Modifies a field with a static value. Can append values to lists, and will create lists if configured to do so.")
 public class SetStaticFieldStage extends AbstractProcessStage {
-	private static Logger logger = LoggerFactory
-			.getLogger(SetStaticFieldStage.class);
 
 	public enum Policy {
 		OVERWRITE, SKIP, THROW, ADD
 	};
 
-	private static final Policy DEFAULTOVERWRITEPOLICY = Policy.ADD;
-
-	private Policy overwritePolicy = SetStaticFieldStage.DEFAULTOVERWRITEPOLICY;
-
-	@Parameter(name = "fieldNames", description = "A map of fields to modify, and the values to write to them")
+	@Parameter(required = true, name = "fieldNames", description = "A map of fields to modify, and the values to write to them")
 	private Map<String, Object> fieldValueMap;
-	@Parameter(name = "overwrite", description = "Switch for behaviour when modifying; 0 = overwrite content, 1 = skip if there is content, 2 = throw exception if there is content, 3 = append to content, converting the content to a list if necessary (default)")
-	private int overwrite = -1;
-
-	@Override
-	public void init() throws RequiredArgumentMissingException {
-		if (overwrite != -1) {
-			try {
-				overwritePolicy = Policy.values()[overwrite];
-			} catch (ArrayIndexOutOfBoundsException e) {
-				logger.error("The passed value for parameter overwrite is not allowed, defaulting to ADD. Expected values:(0..3), found value:"
-						+ overwrite);
-				overwritePolicy = SetStaticFieldStage.DEFAULTOVERWRITEPOLICY;
-			}
-		}
-	}
+	@Parameter(name = "overwritePolicy", description = "Switch for behaviour when modifying. Available options: 0/OVERWRITE = overwrite content, 1/SKIP = skip if there is content, 2/THROW = throw exception if there is content, 3/ADD = append to content, converting the content to a list if necessary (default)")
+	private Policy overwritePolicy = Policy.ADD;
 
 	@Override
 	public void process(LocalDocument doc) throws ProcessException {

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/SetStaticFieldStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/SetStaticFieldStageTest.java
@@ -90,7 +90,7 @@ public class SetStaticFieldStageTest {
 
 	public void init(Policy policy) throws Exception {
 		HashMap<String, Object> map = new HashMap<String, Object>();
-		map.put("overwrite", policy.ordinal());
+		map.put("overwritePolicy", policy);
 		HashMap<String, Object> fieldValueMap = new HashMap<String, Object>();
 		fieldValueMap.put("empty", "value");
 		fieldValueMap.put("string", 1);


### PR DESCRIPTION
It bugged me while creating the new implementation for SetStaticFieldStage that enum support wasn't included in the API for stage parameters. Now it is.
