### PR TITLE
Fixes one cause of #168

### DIFF
--- a/core/src/main/java/com/findwise/hydra/StageRunner.java
+++ b/core/src/main/java/com/findwise/hydra/StageRunner.java
@@ -99,7 +99,7 @@ public class StageRunner extends Thread {
 		stageDestroyer = new StageDestroyer();
 
 		setParameters(stageGroup.toPropertiesMap());
-		if (stageGroup.getStages().size() == 1) {
+		if (stageGroup.getSize() == 1) {
 			//If there is only a single stage in this group, it's configuration takes precedent
 			setParameters(stageGroup.getStages().iterator().next().getProperties());
 		}
@@ -133,7 +133,7 @@ public class StageRunner extends Thread {
 			return;
 		}
 
-		if (stageGroup.getStages().size() < 1) {
+		if (stageGroup.getSize() < 1) {
 			logger.info("Stage group " + stageGroup.getName() + " has no stages, and can not be started.");
 			return;
 		}

--- a/core/src/main/java/com/findwise/hydra/StageRunner.java
+++ b/core/src/main/java/com/findwise/hydra/StageRunner.java
@@ -133,7 +133,7 @@ public class StageRunner extends Thread {
 			return;
 		}
 
-		if (stageGroup.getSize() < 1) {
+		if (stageGroup.isEmpty()) {
 			logger.info("Stage group " + stageGroup.getName() + " has no stages, and can not be started.");
 			return;
 		}

--- a/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoPipelineWriter.java
+++ b/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoPipelineWriter.java
@@ -14,11 +14,17 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.WriteConcern;
+import com.mongodb.WriteResult;
 import com.mongodb.gridfs.GridFS;
 import com.mongodb.gridfs.GridFSDBFile;
 import com.mongodb.gridfs.GridFSInputFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MongoPipelineWriter implements PipelineWriter {
+
+	private final Logger logger = LoggerFactory.getLogger(MongoPipelineWriter.class);
+
 	private GridFS pipelinefs;
 	private DBCollection stages;
 	private MongoPipelineReader reader;
@@ -125,12 +131,18 @@ public class MongoPipelineWriter implements PipelineWriter {
 	
 	private void writeProperties(StageGroup stageGroup) {
 		DBObject q = reader.getGroupQuery(stageGroup.getName());
-		stages.update(q, getGroupDBObject(stageGroup), true, false, concern);
+		WriteResult result = stages.update(q, getGroupDBObject(stageGroup), true, false, concern);
+		if (logger.isDebugEnabled()) {
+			logger.debug("Wrote properties for group '{}', operation updated '{}' objects, got message '{}'", stageGroup.getName(), result.getN(), result);
+		}
 	}
 	
 	public void write(Stage stage, String group) throws IOException  {
 		DBObject q = reader.getStageQuery(stage.getName());
-		stages.update(q, getStageDBObject(stage, group), true, false, concern);
+		WriteResult result = stages.update(q, getStageDBObject(stage, group), true, false, concern);
+		if (logger.isDebugEnabled()) {
+			logger.debug("Wrote stage '{}' in group '{}', operation updated '{}' objects, got message '{}'", stage.getName(), group, result.getN(), result);
+		}
 	}
 
 	@Override

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoPipelineIOIT.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoPipelineIOIT.java
@@ -125,8 +125,8 @@ public class MongoPipelineIOIT {
 		Assert.assertTrue(reader.getPipeline().hasGroup("multi"));
 		Assert.assertTrue(reader.getPipeline().hasGroup("singleStage"));
 
-		Assert.assertEquals(2, reader.getPipeline().getGroup("multi").getStages().size());
-		Assert.assertEquals(1, reader.getPipeline().getGroup("singleStage").getStages().size());
+		Assert.assertEquals(2, reader.getPipeline().getGroup("multi").getSize());
+		Assert.assertEquals(1, reader.getPipeline().getGroup("singleStage").getSize());
 	}
 	
 	@Test

--- a/database/src/main/java/com/findwise/hydra/StageGroup.java
+++ b/database/src/main/java/com/findwise/hydra/StageGroup.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.Collections;
 
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
@@ -154,7 +155,7 @@ public class StageGroup {
 	}
 	
 	public Set<String> getStageNames() {
-		return stages.keySet();
+		return Collections.unmodifiableSet(new HashSet<String>(stages.keySet()));
 	}
 	
 	public boolean hasStage(String name) {
@@ -205,9 +206,7 @@ public class StageGroup {
 	}
 
 	public Set<Stage> getStages() {
-		Set<Stage> s = new HashSet<Stage>();
-		s.addAll(stages.values());
-		return s;
+		return Collections.unmodifiableSet(new HashSet<Stage>(stages.values()));
 	}
 	
 	public void addStage(Stage stage) {

--- a/database/src/main/java/com/findwise/hydra/StageGroup.java
+++ b/database/src/main/java/com/findwise/hydra/StageGroup.java
@@ -181,7 +181,7 @@ public class StageGroup {
 		}
 		
 		StageGroup g = (StageGroup) obj;
-		if(g.getStages().size() == stages.size()) {
+		if(g.getSize() == stages.size()) {
 			for(Stage s : g.getStages()) {
 				if(!hasStage(s.getName()) || !getStage(s.getName()).equals(s)) {
 					return false;
@@ -211,5 +211,9 @@ public class StageGroup {
 	
 	public void addStage(Stage stage) {
 		stages.put(stage.getName(), stage);
+	}
+
+	public int getSize() {
+		return stages.size();
 	}
 }

--- a/database/src/main/java/com/findwise/hydra/StageGroup.java
+++ b/database/src/main/java/com/findwise/hydra/StageGroup.java
@@ -23,7 +23,7 @@ public class StageGroup {
 	public static final String CLASSPATH_KEY = "classpath";
 	public static final String JAVA_LOCATION_KEY = "java_location";
 	
-	private Map<String, Stage> stages;
+	private final Map<String, Stage> stages;
 	
 	private String jvmParameters;
 	private String classpath;
@@ -215,5 +215,9 @@ public class StageGroup {
 
 	public int getSize() {
 		return stages.size();
+	}
+
+	public boolean isEmpty() {
+		return stages.isEmpty();
 	}
 }

--- a/database/src/main/java/com/findwise/hydra/StageGroup.java
+++ b/database/src/main/java/com/findwise/hydra/StageGroup.java
@@ -22,7 +22,7 @@ public class StageGroup {
 	public static final String CLASSPATH_KEY = "classpath";
 	public static final String JAVA_LOCATION_KEY = "java_location";
 	
-	private Set<Stage> stages;
+	private Map<String, Stage> stages;
 	
 	private String jvmParameters;
 	private String classpath;
@@ -37,7 +37,7 @@ public class StageGroup {
 	private static final Logger logger = LoggerFactory.getLogger(StageGroup.class);
 	
 	public StageGroup(String name) {
-		stages = new HashSet<Stage>();
+		stages = new HashMap<String, Stage>();
 		this.name = name;
 	}
 	
@@ -140,7 +140,7 @@ public class StageGroup {
 	public Set<DatabaseFile> getDatabaseFiles() {
 		Map<Object, DatabaseFile> files = new HashMap<Object, DatabaseFile>();
 		
-		for(Stage s : stages) {
+		for(Stage s : stages.values()) {
 			if(s.getDatabaseFile()==null) {
 				logger.error("Stage group '"+s.getName()+"' is missing it's library file");
 				return null;
@@ -154,15 +154,11 @@ public class StageGroup {
 	}
 	
 	public Set<String> getStageNames() {
-		HashSet<String> names = new HashSet<String>();
-		for(Stage stage : stages) {
-			names.add(stage.getName());
-		}
-		return names;
+		return stages.keySet();
 	}
 	
 	public boolean hasStage(String name) {
-		return getStage(name)!=null;
+		return stages.containsKey(name);
 	}
 
 	@Override
@@ -201,29 +197,20 @@ public class StageGroup {
 	}
 
 	public Stage getStage(String name) {
-		for(Stage stage : stages) {
-			if(stage.getName().equals(name)) {
-				return stage;
-			}
-		}
-		return null;
+		return stages.get(name);
 	}
 	
 	public Stage removeStage(String stageName) {
-		for(Stage stage : stages) {
-			if(stage.getName().equals(stageName)) {
-				stages.remove(stage);
-				return stage;
-			}
-		}
-		return null;
+		return stages.remove(stageName);
 	}
 
 	public Set<Stage> getStages() {
-		return stages;
+		Set<Stage> s = new HashSet<Stage>();
+		s.addAll(stages.values());
+		return s;
 	}
 	
-	public boolean addStage(Stage stage) {
-		return stages.add(stage);
+	public void addStage(Stage stage) {
+		stages.put(stage.getName(), stage);
 	}
 }

--- a/database/src/test/java/com/findwise/hydra/StageGroupTest.java
+++ b/database/src/test/java/com/findwise/hydra/StageGroupTest.java
@@ -32,7 +32,7 @@ public class StageGroupTest {
 		stageGroup.addStage(stageConfig1);
 		stageGroup.addStage(stageConfig2);
 		
-		assertEquals(1, stageGroup.getStages().size());
+		assertEquals(1, stageGroup.getSize());
 		assertEquals(stageConfig2, stageGroup.getStage("stage1"));
 	}
 }

--- a/database/src/test/java/com/findwise/hydra/StageGroupTest.java
+++ b/database/src/test/java/com/findwise/hydra/StageGroupTest.java
@@ -1,0 +1,38 @@
+package com.findwise.hydra;
+
+import static org.junit.Assert.*;
+
+import java.util.Date;
+import java.util.HashMap;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+public class StageGroupTest {
+
+	@Mock private DatabaseFile databaseFile;
+
+	private StageGroup stageGroup;
+
+	@Before
+	public void setUp() throws Exception {
+		stageGroup = new StageGroup("testgroup");
+	}
+
+	@Test
+	public void testAddStage_replaces_configuration() {
+		Stage stageConfig1 = new Stage("stage1", databaseFile);
+		stageConfig1.setProperties(new HashMap<String, Object>());
+		stageConfig1.setPropertiesModifiedDate(new Date(1000));
+		Stage stageConfig2 = new Stage("stage1", databaseFile);
+		stageConfig2.setProperties(new HashMap<String, Object>());
+		stageConfig2.setPropertiesModifiedDate(new Date(2000));
+
+		stageGroup.addStage(stageConfig1);
+		stageGroup.addStage(stageConfig2);
+		
+		assertEquals(1, stageGroup.getStages().size());
+		assertEquals(stageConfig2, stageGroup.getStage("stage1"));
+	}
+}


### PR DESCRIPTION
`StageGroup`s were keeping the stage configurations in a HashSet, where the hashcode for each configuration was dependent on when it was created. This means a stage could get several configurations in the same stage group. When the set of stages was iterated on, the order was not guaranteed which often meant the old config was applied instead of the new.

The set is now a map using the stage name as key instead.

This should solve part of #168, although I believe there is more going on that causes the unreliable config updates.
