### PR TITLE
Admin service delete documents

### DIFF
--- a/admin-service/README.md
+++ b/admin-service/README.md
@@ -391,3 +391,26 @@ Available endpoints
 		"document_id" : "23432451"
 	}
 	```
+* **/documents/discard** - Method: GET
+	
+	Deletes the documents matching a query.
+	The number of documents to be deleted and what document to start deleting from, can be configured with request parameters
+	
+	Available parameters: 
+	
+		- q: A json query to be matched by the documents to be deleted
+		
+		- limit: The maximum number of documents to delete (*default: 1*)
+		
+		- skip: The number of documents to skip (used for example if you want to delete all documents except the first 10) (*default: 0*)
+	
+	Sample request: http://localhost:8080/hydra/documents/discard?q={fetched:{rename:true}}&limit=10&skip=0
+	Deleted 10 documents matching the query, starting with the first one.
+	
+	Sample response: 
+	
+	```
+	{
+		success: true
+	}
+	```

--- a/admin-service/README.md
+++ b/admin-service/README.md
@@ -400,7 +400,7 @@ Available endpoints
 	
 		- q: A json query to be matched by the documents to be deleted
 		
-		- limit: The maximum number of documents to delete (*default: 1*)
+		- limit: The maximum number of documents to delete (*default: no limit*)
 		
 		- skip: The number of documents to skip (used for example if you want to delete all documents except the first 10) (*default: 0*)
 	

--- a/admin-service/src/main/java/com/findwise/hydra/admin/documents/DocumentsService.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/documents/DocumentsService.java
@@ -71,6 +71,17 @@ public class DocumentsService<T extends DatabaseType> {
 		return getConnector().getDocumentReader().getDocuments(query, limit, skip);
 	}
 
+	private boolean discardDocuments(DatabaseQuery<T> query, int limit, int skip) {
+		List<DatabaseDocument<T>> res = getConnector().getDocumentReader().getDocuments(query, limit, skip);
+			if (res.isEmpty()) {
+				return false;
+			} else {
+			for (DatabaseDocument<T> databaseDocument : res) {
+				getConnector().getDocumentWriter().delete(databaseDocument);
+			}
+		return true;
+	    }
+	}
 	public DatabaseConnector<T> getConnector() {
 		return connector;
 	}
@@ -187,4 +198,24 @@ public class DocumentsService<T extends DatabaseType> {
 		
 		return ret;
 	}
+        
+	public Map<String, Object> discardDocuments(String jsonQuery, int limit, int skip) {
+		Map<String, Object> ret = new HashMap<String, Object>();
+
+		try {
+			DatabaseQuery<AdminServiceType> query = new AdminServiceQuery();
+			query.fromJson(jsonQuery);
+			boolean success = discardDocuments(connector.convert(query), limit, skip);
+			ret.put("success", success);
+
+		} catch (JsonException e) {
+			Map<String, String> error = new HashMap<String, String>();
+			error.put("Invalid query", jsonQuery);
+			ret.put("error", error);
+			ret.put("success", false);
+		}
+
+		return ret;
+	}        
+
 }

--- a/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
@@ -174,7 +174,7 @@ public class ConfigurationController {
 	@RequestMapping(method = RequestMethod.GET, value = "/documents/discard")
 	public Map<String, Object> discardDocuments(
 			@RequestParam(required = true, value = "q") String jsonQuery,
-			@RequestParam(required = false, defaultValue = "1", value = "limit") int limit,
+			@RequestParam(required = false, defaultValue = Integer.MAX_VALUE + "", value = "limit") int limit,
 			@RequestParam(required = false, defaultValue = "0", value = "skip") int skip){
 		return documentService.discardDocuments(jsonQuery, limit, skip);
 	}

--- a/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
@@ -169,6 +169,15 @@ public class ConfigurationController {
 			@RequestBody String changes) {
 		return documentService.updateDocuments(jsonQuery, limit, changes);
 	}
+
+        @ResponseBody
+	@RequestMapping(method = RequestMethod.GET, value = "/documents/discard")
+	public Map<String, Object> discardDocuments(
+			@RequestParam(required = true, value = "q") String jsonQuery,
+			@RequestParam(required = false, defaultValue = "1", value = "limit") int limit,
+			@RequestParam(required = false, defaultValue = "0", value = "skip") int skip){
+		return documentService.discardDocuments(jsonQuery, limit, skip);
+	}
 	
 	@ResponseStatus(HttpStatus.ACCEPTED)
 	@ResponseBody


### PR DESCRIPTION
Added a admin-service for discarding documents. Can delete one or many documents based on query. Default limits to 1 and also supports skip parameter
