### PR TITLE
AbstractProcessStage timeouts and cleaner shutdown

### DIFF
--- a/api/src/main/java/com/findwise/hydra/stage/AbstractProcessStage.java
+++ b/api/src/main/java/com/findwise/hydra/stage/AbstractProcessStage.java
@@ -132,11 +132,7 @@ public abstract class AbstractProcessStage extends AbstractStage {
 				}
 			} catch (Exception e) {
 				logger.error("Caught exception while running", e);
-				Thread shutdownHook = getShutDownHook();
-				if (null != shutdownHook) {
-					Runtime.getRuntime().removeShutdownHook(shutdownHook);
-				}
-				System.exit(1);
+				killStage();
 			}
 		}
 		shutdownProcessing();
@@ -170,9 +166,10 @@ public abstract class AbstractProcessStage extends AbstractStage {
 				throw e;
 			}
 		} catch (TimeoutException e) {
-			handleProcessException(doc, new ProcessException(e));
 			boolean interruptIfRunning = true;
-			if (!future.cancel(interruptIfRunning)) {
+			boolean cancelSucceeded = future.cancel(interruptIfRunning);
+			handleProcessException(doc, new ProcessException(e));
+			if (!cancelSucceeded) {
 				logger.error("Processing for doc '{}' timed out and processing thread could not be cancelled", doc.getID());
 				throw e;
 			}

--- a/api/src/main/java/com/findwise/hydra/stage/AbstractProcessStage.java
+++ b/api/src/main/java/com/findwise/hydra/stage/AbstractProcessStage.java
@@ -41,7 +41,7 @@ public abstract class AbstractProcessStage extends AbstractStage {
 	private long holdInterval = DEFAULT_HOLD_INTERVAL;
 
 	private long terminationTimeout = DEFAULT_SHUTDOWN_TIMEOUT;
-	public static final int DEFAULT_SHUTDOWN_TIMEOUT = 2000;
+	public static final long DEFAULT_SHUTDOWN_TIMEOUT = TimeUnit.SECONDS.toMillis(2);
 
 	// The size of the thread pool is limited to 1, as the pool is only used for timeout functionality, not concurrency
 	private final ExecutorService executor;

--- a/api/src/main/java/com/findwise/hydra/stage/AbstractStage.java
+++ b/api/src/main/java/com/findwise/hydra/stage/AbstractStage.java
@@ -36,7 +36,7 @@ public abstract class AbstractStage extends Thread {
 	public static final String ARG_NAME_STAGE_CLASS = "stageClass";
 	public static final String PROPERTY_NAME_COMMANDLINE_ARGS = "cmdline_args";
 	
-	@Parameter(description="The Query that this stage will recieve documents matching")
+	@Parameter(description="The Query that this stage will receive documents matching")
 	private LocalQuery query = new LocalQuery();
 	
 	@Parameter(description="Number of instances (threads) to start of this stage within a single JVM. Defaults to 1.")

--- a/api/src/main/java/com/findwise/hydra/stage/AbstractStage.java
+++ b/api/src/main/java/com/findwise/hydra/stage/AbstractStage.java
@@ -54,7 +54,10 @@ public abstract class AbstractStage extends Thread {
 	public static final int DEFAULT_HOLD_INTERVAL = 2000;
 	private RemotePipeline remotePipeline = null;
 	private Thread shutDownHook;
-	
+
+	private String stageName;
+	private boolean continueRunning;
+
 	/**
 	 * Initiates an implementation of AbstractDocument. When this method is
 	 * called, and Object of the class has been initialized. The arguments
@@ -74,9 +77,6 @@ public abstract class AbstractStage extends Thread {
 	public void setShutDownHook(Thread shutDownHook) {
 		this.shutDownHook = shutDownHook;
 	}
-
-	private String stageName;
-	private boolean continueRunning;
 
 	/**
 	 * 

--- a/api/src/main/java/com/findwise/hydra/stage/AbstractStage.java
+++ b/api/src/main/java/com/findwise/hydra/stage/AbstractStage.java
@@ -41,10 +41,8 @@ public abstract class AbstractStage extends Thread {
 	
 	@Parameter(description="Number of instances (threads) to start of this stage within a single JVM. Defaults to 1.")
 	private int numberOfThreads = 1;
-	
-	public LocalQuery getQuery() {
-		return query;
-	}
+
+	private StageKiller stageKiller = new JvmStageKiller();
 	
 	public static final int CMDLINE_STAGE_NAME_PARAM = 0;
 	public static final int CMDLINE_PIPELINE_HOST_PARAM = 1;
@@ -120,6 +118,17 @@ public abstract class AbstractStage extends Thread {
 		return stageName;
 	}
 
+	public LocalQuery getQuery() {
+		return query;
+	}
+
+	public void setStageKiller(StageKiller stageKiller) {
+		this.stageKiller = stageKiller;
+	}
+
+	public void killStage() {
+		this.stageKiller.kill(this);
+	}
 	
 	/**
 	 * Injects the parameters found in the map to any fields annotated with @Stage, whose names matches

--- a/api/src/main/java/com/findwise/hydra/stage/GroupStarter.java
+++ b/api/src/main/java/com/findwise/hydra/stage/GroupStarter.java
@@ -18,7 +18,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * 
+ * Starts a StageGroup in a new JVM by fetching stage names and setting up logging.
+ * This class delegates the actual startup procedure to {@link AbstractStage}.
+ *
  * @author joel.westberg
  *
  */

--- a/api/src/main/java/com/findwise/hydra/stage/JvmStageKiller.java
+++ b/api/src/main/java/com/findwise/hydra/stage/JvmStageKiller.java
@@ -1,0 +1,17 @@
+package com.findwise.hydra.stage;
+
+/**
+ * Kills stages by exiting the JVM.
+ *
+ * Will unregister shutdown hooks.
+ */
+public class JvmStageKiller implements StageKiller {
+	@Override
+	public void kill(AbstractStage stage) {
+		Thread shutdownHook = stage.getShutDownHook();
+		if (null != shutdownHook) {
+			Runtime.getRuntime().removeShutdownHook(shutdownHook);
+		}
+		System.exit(1);
+	}
+}

--- a/api/src/main/java/com/findwise/hydra/stage/ProcessException.java
+++ b/api/src/main/java/com/findwise/hydra/stage/ProcessException.java
@@ -1,16 +1,10 @@
 package com.findwise.hydra.stage;
 
 /**
- * Created by IntelliJ IDEA.
- * User:  karl.neyvaldt
- * Date:  5/9/11
- * Time:  4:36 PM
- * E-mail: karl.neyvaldt@findwise.com
+ * @author karl.neyvaldt
  */
 public class ProcessException extends Exception {
-	/**
-	 * 
-	 */
+
 	private static final long serialVersionUID = 1L;
 	
 	public ProcessException(String msg){
@@ -25,7 +19,7 @@ public class ProcessException extends Exception {
 		super(cause);
 	}
 	
-    public ProcessException(String message, Throwable cause) {
-        super(message, cause);
-    }
+	public ProcessException(String message, Throwable cause) {
+		super(message, cause);
+	}
 }

--- a/api/src/main/java/com/findwise/hydra/stage/RequiredArgumentMissingException.java
+++ b/api/src/main/java/com/findwise/hydra/stage/RequiredArgumentMissingException.java
@@ -1,9 +1,7 @@
 package com.findwise.hydra.stage;
 
 public class RequiredArgumentMissingException extends Exception {
-	/**
-	 * 
-	 */
+
 	private static final long serialVersionUID = 1L;
 
 	public RequiredArgumentMissingException(String msg){
@@ -18,7 +16,7 @@ public class RequiredArgumentMissingException extends Exception {
 		super(cause);
 	}
 	
-    public RequiredArgumentMissingException(String message, Throwable cause) {
-        super(message, cause);
-    }
+	public RequiredArgumentMissingException(String message, Throwable cause) {
+		super(message, cause);
+	}
 }

--- a/api/src/main/java/com/findwise/hydra/stage/Stage.java
+++ b/api/src/main/java/com/findwise/hydra/stage/Stage.java
@@ -8,8 +8,7 @@ import java.lang.annotation.Target;
 
 /**
  * Denotes a Hydra Stage
- * 
- * Strictly a label for now
+ *
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/com/findwise/hydra/stage/StageKiller.java
+++ b/api/src/main/java/com/findwise/hydra/stage/StageKiller.java
@@ -1,0 +1,5 @@
+package com.findwise.hydra.stage;
+
+public interface StageKiller {
+	public void kill(AbstractStage stage);
+}

--- a/api/src/test/java/com/findwise/hydra/stage/AbstractProcessStageTest.java
+++ b/api/src/test/java/com/findwise/hydra/stage/AbstractProcessStageTest.java
@@ -38,7 +38,7 @@ public class AbstractProcessStageTest {
 	}
 
 	@Test
-	public void testDocumentProcessException() throws Exception {
+	public void testProcess_does_not_fail_document_when_failDocumentOnProcessException_is_false() throws Exception {
 		rp = mock(RemotePipeline.class);
 		stage = new LimitedCountExceptionStage(3);
 		stage.setRemotePipeline(rp);
@@ -65,7 +65,7 @@ public class AbstractProcessStageTest {
 	}
 
 	@Test
-	public void testFailDocumentOnProcessException() throws Exception {
+	public void testProcess_fails_document_on_processException() throws Exception {
 		rp = mock(RemotePipeline.class);
 		stage = new LimitedCountExceptionStage(3);
 		stage.setRemotePipeline(rp);
@@ -92,7 +92,7 @@ public class AbstractProcessStageTest {
 	}
 
 	@Test
-	public void testPersistError() throws Exception {
+	public void testProcess_persists_error() throws Exception {
 		stage = new SingleDocumentExceptionStage();
 		stage.setName("stagename");
 		RemotePipeline rp = mock(RemotePipeline.class);
@@ -113,7 +113,7 @@ public class AbstractProcessStageTest {
 	}
 
 	@Test
-	public void testPersistErrorOnSaveFailure() throws Exception {
+	public void testProcess_persists_error_on_save_failure() throws Exception {
 		RemotePipeline rp = mock(RemotePipeline.class);
 		when(rp.getDocument(any(LocalQuery.class))).thenReturn(new LocalDocument());
 

--- a/api/src/test/java/com/findwise/hydra/stage/ImmediateStoppingStage.java
+++ b/api/src/test/java/com/findwise/hydra/stage/ImmediateStoppingStage.java
@@ -1,0 +1,12 @@
+package com.findwise.hydra.stage;
+
+import com.findwise.hydra.local.LocalDocument;
+
+@Stage
+class ImmediateStoppingStage extends AbstractProcessStage {
+
+	@Override
+	public void process(LocalDocument doc) throws ProcessException {
+		stopStage();
+	}
+}

--- a/api/src/test/java/com/findwise/hydra/stage/InterruptibleWaitingStage.java
+++ b/api/src/test/java/com/findwise/hydra/stage/InterruptibleWaitingStage.java
@@ -1,0 +1,20 @@
+package com.findwise.hydra.stage;
+
+import com.findwise.hydra.local.LocalDocument;
+
+@Stage
+class InterruptibleWaitingStage extends AbstractProcessStage {
+
+	@Override
+	public void process(LocalDocument doc) throws ProcessException {
+		try {
+			while (true) {
+				sleep(100);
+			}
+		} catch (InterruptedException e) {
+			return;
+		} finally {
+			stopStage();
+		}
+	}
+}

--- a/api/src/test/java/com/findwise/hydra/stage/LimitedCountExceptionStage.java
+++ b/api/src/test/java/com/findwise/hydra/stage/LimitedCountExceptionStage.java
@@ -1,0 +1,28 @@
+package com.findwise.hydra.stage;
+
+import com.findwise.hydra.local.LocalDocument;
+
+@Stage
+class LimitedCountExceptionStage extends AbstractProcessStage {
+
+	private int count = 0;
+	private final int limit;
+
+	public LimitedCountExceptionStage(int limit) {
+		super();
+		this.limit = limit;
+	}
+
+	@Override
+	public void process(LocalDocument doc) throws ProcessException {
+		try {
+			count++;
+			throw new ProcessException("processed: " + count);
+		} finally {
+			if (count >= limit) {
+				stopStage();
+			}
+		}
+
+	}
+}

--- a/api/src/test/java/com/findwise/hydra/stage/LimitedCountInterruptibleWaitingStage.java
+++ b/api/src/test/java/com/findwise/hydra/stage/LimitedCountInterruptibleWaitingStage.java
@@ -1,0 +1,30 @@
+package com.findwise.hydra.stage;
+
+import com.findwise.hydra.local.LocalDocument;
+
+@Stage
+class LimitedCountInterruptibleWaitingStage extends AbstractProcessStage {
+
+	private int count = 0;
+	private final int limit;
+
+	public LimitedCountInterruptibleWaitingStage(int limit) {
+		this.limit = limit;
+	}
+
+	@Override
+	public void process(LocalDocument doc) throws ProcessException {
+		try {
+			count++;
+			while (true) {
+				sleep(100);
+			}
+		} catch (InterruptedException e) {
+			return;
+		} finally {
+			if (count >= limit) {
+				stopStage();
+			}
+		}
+	}
+}

--- a/api/src/test/java/com/findwise/hydra/stage/SingleDocumentExceptionStage.java
+++ b/api/src/test/java/com/findwise/hydra/stage/SingleDocumentExceptionStage.java
@@ -1,0 +1,16 @@
+package com.findwise.hydra.stage;
+
+import com.findwise.hydra.local.LocalDocument;
+
+@Stage
+class SingleDocumentExceptionStage extends AbstractProcessStage {
+
+	@Override
+	public void process(LocalDocument doc) throws ProcessException {
+		try {
+			throw new ProcessException("msg");
+		} finally {
+			stopStage();
+		}
+	}
+}

--- a/core/src/main/java/com/findwise/hydra/Main.java
+++ b/core/src/main/java/com/findwise/hydra/Main.java
@@ -16,7 +16,7 @@ import com.findwise.hydra.mongodb.MongoType;
 import com.findwise.hydra.net.HttpRESTHandler;
 import com.findwise.hydra.net.RESTServer;
 
-public final class Main implements TerminationHandler {
+public final class Main implements ShutdownHandler {
 
 	private static final long KILL_DELAY = TimeUnit.SECONDS.toMillis(30);
 
@@ -133,7 +133,7 @@ public final class Main implements TerminationHandler {
 		}
 	}
 
-	public boolean isTerminating() {
+	public boolean isShuttingDown() {
 		return shuttingDown;
 	}
 
@@ -162,17 +162,17 @@ public final class Main implements TerminationHandler {
 
 	private class ShuttingDownOnUncaughtException implements UncaughtExceptionHandler {
 
-		private final TerminationHandler terminationHandler;
+		private final ShutdownHandler shutdownHandler;
 
-		public ShuttingDownOnUncaughtException(TerminationHandler terminationHandler) {
-			this.terminationHandler = terminationHandler;
+		public ShuttingDownOnUncaughtException(ShutdownHandler shutdownHandler) {
+			this.shutdownHandler = shutdownHandler;
 		}
 
 		@Override
 		public void uncaughtException(Thread t, Throwable e) {
-			if (!terminationHandler.isTerminating()) {
+			if (!shutdownHandler.isShuttingDown()) {
 				logger.error("Got an uncaught exception. Shutting down Hydra", e);
-				terminationHandler.shutdown();
+				shutdownHandler.shutdown();
 			} else {
 				logger.error("Got exception while shutting down", e);
 			}

--- a/core/src/main/java/com/findwise/hydra/Main.java
+++ b/core/src/main/java/com/findwise/hydra/Main.java
@@ -2,12 +2,14 @@ package com.findwise.hydra;
 
 import java.io.IOException;
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.concurrent.TimeUnit;
 
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.net.SimpleSocketServer;
 import org.apache.commons.configuration.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.net.SimpleSocketServer;
 
 import com.findwise.hydra.mongodb.MongoConnector;
 import com.findwise.hydra.mongodb.MongoType;
@@ -112,8 +114,7 @@ public final class Main {
 	private static void shutdown() {
 		logger.info("Got shutdown request...");
 		shuttingDown = true;
-
-		long killDelay = 30 * 1000;
+		long killDelay = TimeUnit.SECONDS.toMillis(30);
 		killUnlessShutdownWithin(killDelay);
 
 		if (simpleSocketServer != null) {

--- a/core/src/main/java/com/findwise/hydra/NodeMaster.java
+++ b/core/src/main/java/com/findwise/hydra/NodeMaster.java
@@ -24,9 +24,11 @@ public final class NodeMaster<T extends DatabaseType> extends Thread {
 	private int port;
 	
 	private CoreConfiguration conf;
+	private TerminationHandler terminationHandler;
 	
-	public NodeMaster(CoreConfiguration conf, CachingDocumentNIO<T> documentNIO, Pipeline pipeline) {
+	public NodeMaster(CoreConfiguration conf, CachingDocumentNIO<T> documentNIO, Pipeline pipeline, TerminationHandler terminationHandler) {
 		this.conf = conf;
+		this.terminationHandler = terminationHandler;
 		sm = StageManager.getStageManager();
 		this.pipeline = pipeline;
 		this.pollingInterval = conf.getPollingInterval();
@@ -129,7 +131,7 @@ public final class NodeMaster<T extends DatabaseType> extends Thread {
 			if(!pipeline.hasGroup(group.getName())) {
 				pipeline.addGroup(group);
 				if(attachFiles(group)) {
-					sm.addRunner(new StageRunner(group, new File(namespace), port, conf.isPerformanceLogging(), conf.getLoggingPort()));
+					sm.addRunner(new StageRunner(group, new File(namespace), port, conf.isPerformanceLogging(), conf.getLoggingPort(), terminationHandler));
 				} else {
 					logger.error("Was unable to start the stage group '"+group.getName()+"' due to missing libraries.");
 				}

--- a/core/src/main/java/com/findwise/hydra/NodeMaster.java
+++ b/core/src/main/java/com/findwise/hydra/NodeMaster.java
@@ -24,11 +24,11 @@ public final class NodeMaster<T extends DatabaseType> extends Thread {
 	private int port;
 	
 	private CoreConfiguration conf;
-	private TerminationHandler terminationHandler;
+	private ShutdownHandler shutdownHandler;
 	
-	public NodeMaster(CoreConfiguration conf, CachingDocumentNIO<T> documentNIO, Pipeline pipeline, TerminationHandler terminationHandler) {
+	public NodeMaster(CoreConfiguration conf, CachingDocumentNIO<T> documentNIO, Pipeline pipeline, ShutdownHandler shutdownHandler) {
 		this.conf = conf;
-		this.terminationHandler = terminationHandler;
+		this.shutdownHandler = shutdownHandler;
 		sm = StageManager.getStageManager();
 		this.pipeline = pipeline;
 		this.pollingInterval = conf.getPollingInterval();
@@ -131,7 +131,7 @@ public final class NodeMaster<T extends DatabaseType> extends Thread {
 			if(!pipeline.hasGroup(group.getName())) {
 				pipeline.addGroup(group);
 				if(attachFiles(group)) {
-					sm.addRunner(new StageRunner(group, new File(namespace), port, conf.isPerformanceLogging(), conf.getLoggingPort(), terminationHandler));
+					sm.addRunner(new StageRunner(group, new File(namespace), port, conf.isPerformanceLogging(), conf.getLoggingPort(), shutdownHandler));
 				} else {
 					logger.error("Was unable to start the stage group '"+group.getName()+"' due to missing libraries.");
 				}

--- a/core/src/main/java/com/findwise/hydra/ShutdownHandler.java
+++ b/core/src/main/java/com/findwise/hydra/ShutdownHandler.java
@@ -1,0 +1,6 @@
+package com.findwise.hydra;
+
+public interface ShutdownHandler {
+	public boolean isShuttingDown();
+	public void shutdown();
+}

--- a/core/src/main/java/com/findwise/hydra/StageRunner.java
+++ b/core/src/main/java/com/findwise/hydra/StageRunner.java
@@ -150,7 +150,7 @@ public class StageRunner extends Thread {
 				logger.error("The stage group " + stageGroup.getName() + " did not start. It will not be restarted until configuration changes.");
 				return;
 			}
-		} while (timesToRetry == -1 || timesToRetry >= timesStarted);
+		} while ((timesToRetry == -1 || timesToRetry >= timesStarted) && !Main.isShuttingDown());
 
 		logger.error("Stage group " + stageGroup.getName()
 				+ " has failed and cannot be restarted. ");

--- a/core/src/main/java/com/findwise/hydra/StageRunner.java
+++ b/core/src/main/java/com/findwise/hydra/StageRunner.java
@@ -50,7 +50,7 @@ public class StageRunner extends Thread {
 
 	private boolean started;
 	private boolean wasKilled = false;
-	private TerminationHandler terminationHandler;
+	private ShutdownHandler shutdownHandler;
 
 	public synchronized void setHasQueried() {
 		hasQueried = true;
@@ -60,14 +60,14 @@ public class StageRunner extends Thread {
 		return hasQueried;
 	}
 
-	public StageRunner(StageGroup stageGroup, File baseDirectory, int pipelinePort, boolean performanceLogging, int loggingPort, TerminationHandler terminationHandler) {
+	public StageRunner(StageGroup stageGroup, File baseDirectory, int pipelinePort, boolean performanceLogging, int loggingPort, ShutdownHandler shutdownHandler) {
 		this.stageGroup = stageGroup;
 		this.baseDirectory = baseDirectory;
 		this.targetDirectory = new File(baseDirectory, stageGroup.getName());
 		this.pipelinePort = pipelinePort;
 		this.performanceLogging = performanceLogging;
 		this.loggingPort = loggingPort;
-		this.terminationHandler = terminationHandler;
+		this.shutdownHandler = shutdownHandler;
 		timesStarted = 0;
 	}
 
@@ -152,7 +152,7 @@ public class StageRunner extends Thread {
 				logger.error("The stage group " + stageGroup.getName() + " did not start. It will not be restarted until configuration changes.");
 				return;
 			}
-		} while ((timesToRetry == -1 || timesToRetry >= timesStarted) && !terminationHandler.isTerminating());
+		} while ((timesToRetry == -1 || timesToRetry >= timesStarted) && !shutdownHandler.isShuttingDown());
 
 		logger.error("Stage group " + stageGroup.getName()
 				+ " has failed and cannot be restarted. ");

--- a/core/src/main/java/com/findwise/hydra/StageRunner.java
+++ b/core/src/main/java/com/findwise/hydra/StageRunner.java
@@ -50,6 +50,7 @@ public class StageRunner extends Thread {
 
 	private boolean started;
 	private boolean wasKilled = false;
+	private TerminationHandler terminationHandler;
 
 	public synchronized void setHasQueried() {
 		hasQueried = true;
@@ -59,13 +60,14 @@ public class StageRunner extends Thread {
 		return hasQueried;
 	}
 
-	public StageRunner(StageGroup stageGroup, File baseDirectory, int pipelinePort, boolean performanceLogging, int loggingPort) {
+	public StageRunner(StageGroup stageGroup, File baseDirectory, int pipelinePort, boolean performanceLogging, int loggingPort, TerminationHandler terminationHandler) {
 		this.stageGroup = stageGroup;
 		this.baseDirectory = baseDirectory;
 		this.targetDirectory = new File(baseDirectory, stageGroup.getName());
 		this.pipelinePort = pipelinePort;
 		this.performanceLogging = performanceLogging;
 		this.loggingPort = loggingPort;
+		this.terminationHandler = terminationHandler;
 		timesStarted = 0;
 	}
 
@@ -150,7 +152,7 @@ public class StageRunner extends Thread {
 				logger.error("The stage group " + stageGroup.getName() + " did not start. It will not be restarted until configuration changes.");
 				return;
 			}
-		} while ((timesToRetry == -1 || timesToRetry >= timesStarted) && !Main.isShuttingDown());
+		} while ((timesToRetry == -1 || timesToRetry >= timesStarted) && !terminationHandler.isTerminating());
 
 		logger.error("Stage group " + stageGroup.getName()
 				+ " has failed and cannot be restarted. ");

--- a/core/src/main/java/com/findwise/hydra/TerminationHandler.java
+++ b/core/src/main/java/com/findwise/hydra/TerminationHandler.java
@@ -1,6 +1,0 @@
-package com.findwise.hydra;
-
-public interface TerminationHandler {
-	public boolean isTerminating();
-	public void shutdown();
-}

--- a/core/src/main/java/com/findwise/hydra/TerminationHandler.java
+++ b/core/src/main/java/com/findwise/hydra/TerminationHandler.java
@@ -1,0 +1,6 @@
+package com.findwise.hydra;
+
+public interface TerminationHandler {
+	public boolean isTerminating();
+	public void shutdown();
+}

--- a/core/src/test/java/com/findwise/hydra/StageRunnerTest.java
+++ b/core/src/test/java/com/findwise/hydra/StageRunnerTest.java
@@ -21,7 +21,10 @@ public class StageRunnerTest {
 		group.addStage(mockedStage);
 		Mockito.when(mockedStage.getProperties()).thenReturn(new HashMap<String, Object>());
 		
-		StageRunner sr = new StageRunner(group, new File("test"), 0, false, 0);
+		TerminationHandler terminationHandler = Mockito.mock(TerminationHandler.class);
+		Mockito.when(terminationHandler.isTerminating()).thenReturn(false);
+		
+		StageRunner sr = new StageRunner(group, new File("test"), 0, false, 0, terminationHandler);
 		sr.setStageDestroyer(sd);
 		
 		sr.destroy();

--- a/core/src/test/java/com/findwise/hydra/StageRunnerTest.java
+++ b/core/src/test/java/com/findwise/hydra/StageRunnerTest.java
@@ -21,10 +21,10 @@ public class StageRunnerTest {
 		group.addStage(mockedStage);
 		Mockito.when(mockedStage.getProperties()).thenReturn(new HashMap<String, Object>());
 		
-		TerminationHandler terminationHandler = Mockito.mock(TerminationHandler.class);
-		Mockito.when(terminationHandler.isTerminating()).thenReturn(false);
+		ShutdownHandler shutdownHandler = Mockito.mock(ShutdownHandler.class);
+		Mockito.when(shutdownHandler.isShuttingDown()).thenReturn(false);
 		
-		StageRunner sr = new StageRunner(group, new File("test"), 0, false, 0, terminationHandler);
+		StageRunner sr = new StageRunner(group, new File("test"), 0, false, 0, shutdownHandler);
 		sr.setStageDestroyer(sd);
 		
 		sr.destroy();

--- a/core/src/test/java/com/findwise/hydra/net/RemotePipelineIT.java
+++ b/core/src/test/java/com/findwise/hydra/net/RemotePipelineIT.java
@@ -9,11 +9,13 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.findwise.hydra.CachingDocumentNIO;
 import com.findwise.hydra.ConfigurationFactory;
 import com.findwise.hydra.CoreConfiguration;
 import com.findwise.hydra.DatabaseDocument;
+import com.findwise.hydra.TerminationHandler;
 import com.findwise.hydra.Document.Action;
 import com.findwise.hydra.DocumentFile;
 import com.findwise.hydra.NodeMaster;
@@ -43,7 +45,11 @@ public class RemotePipelineIT {
 		CoreConfiguration conf = ConfigurationFactory.getConfiguration("jUnit-RemotePipelineTest");
 		dbc = new MongoConnector(conf);
 		
-		nm = new NodeMaster<MongoType>(conf, new CachingDocumentNIO<MongoType>(dbc, new NoopCache<MongoType>(), false), new Pipeline());
+		TerminationHandler terminationHandler = Mockito.mock(TerminationHandler.class);
+		
+		Mockito.when(terminationHandler.isTerminating()).thenReturn(false);
+		
+		nm = new NodeMaster<MongoType>(conf, new CachingDocumentNIO<MongoType>(dbc, new NoopCache<MongoType>(), false), new Pipeline(), terminationHandler);
 		if(!nm.isAlive()) {
 			nm.blockingStart();
 		

--- a/core/src/test/java/com/findwise/hydra/net/RemotePipelineIT.java
+++ b/core/src/test/java/com/findwise/hydra/net/RemotePipelineIT.java
@@ -15,7 +15,7 @@ import com.findwise.hydra.CachingDocumentNIO;
 import com.findwise.hydra.ConfigurationFactory;
 import com.findwise.hydra.CoreConfiguration;
 import com.findwise.hydra.DatabaseDocument;
-import com.findwise.hydra.TerminationHandler;
+import com.findwise.hydra.ShutdownHandler;
 import com.findwise.hydra.Document.Action;
 import com.findwise.hydra.DocumentFile;
 import com.findwise.hydra.NodeMaster;
@@ -45,11 +45,11 @@ public class RemotePipelineIT {
 		CoreConfiguration conf = ConfigurationFactory.getConfiguration("jUnit-RemotePipelineTest");
 		dbc = new MongoConnector(conf);
 		
-		TerminationHandler terminationHandler = Mockito.mock(TerminationHandler.class);
+		ShutdownHandler shutdownHandler = Mockito.mock(ShutdownHandler.class);
 		
-		Mockito.when(terminationHandler.isTerminating()).thenReturn(false);
+		Mockito.when(shutdownHandler.isShuttingDown()).thenReturn(false);
 		
-		nm = new NodeMaster<MongoType>(conf, new CachingDocumentNIO<MongoType>(dbc, new NoopCache<MongoType>(), false), new Pipeline(), terminationHandler);
+		nm = new NodeMaster<MongoType>(conf, new CachingDocumentNIO<MongoType>(dbc, new NoopCache<MongoType>(), false), new Pipeline(), shutdownHandler);
 		if(!nm.isAlive()) {
 			nm.blockingStart();
 		

--- a/database/src/main/java/com/findwise/hydra/CachingDatabaseConnector.java
+++ b/database/src/main/java/com/findwise/hydra/CachingDatabaseConnector.java
@@ -2,9 +2,6 @@ package com.findwise.hydra;
 
 import java.io.IOException;
 
-import com.findwise.hydra.Document;
-import com.findwise.hydra.Query;
-
 public class CachingDatabaseConnector<BackingType extends DatabaseType>
 		implements DatabaseConnector<BackingType> {
 	private DatabaseConnector<BackingType> backing;

--- a/database/src/main/java/com/findwise/hydra/CachingDocumentNIO.java
+++ b/database/src/main/java/com/findwise/hydra/CachingDocumentNIO.java
@@ -2,9 +2,7 @@ package com.findwise.hydra;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.Date;
 import java.util.List;

--- a/database/src/main/java/com/findwise/hydra/Pipeline.java
+++ b/database/src/main/java/com/findwise/hydra/Pipeline.java
@@ -5,8 +5,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import com.findwise.hydra.SerializationUtils;
-
 public class Pipeline {
 	private Map<String, StageGroup> stageGroups;
 	

--- a/database/src/main/java/com/findwise/hydra/Stage.java
+++ b/database/src/main/java/com/findwise/hydra/Stage.java
@@ -3,8 +3,6 @@ package com.findwise.hydra;
 import java.util.Date;
 import java.util.Map;
 
-import com.findwise.hydra.SerializationUtils;
-
 public class Stage {
 	public enum Mode { ACTIVE, INACTIVE, DEBUG }
 	private String name;

--- a/stages/debugging/debugging/src/main/java/com/findwise/hydra/debugging/InfinitLoopStage.java
+++ b/stages/debugging/debugging/src/main/java/com/findwise/hydra/debugging/InfinitLoopStage.java
@@ -1,0 +1,27 @@
+package com.findwise.hydra.debugging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.findwise.hydra.local.LocalDocument;
+import com.findwise.hydra.stage.AbstractProcessStage;
+import com.findwise.hydra.stage.ProcessException;
+import com.findwise.hydra.stage.Stage;
+
+@Stage(description = "A stage that gets stuck in an infinit loop and never returns")
+public class InfinitLoopStage extends AbstractProcessStage {
+
+	Logger logger = LoggerFactory.getLogger(InfinitLoopStage.class);
+
+	@Override
+	public void process(LocalDocument doc) throws ProcessException {
+		for (int i = 0; true; i++) {
+			doc.putContentField("field" + i, i);
+			try {
+				Thread.sleep(1000);
+			} catch (InterruptedException e) {
+			}
+		}
+	}
+
+}

--- a/stages/debugging/debugging/src/main/java/com/findwise/hydra/debugging/InfiniteLoopStage.java
+++ b/stages/debugging/debugging/src/main/java/com/findwise/hydra/debugging/InfiniteLoopStage.java
@@ -8,7 +8,7 @@ import com.findwise.hydra.stage.AbstractProcessStage;
 import com.findwise.hydra.stage.ProcessException;
 import com.findwise.hydra.stage.Stage;
 
-@Stage(description = "A stage that gets stuck in an infinite loop and never returns")
+@Stage(description = "A stage that gets stuck in an infinite loop and never returns. Warning: This stage cannot be interrupted")
 public class InfiniteLoopStage extends AbstractProcessStage {
 
 	Logger logger = LoggerFactory.getLogger(InfiniteLoopStage.class);

--- a/stages/debugging/debugging/src/main/java/com/findwise/hydra/debugging/InfiniteLoopStage.java
+++ b/stages/debugging/debugging/src/main/java/com/findwise/hydra/debugging/InfiniteLoopStage.java
@@ -8,10 +8,10 @@ import com.findwise.hydra.stage.AbstractProcessStage;
 import com.findwise.hydra.stage.ProcessException;
 import com.findwise.hydra.stage.Stage;
 
-@Stage(description = "A stage that gets stuck in an infinit loop and never returns")
-public class InfinitLoopStage extends AbstractProcessStage {
+@Stage(description = "A stage that gets stuck in an infinite loop and never returns")
+public class InfiniteLoopStage extends AbstractProcessStage {
 
-	Logger logger = LoggerFactory.getLogger(InfinitLoopStage.class);
+	Logger logger = LoggerFactory.getLogger(InfiniteLoopStage.class);
 
 	@Override
 	public void process(LocalDocument doc) throws ProcessException {

--- a/stages/debugging/debugging/src/main/java/com/findwise/hydra/debugging/ThrowingStage.java
+++ b/stages/debugging/debugging/src/main/java/com/findwise/hydra/debugging/ThrowingStage.java
@@ -1,0 +1,16 @@
+package com.findwise.hydra.debugging;
+
+import com.findwise.hydra.local.LocalDocument;
+import com.findwise.hydra.stage.AbstractProcessStage;
+import com.findwise.hydra.stage.ProcessException;
+import com.findwise.hydra.stage.Stage;
+
+@Stage
+public class ThrowingStage extends AbstractProcessStage {
+
+	@Override
+	public void process(LocalDocument doc) throws ProcessException {
+		throw new RuntimeException();
+	}
+
+}

--- a/stages/debugging/debugging/src/test/java/com/findwise/hydra/debugging/ThrowingStageTest.java
+++ b/stages/debugging/debugging/src/test/java/com/findwise/hydra/debugging/ThrowingStageTest.java
@@ -1,0 +1,15 @@
+package com.findwise.hydra.debugging;
+
+import org.junit.Test;
+
+import com.findwise.hydra.local.LocalDocument;
+
+public class ThrowingStageTest {
+	
+	ThrowingStage stage = new ThrowingStage();
+	
+	@Test(expected=RuntimeException.class)
+	public void testProcessIsThrowing() throws Exception {
+		stage.process(new LocalDocument());
+	}
+}

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/ConcatenatingHashStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/ConcatenatingHashStage.java
@@ -1,7 +1,3 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package com.findwise.hydra.stage;
 
 import com.findwise.hydra.local.LocalDocument;


### PR DESCRIPTION
This is a continuation of @ssimon's work in #250, which fixes #247, #248 and #249.

Processing stages now create a separate processing thread, which can have an optional timeout set. If the processing takes longer than the timeout, the processing thread will be cancelled. If the thread can't cancel, the stage will destroy the JVM to prevent memory leaks and avoid corrupt state. Core should handle this as any other stage crash and restart the stage.

The motivation for this is that there is no way of knowing if a thread will exit if it can't be cancelled, which means it will take up memory and possibly continue doing work. To protect the rest of the stage JVM, the only way to stop the thread is to destroy the whole JVM.

The tests for `AbstractProcessStage` are now improved and no longer rely on timing to pass.

I couldn't come up with a good test for one case, so I created #263 for that.
