### PR TITLE
Admin-service configuration via property file

### DIFF
--- a/admin-service/README.md
+++ b/admin-service/README.md
@@ -1,6 +1,22 @@
 Hydra Admin Service
 ==========================
 
+Description
+-----------
+
+This service talks directly to the backend database. The service can configure pipelines without any running Core.
+
+As a webapp, this service needs to be deployed in a container such as Tomcat or Jetty.
+
+Configuration
+-------------
+
+If you need to set any of the configuration parameters (such as database authentication), you need to supply the `admin-service.properties` file via a JVM system property. Simply add the following to your Java startup command:
+
+    -Dhydra.admin.config.dir=<path-to-directory>
+
+Put your `admin-service.properties` in that directory and the admin service should load it when initiated.
+
 Available endpoints
 ----------------
 

--- a/admin-service/pom.xml
+++ b/admin-service/pom.xml
@@ -93,5 +93,12 @@
 			<version>4.10</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>1.9.0</version>
+			<type>jar</type>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/admin-service/src/main/java/com/findwise/hydra/admin/JarFetcher.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/JarFetcher.java
@@ -1,0 +1,67 @@
+package com.findwise.hydra.admin;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+
+import com.findwise.hydra.DatabaseFile;
+import com.findwise.hydra.PipelineReader;
+
+/**
+ * Creates temporary library JARs that can be read via URLs
+ * 
+ * @author olof.nilsson
+ * 
+ */
+public class JarFetcher {
+
+	private final String tempPrefix;
+
+	private final String tempSuffix;
+
+	public JarFetcher() {
+		this("hydra-admin-tmp", ".jar");
+	}
+
+	public JarFetcher(String prefix, String suffix) {
+		this.tempPrefix = prefix;
+		this.tempSuffix = suffix;
+	}
+
+	/**
+	 * TODO: Avoid creating new files for each call to this method
+	 * 
+	 * @param tmpDir
+	 *            directory for writing jars to
+	 * @param pipelineReader
+	 * @param files
+	 * @return urls to jars loaded for this pipeline
+	 * @throws IOException
+	 */
+	public List<URL> getJars(File tmpDir, PipelineReader pipelineReader,
+			DatabaseFile... files) throws IOException {
+		List<URL> urls = new ArrayList<URL>();
+
+		for (DatabaseFile df : files) {
+			File tmpFile = File.createTempFile(tempPrefix, tempSuffix, tmpDir);
+
+			FileUtils.copyInputStreamToFile(pipelineReader.getStream(df),
+					tmpFile);
+			URL url = tmpFile.toURI().toURL();
+			urls.add(url);
+		}
+		return urls;
+	}
+
+	public void cleanup(List<URL> urls) {
+		for (URL url : urls) {
+			File file = FileUtils.toFile(url);
+			FileUtils.deleteQuietly(file);
+		}
+	}
+}

--- a/admin-service/src/main/java/com/findwise/hydra/admin/JarFetcher.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/JarFetcher.java
@@ -2,7 +2,6 @@ package com.findwise.hydra.admin;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;

--- a/admin-service/src/main/java/com/findwise/hydra/admin/PipelineScanner.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/PipelineScanner.java
@@ -5,38 +5,136 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 import org.apache.commons.io.FileUtils;
 import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.findwise.hydra.DatabaseFile;
 import com.findwise.hydra.DatabaseType;
+import com.findwise.hydra.Pipeline;
 import com.findwise.hydra.PipelineReader;
