### PR TITLE
Fixes to stage parameter parsing

### DIFF
--- a/api/src/test/java/com/findwise/hydra/stage/AbstractStageTest.java
+++ b/api/src/test/java/com/findwise/hydra/stage/AbstractStageTest.java
@@ -2,9 +2,13 @@ package com.findwise.hydra.stage;
 
 import static org.junit.Assert.*;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import com.findwise.hydra.JsonException;
 import org.junit.Test;
 
 import com.findwise.hydra.Document.Action;
@@ -15,12 +19,20 @@ import com.findwise.hydra.stage.AbstractStageTest.TestStage.Enumerable;
 public class AbstractStageTest {
 
 	@Test
-	public void testSetParameters() throws Exception {
+	public void testSetParameters_sets_all_supplied_parameters() throws Exception {
 		HashMap<String, Object> parameters = new HashMap<String, Object>();
 		parameters.put("string", "string");
 		parameters.put("integer", 100);
 		parameters.put("e1", "A");
 		parameters.put("e2", 1);
+		parameters.put("externalName", "a string");
+		parameters.put("requiredInteger", 2);
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("key", "value");
+		parameters.put("map", map);
+		List<String> list = new ArrayList<String>();
+		list.add("item");
+		parameters.put("list", list);
 		LocalQuery query = new LocalQuery();
 		query.requireAction(Action.ADD);
 		parameters.put("query", query);
@@ -34,9 +46,46 @@ public class AbstractStageTest {
 		assertEquals(100, stage.integer);
 		assertEquals(Enumerable.A, stage.e1);
 		assertEquals(Enumerable.B, stage.e2);
+		assertEquals("a string", stage.internalName);
+		assertEquals(2, stage.requiredInteger);
+		assertTrue(stage.map.entrySet().containsAll(map.entrySet()));
+		assertFalse(Collections.disjoint(map.entrySet(), stage.map.entrySet()));
+		assertTrue(stage.list.containsAll(list));
+		assertFalse(Collections.disjoint(list, stage.list));
 		assertEquals(query.getAction(), stage.query.getAction());
 	}
-	
+
+	@Test(expected = RequiredArgumentMissingException.class)
+	public void testSetParameters_throws_RequiredArgumentException_when_required_argument_missing() throws JsonException, RequiredArgumentMissingException, IllegalAccessException {
+		HashMap<String, Object> parameters = new HashMap<String, Object>();
+		parameters.put("string", "string");
+		LocalQuery query = new LocalQuery();
+		query.requireAction(Action.ADD);
+		parameters.put("query", query);
+
+		Map<String, Object> serialized = SerializationUtils.fromJson(SerializationUtils.toJson(parameters));
+
+		TestStage stage = new TestStage();
+		stage.setParameters(serialized);
+	}
+
+	@Test
+	public void testSetParameters_does_not_throw_on_missing_nonrequired_parameters() throws JsonException, RequiredArgumentMissingException, IllegalAccessException {
+		HashMap<String, Object> parameters = new HashMap<String, Object>();
+		parameters.put("requiredInteger", 2);
+		LocalQuery query = new LocalQuery();
+		query.requireAction(Action.ADD);
+		parameters.put("query", query);
+
+		Map<String, Object> serialized = SerializationUtils.fromJson(SerializationUtils.toJson(parameters));
+
+		TestStage stage = new TestStage();
+		stage.setParameters(serialized);
+
+		assertEquals(2, stage.requiredInteger);
+		assertEquals(query.getAction(), stage.query.getAction());
+	}
+
 	@Stage
 	static class TestStage extends AbstractStage {
 		@Parameter
@@ -55,6 +104,18 @@ public class AbstractStageTest {
 		
 		@Parameter
 		private LocalQuery query;
+
+		@Parameter(name = "externalName")
+		private String internalName;
+
+		@Parameter(required = true)
+		private int requiredInteger;
+
+		@Parameter
+		private Map<String, Object> map;
+
+		@Parameter
+		private List<String> list;
 	}
 
 }

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/SetStaticFieldStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/SetStaticFieldStage.java
@@ -18,8 +18,7 @@ public class SetStaticFieldStage extends AbstractProcessStage {
 		OVERWRITE, SKIP, THROW, ADD
 	}
 
-	@Parameter(required = true, name = "fieldNames",
-			description = "A map of fields to modify, and the values to write to them")
+	@Parameter(required = true, name = "fieldValueMap", description = "A map of fields to modify, and the values to write to them")
 	private Map<String, Object> fieldValueMap;
 	@Parameter(name = "overwritePolicy",
 			description = "Switch for behaviour when modifying. Available options: 0/OVERWRITE = overwrite content, 1/SKIP = skip if there is content, 2/THROW = throw exception if there is content, 3/ADD = append to content, converting the content to a list if necessary (default)")


### PR DESCRIPTION
- Fixes missing check for required parameters. All stages will now once again fail to start if a `required`parameter is missing.
- Fixes problems when giving parameters a different name than their Java field name. Any `name` given in the `@Parameter` annotation will take precedence over the member variable name.
- Changes the annotated name of the configuration map in `SetStaticFieldStage` to match the name of the variable (as that was previously the correct name)
