### PR TITLE
SimpleFetchingTikaStage should close its resources after fetching

### DIFF
--- a/stages/processing/tika/pom.xml
+++ b/stages/processing/tika/pom.xml
@@ -15,12 +15,6 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit-dep</artifactId>
-			<version>4.8.2</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>com.findwise.hydra</groupId>
 			<artifactId>hydra-api</artifactId>
 			<version>0.4.0-SNAPSHOT</version>
@@ -32,9 +26,15 @@
 			<version>1.1</version>
 		</dependency>
 		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>1.9.0</version>
+			<version>1.9.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/stages/processing/tika/src/main/java/com/findwise/hydra/stage/tika/SimpleFetchingTikaStage.java
+++ b/stages/processing/tika/src/main/java/com/findwise/hydra/stage/tika/SimpleFetchingTikaStage.java
@@ -1,6 +1,7 @@
 package com.findwise.hydra.stage.tika;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
@@ -58,9 +59,14 @@ public class SimpleFetchingTikaStage extends AbstractProcessStage {
 					String num = (i > 1) ? "" + i : "";
 					URL url = it.next();
 					URLConnection connection = createConnection(url);
+					final InputStream inputStream = connection.getInputStream();
+					try {
 					TikaUtils.enrichDocumentWithFileContents(doc, field + num
-							+ "_", connection.getInputStream(), parser,
+							+ "_", inputStream, parser,
 							addMetaData, addLanguage);
+					} finally {
+						inputStream.close();
+					}
 				}
 			} catch (URISyntaxException e) {
 				throw new ProcessException("A field matching the pattern "

--- a/stages/processing/tika/src/main/java/com/findwise/hydra/stage/tika/SimpleFetchingTikaStage.java
+++ b/stages/processing/tika/src/main/java/com/findwise/hydra/stage/tika/SimpleFetchingTikaStage.java
@@ -30,19 +30,19 @@ public class SimpleFetchingTikaStage extends AbstractProcessStage {
 	@Parameter(required = true, description = "The field name pattern that should be matched where " +
 			"urls will be found. First group plus \"_\" will be used as field prefix. Example:" +
 			" \"attachment_(.*)\" will match for example attachment_a and will use \"a_\" as prefix")
-	private String urlFieldPattern = null;
+	public String urlFieldPattern = null;
 
 	@Parameter(name = "addMetaData", description = "Add the metadata to the document or not. Defaults to true")
-	private boolean addMetaData = true;
+	public boolean addMetaData = true;
 
 	@Parameter(description = "Set to true, will also do language detection and add the field 'prefix_language' according to the prefix rules. Defaults to true")
-	private boolean addLanguage = true;
+	public boolean addLanguage = true;
 
 	@Parameter(description = "Username for basic authentication.")
-	private String username = null;
+	public String username = null;
 
 	@Parameter(description = "Password for basic authentication.")
-	private String password = null;
+	public String password = null;
 
 	private Parser parser = new AutoDetectParser();
 

--- a/stages/processing/tika/src/test/java/com/findwise/hydra/stage/tika/SimpleFetchingTikaStageTest.java
+++ b/stages/processing/tika/src/test/java/com/findwise/hydra/stage/tika/SimpleFetchingTikaStageTest.java
@@ -4,13 +4,12 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.Arrays;
 
-import junit.framework.Assert;
-
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.parser.AutoDetectParser;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.sax.BodyContentHandler;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -23,7 +22,7 @@ public class SimpleFetchingTikaStageTest {
 	private SimpleFetchingTikaStage stage;
 	private LocalDocument doc;
 
-	private String pattern = "attachment_(.*)";
+	private final String pattern = "attachment_(.*)";
 
 	@Before
 	public void init() {
@@ -48,7 +47,6 @@ public class SimpleFetchingTikaStageTest {
 						Mockito.any(Metadata.class),
 						Mockito.any(ParseContext.class));
 		stage.process(doc);
-
 	}
 	
 	@Test

--- a/stages/processing/tika/src/test/java/com/findwise/hydra/stage/tika/utils/TikaUtilsTest.java
+++ b/stages/processing/tika/src/test/java/com/findwise/hydra/stage/tika/utils/TikaUtilsTest.java
@@ -1,7 +1,7 @@
 package com.findwise.hydra.stage.tika.utils;
 
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.io.StringWriter;
 import java.net.URI;
@@ -12,10 +12,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Assert;
-
 import org.apache.tika.metadata.Metadata;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -24,7 +23,7 @@ import com.findwise.hydra.local.LocalDocument;
 public class TikaUtilsTest {
 	private LocalDocument doc;
 	
-	private String pattern = "attachment_(.*)";
+	private final String pattern = "attachment_(.*)";
 
 
 	@Before
@@ -72,8 +71,9 @@ public class TikaUtilsTest {
 		List<URL> urls = TikaUtils.getUrlsFromObject("http://google.com");
 
 		Assert.assertEquals(1, urls.size());
-		for (URL url : urls)
+		for (URL url : urls) {
 			Assert.assertEquals("http://google.com", url.toString());
+		}
 	}
 
 	@Test


### PR DESCRIPTION
There is an issue with fetching from windows file urls where the SimpleFetchingTikaStage leaves behind open and therefor locked files.

This patch resolves those issues and well as cleans up some code.