+import com.findwise.hydra.Stage;
+import com.findwise.hydra.StageGroup;
 
 public class PipelineScanner<T extends DatabaseType> {
-	private PipelineReader pipelineReader;
-	
-	public PipelineScanner(PipelineReader reader) {
-		pipelineReader = reader;
+	private Logger logger = LoggerFactory.getLogger(PipelineScanner.class);
+
+	/**
+	 * Temporary directory for scanned JARs
+	 */
+	private final String tempDir;
+
+	private final PipelineReader pipelineReader;
+
+	private final StageScanner stageScanner;
+
+	public PipelineScanner(PipelineReader pipelineReader) {
+		this(pipelineReader, new StageScanner(), "tmp");
 	}
-	
+
+	public PipelineScanner(PipelineReader pipelineReader, StageScanner stageScanner, String tempDir) {
+		this.pipelineReader = pipelineReader;
+		this.tempDir = tempDir;
+		this.stageScanner = stageScanner;
+	}
+
 	public List<DatabaseFile> getLibraryFiles() {
 		return pipelineReader.getFiles();
 	}
 
-	public List<Class<?>> getStageClasses(File tmpdir, DatabaseFile ... files) throws IOException {
-		List<URL> urls = new ArrayList<URL>();
-		
-		for(DatabaseFile df : files) {
-			URL url = new File(tmpdir.getAbsolutePath()+File.separator+df.getFilename()).toURI().toURL();
+	/**
+	 * Extract all stages that can be configured from the supplied library
+	 * 
+	 * @param df
+	 *            library in the database
+	 * @return map of stage class names to their representation
+	 */
+	public Map<String, StageInformation> getStagesMap(DatabaseFile df) {
+		Map<String, StageInformation> map = new HashMap<String, StageInformation>();
+		try {
+			for (Class<?> c : getStageClasses(new File(tempDir), df)) {
+				try {
+					map.put(c.getCanonicalName(), new StageInformation(c));
+				} catch (NoSuchElementException e) {
+					logger.error("Unable to get stage information for class "
+							+ c.getCanonicalName(), e);
+				}
+			}
+		} catch (IOException e) {
+			logger.error("Unable to get stage classes", e);
+		}
+		return map;
+	}
 
-			FileUtils.copyInputStreamToFile(pipelineReader.getStream(df), new File(url.getFile()));
+	/**
+	 * Extracts all currently configured groups and stages from the supplied
+	 * pipeline
+	 * 
+	 * @param pipeline
+	 * @return map containing groups of stages
+	 */
+	public Map<String, Object> getStageConfigMap(Pipeline pipeline) {
+		Map<String, Object> map = new HashMap<String, Object>();
+		for (StageGroup g : pipeline.getStageGroups()) {
+			HashMap<String, Object> group = new HashMap<String, Object>();
+			HashMap<String, Object> stages = new HashMap<String, Object>();
+			for (Stage s : g.getStages()) {
+				HashMap<String, Object> stage = new HashMap<String, Object>();
+				stage.put("properties", s.getProperties());
+
+				HashMap<String, Object> file = new HashMap<String, Object>();
+				file.put("id", s.getDatabaseFile().getId());
+				file.put("name", s.getDatabaseFile().getFilename());
+				stage.put("file", file);
+				stages.put(s.getName(), stage);
+			}
+			group.put("properties", getMapWithoutDefaults(g));
+			group.put("stages", stages);
+			map.put(g.getName(), group);
+		}
+		return map;
+	}
+
+	private Map<String, Object> getMapWithoutDefaults(StageGroup group) {
+		Map<String, Object> propertiesMap = group.toPropertiesMap();
+		Iterator<Map.Entry<String, Object>> it = propertiesMap.entrySet()
+				.iterator();
+		while (it.hasNext()) {
+			if (it.next().getValue() == null) {
+				it.remove();
+			}
+		}
+		if (group.getRetries() == -1) {
+			propertiesMap.remove(StageGroup.RETRIES_KEY);
+		}
+		if (!group.isLogging()) {
+			propertiesMap.remove(StageGroup.LOGGING_KEY);
+		}
+		return propertiesMap;
+	}
+
+	private List<Class<?>> getStageClasses(File tmpdir, DatabaseFile... files)
+			throws IOException {
+		List<URL> urls = new ArrayList<URL>();
+
+		for (DatabaseFile df : files) {
+			URL url = new File(tmpdir.getAbsolutePath() + File.separator
+					+ df.getFilename()).toURI().toURL();
+
+			FileUtils.copyInputStreamToFile(pipelineReader.getStream(df),
+					new File(url.getFile()));
 			urls.add(url);
 		}
-		
+
 		ClassLoader cl = new URLClassLoader(urls.toArray(new URL[urls.size()]));
-		
-		return new StageScanner().getClasses(new Reflections(urls, cl));
+
+		return stageScanner.getClasses(new Reflections(urls, cl));
 	}
 }

--- a/admin-service/src/main/java/com/findwise/hydra/admin/StageInformation.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/StageInformation.java
@@ -11,7 +11,7 @@ public class StageInformation extends HashMap<String, Object>{
 
 	/**
 	 * @param clazz
-	 * @throws NoSuchElementException if the passed Class is not annotated with com.findwise.hydra.stage.Stage
+	 * @throws NoSuchElementException if the passed Class is not annotated with {@link com.findwise.hydra.stage.Stage}
 	 */
 	public StageInformation(Class<?> clazz) throws NoSuchElementException {
 		super();

--- a/admin-service/src/main/java/com/findwise/hydra/admin/StageScanner.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/StageScanner.java
@@ -2,6 +2,8 @@ package com.findwise.hydra.admin;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -20,6 +22,14 @@ import com.findwise.hydra.stage.Stage;
  *
  */
 public class StageScanner {
+	
+	public List<Class<?>> getClasses(List<URL> jars) {
+		ClassLoader cl = new URLClassLoader(jars.toArray(new URL[jars.size()]));
+		
+		Reflections reflections = new Reflections(jars, cl);
+		return getClasses(reflections);
+	}
+	
 	public List<Class<?>> getClasses(Reflections reflections) {
 		List<Class<?>> classes = new ArrayList<Class<?>>();
 		

--- a/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
@@ -54,19 +54,19 @@ public class ConfigurationController {
 	
 	@ResponseBody
 	@RequestMapping(method=RequestMethod.GET, value="") 
-	public Map<String, Object> getStats() {
+	public Map<String, Object> getStats() throws IOException {
 		return service.getStats();
 	}
 	
 	@ResponseBody
 	@RequestMapping(method=RequestMethod.GET, value="/libraries")
-	public Map<String, Object> getLibraries() {
+	public Map<String, Object> getLibraries() throws IOException {
 		return service.getLibraries();
 	}
 	
 	@ResponseBody
 	@RequestMapping(method=RequestMethod.GET, value="/libraries/{id}")
-	public Map<String, Object> getLibrary(@PathVariable String id) {
+	public Map<String, Object> getLibrary(@PathVariable String id) throws IOException {
 		Map<String, Object> library = service.getLibrary(id);
 		if (null != library) {
 			return library;

--- a/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import com.findwise.hydra.DatabaseException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
@@ -54,19 +55,19 @@ public class ConfigurationController {
 	
 	@ResponseBody
 	@RequestMapping(method=RequestMethod.GET, value="") 
-	public Map<String, Object> getStats() throws IOException {
+	public Map<String, Object> getStats() throws DatabaseException {
 		return service.getStats();
 	}
 	
 	@ResponseBody
 	@RequestMapping(method=RequestMethod.GET, value="/libraries")
-	public Map<String, Object> getLibraries() throws IOException {
+	public Map<String, Object> getLibraries() throws DatabaseException {
 		return service.getLibraries();
 	}
 	
 	@ResponseBody
 	@RequestMapping(method=RequestMethod.GET, value="/libraries/{id}")
-	public Map<String, Object> getLibrary(@PathVariable String id) throws IOException {
+	public Map<String, Object> getLibrary(@PathVariable String id) throws DatabaseException {
 		Map<String, Object> library = service.getLibrary(id);
 		if (null != library) {
 			return library;
@@ -78,7 +79,7 @@ public class ConfigurationController {
 	@ResponseStatus(HttpStatus.ACCEPTED)
 	@RequestMapping(method=RequestMethod.POST, value="/libraries/{id}")
 	@ResponseBody
-	public Map<String, Object> addLibrary(@PathVariable String id, @RequestParam MultipartFile file) throws IOException {
+	public Map<String, Object> addLibrary(@PathVariable String id, @RequestParam MultipartFile file) throws DatabaseException, IOException {
 		service.addLibrary(id, file.getOriginalFilename(), file.getInputStream());
 		return getLibrary(id);
 	}

--- a/admin-service/src/main/java/com/findwise/hydra/admin/rest/DatabaseConfig.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/rest/DatabaseConfig.java
@@ -1,0 +1,79 @@
+package com.findwise.hydra.admin.rest;
+
+import org.springframework.beans.factory.annotation.Value;
+
+import com.findwise.hydra.DatabaseConfiguration;
+
+public class DatabaseConfig implements DatabaseConfiguration {
+
+	private static final String DEFAULT_NAMESPACE = "pipeline";
+	private static final String DEFAULT_DB_URL = "localhost";
+	private static final String DEFAULT_DB_USER = "admin";
+	private static final String DEFAULT_DB_PASSWORD = "changeme";
+	private static final int DEFAULT_OLD_MAX_SIZE = 100;
+	private static final int DEFAULT_OLD_MAX_COUNT = 10000;
+
+	@Value("${admin.pipeline:pipeline}")
+	private String namespace = DEFAULT_NAMESPACE;
+	@Value("${database.url:localhost}")
+	private String databaseUrl = DEFAULT_DB_URL;
+	@Value("${database.username:admin}")
+	private String databaseUser = DEFAULT_DB_USER;
+	@Value("${database.password:changeme}")
+	private String databasePassword = DEFAULT_DB_PASSWORD;
+	@Value("${old.storage_size_mb:100}")
+	private int oldMaxSize = DEFAULT_OLD_MAX_SIZE;
+	@Value("${old.max_count:10000}")
+	private int oldMaxCount = DEFAULT_OLD_MAX_COUNT;
+
+	@Override
+	public String getNamespace() {
+		return namespace;
+	}
+
+	@Override
+	public String getDatabaseUrl() {
+		return databaseUrl;
+	}
+
+	@Override
+	public String getDatabaseUser() {
+		return databaseUser;
+	}
+
+	@Override
+	public String getDatabasePassword() {
+		return databasePassword;
+	}
+
+	@Override
+	public int getOldMaxSize() {
+		return oldMaxSize;
+	}
+
+	@Override
+	public int getOldMaxCount() {
+		return oldMaxCount;
+	}
+
+	public void setNamespace(String namespace) {
+		this.namespace = namespace;
+	}
+
+	public void setDatabaseUrl(String databaseUrl) {
+		this.databaseUrl = databaseUrl;
+	}
+
+	public void setDatabaseUser(String databaseUser) {
+		this.databaseUser = databaseUser;
+	}
+
+	public void setOldMaxSize(int oldMaxSize) {
+		this.oldMaxSize = oldMaxSize;
+	}
+
+	public void setOldMaxCount(int oldMaxCount) {
+		this.oldMaxCount = oldMaxCount;
+	}
+
+}

--- a/admin-service/src/main/java/com/findwise/hydra/admin/stages/StagesService.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/stages/StagesService.java
@@ -34,16 +34,16 @@ public class StagesService<T extends DatabaseType> {
 		ret.put("stages", new ArrayList<Stage>(connector.getPipelineReader().getPipeline().getStages()));
 		return ret;
 	}
-        
-        public Map<String, List<StageGroup>> getStageGroups() {
+
+	public Map<String, List<StageGroup>> getStageGroups() {
 		Map<String, List<StageGroup>> ret = new HashMap<String, List<StageGroup>>();
 		ret.put("stagegroups", new ArrayList<StageGroup>(connector.getPipelineReader().getPipeline().getStageGroups()));
 		return ret;
 	}
-        
-        public StageGroup getStageGroup(String groupName) {
-            return connector.getPipelineReader().getPipeline().getGroup(groupName);
-        }
+
+	public StageGroup getStageGroup(String groupName) {
+		return connector.getPipelineReader().getPipeline().getGroup(groupName);
+	}
 	
 	public void addStage(Stage stage) throws IOException {
 		addStage(stage, null);

--- a/admin-service/src/main/resources/admin-service.properties
+++ b/admin-service/src/main/resources/admin-service.properties
@@ -33,7 +33,7 @@ database.url = localhost
 # Type: String
 # Default: -
 
-database.password = admin
+# database.password = admin
 
 ###############################################
 # Settings for storage of processed documents #

--- a/admin-service/src/main/resources/admin-service.properties
+++ b/admin-service/src/main/resources/admin-service.properties
@@ -1,0 +1,54 @@
+##########################################
+# Admin Service configuration parameters #
+##########################################
+
+# The name of the pipeline this admin-service will work with.
+#
+# Type: String 
+
+admin.pipeline = pipeline
+
+######################################
+# Settings for the backing database. #
+######################################
+
+# The url of the database. 
+#
+# Type: String
+# Default: localhost
+
+database.url = localhost
+
+# If required, the user to connect to the
+# database as.
+#
+# Type: String
+# Default: -
+
+# database.username = admin
+
+# If required, the password to use when connecting
+# to the database
+#
+# Type: String
+# Default: -
+
+database.password = admin
+
+###############################################
+# Settings for storage of processed documents #
+###############################################
+
+# Sets the maximum amount of old processed documents
+# to keep. 
+#
+# Type: Integer
+
+# old.max_count = 10000
+
+# Sets the maximum size in Megabytes that the old
+# processed documents are allowed to reach.
+#
+# Type: Integer
+
+# old.storage_size_mb = 100

--- a/admin-service/src/main/webapp/WEB-INF/web.xml
+++ b/admin-service/src/main/webapp/WEB-INF/web.xml
@@ -5,7 +5,7 @@
    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee 
       http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd" 
    id="WebApp_ID" version="3.0">
-   <display-name>rest</display-name>
+   <display-name>Hydra Admin Service</display-name>
    
    <context-param>
       <param-name>contextClass</param-name>

--- a/admin-service/src/test/java/com/findwise/hydra/admin/ConfigurationServiceTest.java
+++ b/admin-service/src/test/java/com/findwise/hydra/admin/ConfigurationServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.util.Map;
 
+import com.findwise.hydra.DatabaseException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -64,7 +65,7 @@ public class ConfigurationServiceTest {
 	}
 
 	@Test
-	public void testGetStats() throws IOException {
+	public void testGetStats() throws DatabaseException {
 		Map<String, Object> stats = service.getStats();
 		
 		verify(pipelineReader).getPipeline();

--- a/admin-service/src/test/java/com/findwise/hydra/admin/ConfigurationServiceTest.java
+++ b/admin-service/src/test/java/com/findwise/hydra/admin/ConfigurationServiceTest.java
@@ -1,0 +1,81 @@
+package com.findwise.hydra.admin;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.findwise.hydra.DatabaseConnector;
+import com.findwise.hydra.DocumentReader;
+import com.findwise.hydra.DocumentWriter;
+import com.findwise.hydra.Pipeline;
+import com.findwise.hydra.PipelineReader;
+import com.findwise.hydra.PipelineWriter;
+import com.findwise.hydra.admin.database.AdminServiceType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigurationServiceTest {
+
+	@Mock
+	private DatabaseConnector<AdminServiceType> connector;
+
+	@Mock
+	private PipelineReader pipelineReader;
+	
+	@Mock
+	private PipelineWriter pipelineWriter;
+	
+	@Mock
+	private Pipeline pipeline;
+
+	@Mock
+	private Pipeline debugPipeline;
+	
+	@Mock
+	private DocumentReader<AdminServiceType> documentReader;
+	
+	@Mock
+	private DocumentWriter<AdminServiceType> documentWriter;
+
+	private ConfigurationService<AdminServiceType> service;
+
+	@Before
+	public void setUp() throws Exception {
+		when(documentReader.getActiveDatabaseSize()).thenReturn(1L);
+		when(documentReader.getInactiveDatabaseSize()).thenReturn(1L);
+		
+		when(pipelineReader.getPipeline()).thenReturn(pipeline);
+		when(pipelineReader.getDebugPipeline()).thenReturn(debugPipeline);
+		
+		when(connector.getPipelineReader()).thenReturn(pipelineReader);
+		when(connector.getPipelineWriter()).thenReturn(pipelineWriter);
+		when(connector.getDocumentReader()).thenReturn(documentReader);
+		when(connector.getDocumentWriter()).thenReturn(documentWriter);
+		service = new ConfigurationService<AdminServiceType>(connector);
+	}
+
+	@Test
+	public void testGetStats() throws IOException {
+		Map<String, Object> stats = service.getStats();
+		
+		verify(pipelineReader).getPipeline();
+		verify(pipelineReader).getDebugPipeline();
+		
+		verify(documentReader).getActiveDatabaseSize();
+		verify(documentReader).getInactiveDatabaseSize();
+		
+		assertTrue(stats.containsKey("documents"));
+		assertTrue(stats.containsKey("groups"));
+		assertEquals(2, stats.size());
+	}
+	
+}

--- a/database/src/main/java/com/findwise/hydra/DatabaseException.java
+++ b/database/src/main/java/com/findwise/hydra/DatabaseException.java
@@ -1,0 +1,24 @@
+package com.findwise.hydra;
+
+public class DatabaseException extends Exception {
+
+	public DatabaseException() {
+		super();
+	}
+
+	public DatabaseException(String message) {
+		super(message);
+	}
+
+	public DatabaseException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public DatabaseException(Throwable cause) {
+		super(cause);
+	}
+
+	protected DatabaseException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}


### PR DESCRIPTION
The admin-service can now be configured with a property file, just like the Core.

This means the admin-service now supports authentication to MongoDB.

Adds a stub of a test for the service endpoint methods, suggestions on how to create proper tests for those are very welcome!
