### PR TITLE
Fix for #259: Removes Java 7-specific constructor

### DIFF
--- a/database/src/main/java/com/findwise/hydra/DatabaseException.java
+++ b/database/src/main/java/com/findwise/hydra/DatabaseException.java
@@ -17,8 +17,4 @@ public class DatabaseException extends Exception {
 	public DatabaseException(Throwable cause) {
 		super(cause);
 	}
-
-	protected DatabaseException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-		super(message, cause, enableSuppression, writableStackTrace);
-	}
 }


### PR DESCRIPTION
Removes the accidentally added Java 7 method for `DatabaseException`. This allows Hydra to build on Java 6.

Fixes #259 

Not sure why this was not caught by having maven specify the source as 1.6. No regression should be possible now, though, since I added a java 6 build to Travis CI.
