### PR TITLE
Adds method for retrieving all document attachments, changes Date serialization

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -27,6 +27,11 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.0.10</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.11</version>
@@ -39,9 +44,22 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-			<version>1.0.10</version>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock</artifactId>
+			<version>1.33</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>junit</groupId>
+					<artifactId>junit-dep</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.4</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/api/src/main/java/com/findwise/hydra/DocumentFile.java
+++ b/api/src/main/java/com/findwise/hydra/DocumentFile.java
@@ -3,6 +3,14 @@ package com.findwise.hydra;
 import java.io.InputStream;
 import java.util.Date;
 
+/**
+ * Represents a file attachment to a document
+ *
+ * Equality of a {@link DocumentFile} depends only on <strong>metadata</strong>,
+ * not actual file content.
+ *
+ * @param <T>
+ */
 public class DocumentFile<T> {
 	private InputStream stream;
 	private String fileName;
@@ -83,29 +91,32 @@ public class DocumentFile<T> {
 	public String getEncoding() {
 		return encoding;
 	}
-	
-//	@Override
-//	public String toJson() {
-//		HashMap<String, Object> map = new HashMap<String, Object>();
-//		
-//		map.put("stream", stream);
-//		map.put("fileName", fileName);
-//		map.put("uploadDate", uploadDate);
-//		map.put("documentId", documentId.getID());
-//		map.put("savedByStage", savedByStage);
-//		map.put("encoding", encoding);
-//		map.put("mimetype", mimetype);
-//		
-//		return SerializationUtils.toJson(map);
-//	}
 
-//	@Override
-//	public void fromJson(String json) throws JsonException {
-//		Map<String, Object> map = SerializationUtils.fromJson(json);
-//		
-//		stream = (InputStream) map.get("stream");
-//		fileName = (String) map.get("fileName");
-//		uploadDate = (Date) map.get("uploadDate");
-//		documentId = new map.get("stream");
-//	}
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		DocumentFile that = (DocumentFile) o;
+
+		if (documentId != null ? !documentId.equals(that.documentId) : that.documentId != null) return false;
+		if (encoding != null ? !encoding.equals(that.encoding) : that.encoding != null) return false;
+		if (fileName != null ? !fileName.equals(that.fileName) : that.fileName != null) return false;
+		if (mimetype != null ? !mimetype.equals(that.mimetype) : that.mimetype != null) return false;
+		if (savedByStage != null ? !savedByStage.equals(that.savedByStage) : that.savedByStage != null) return false;
+		if (uploadDate != null ? uploadDate.compareTo(that.uploadDate) != 0 : that.uploadDate != null) return false;
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = fileName != null ? fileName.hashCode() : 0;
+		result = 31 * result + (uploadDate != null ? (int)uploadDate.getTime() : 0);
+		result = 31 * result + (documentId != null ? documentId.hashCode() : 0);
+		result = 31 * result + (savedByStage != null ? savedByStage.hashCode() : 0);
+		result = 31 * result + (encoding != null ? encoding.hashCode() : 0);
+		result = 31 * result + (mimetype != null ? mimetype.hashCode() : 0);
+		return result;
+	}
 }

--- a/api/src/main/java/com/findwise/hydra/SerializationUtils.java
+++ b/api/src/main/java/com/findwise/hydra/SerializationUtils.java
@@ -40,6 +40,10 @@ public final class SerializationUtils {
     private static Logger internalLogger = LoggerFactory.getLogger("internal");
 
     private static SimpleDateFormat getDateFormat() {
+		return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+	}
+
+	private static SimpleDateFormat getLegacyDateFormat() {
 		return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
 	}
 	
@@ -185,7 +189,11 @@ public final class SerializationUtils {
 				try {
 					return getDateFormat().parse(json.getAsString());
 				} catch(ParseException e) {
-					return json.getAsString();
+					try {
+						return getLegacyDateFormat().parse(json.getAsString());
+					} catch (ParseException e2) {
+						return json.getAsString();
+					}
 				}
 			} else {
 				BigDecimal bigDec = json.getAsBigDecimal();

--- a/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
+++ b/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -409,7 +410,7 @@ public class RemotePipeline {
 
 	@SuppressWarnings("unchecked")
 	public List<String> getFileNames(DocumentID<?> docid) throws IOException {
-		HttpResponse response = core.get(fileUrl+"&"+RemotePipeline.DOCID_PARAM+"="+URLEncoder.encode(docid.toJSON(), "UTF-8"));
+		HttpResponse response = core.get(fileUrl + "&" + RemotePipeline.DOCID_PARAM + "=" + URLEncoder.encode(docid.toJSON(), "UTF-8"));
 
 		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
 			try {
@@ -421,6 +422,15 @@ public class RemotePipeline {
 			logUnexpected(response);
 			return null;
 		}
+	}
+
+	public List<DocumentFile<Local>> getFiles(DocumentID<Local> docid) throws IOException {
+		List<String> fileNames = getFileNames(docid);
+		List<DocumentFile<Local>> files = new ArrayList<DocumentFile<Local>>();
+		for (String fileName : fileNames) {
+			files.add(getFile(fileName, docid));
+		}
+		return files;
 	}
 	
 	public String getStageName() {

--- a/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
+++ b/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
@@ -25,8 +25,8 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 
 public class RemotePipeline {
-    private static final Logger internalLogger = LoggerFactory.getLogger("internal");
-    private static final Logger logger = LoggerFactory.getLogger(RemotePipeline.class);
+	private static final Logger internalLogger = LoggerFactory.getLogger("internal");
+	private static final Logger logger = LoggerFactory.getLogger(RemotePipeline.class);
 
 	public static final String GET_DOCUMENT_URL = "getDocument";
 	public static final String WRITE_DOCUMENT_URL = "writeDocument";
@@ -37,22 +37,22 @@ public class RemotePipeline {
 	public static final String GET_PROPERTIES_URL = "getProperties";
 	public static final String FAILED_DOCUMENT_URL = "failedDocument";
 	public static final String FILE_URL = "documentFile";
-	
+
 	public static final String STAGE_PARAM = "stage";
 	public static final String NORELEASE_PARAM = "norelease";
 	public static final String PARTIAL_PARAM = "partial";
 	public static final String DOCID_PARAM = "docid";
 	public static final String FILENAME_PARAM = "filename";
-	
+
 	public static final int DEFAULT_PORT = 12001;
 	public static final String DEFAULT_HOST = "127.0.0.1";
-	
+
 	private boolean performanceLogging = false;
-	
+
 	private HttpConnection core;
-	
+
 	private boolean keepLock;
-	
+
 	private String getUrl;
 	private String writeUrl;
 	private String releaseUrl;
@@ -62,48 +62,48 @@ public class RemotePipeline {
 	private String discardedUrl;
 	private String propertyUrl;
 	private String fileUrl;
-	
+
 	private String stageName;
-	
+
 	private LocalDocument currentDocument;
 
 	/**
-	 * Calls RemotePipeline(String, int, String) with default values for 
+	 * Calls RemotePipeline(String, int, String) with default values for
 	 * hostName (RemotePipeline.DEFAULT_HOST) and port (RemotePipeline.DEFAULT_PORT).
-	 * 
+	 *
 	 * @param stageName
 	 */
 	public RemotePipeline(String stageName) {
 		this(DEFAULT_HOST, DEFAULT_PORT, stageName);
 	}
-	
+
 	public RemotePipeline(String hostName, int port, String stageName) {
 		this.stageName = stageName;
-		getUrl = "/"+GET_DOCUMENT_URL+"?"+STAGE_PARAM+"="+stageName;
-		writeUrl = "/"+WRITE_DOCUMENT_URL+"?"+STAGE_PARAM+"="+stageName;
-		releaseUrl = "/"+RELEASE_DOCUMENT_URL+"?"+STAGE_PARAM+"="+stageName;
-		processedUrl = "/"+PROCESSED_DOCUMENT_URL+"?"+STAGE_PARAM+"="+stageName;
-		failedUrl = "/"+FAILED_DOCUMENT_URL+"?"+STAGE_PARAM+"="+stageName;
-		pendingUrl = "/"+PENDING_DOCUMENT_URL+"?"+STAGE_PARAM+"="+stageName;
-		discardedUrl = "/"+DISCARDED_DOCUMENT_URL+"?"+STAGE_PARAM+"="+stageName;
-		propertyUrl = "/"+GET_PROPERTIES_URL+"?"+STAGE_PARAM+"="+stageName;
-		fileUrl = "/"+FILE_URL+"?"+STAGE_PARAM+"="+stageName;
-		
+		getUrl = "/" + GET_DOCUMENT_URL + "?" + STAGE_PARAM + "=" + stageName;
+		writeUrl = "/" + WRITE_DOCUMENT_URL + "?" + STAGE_PARAM + "=" + stageName;
+		releaseUrl = "/" + RELEASE_DOCUMENT_URL + "?" + STAGE_PARAM + "=" + stageName;
+		processedUrl = "/" + PROCESSED_DOCUMENT_URL + "?" + STAGE_PARAM + "=" + stageName;
+		failedUrl = "/" + FAILED_DOCUMENT_URL + "?" + STAGE_PARAM + "=" + stageName;
+		pendingUrl = "/" + PENDING_DOCUMENT_URL + "?" + STAGE_PARAM + "=" + stageName;
+		discardedUrl = "/" + DISCARDED_DOCUMENT_URL + "?" + STAGE_PARAM + "=" + stageName;
+		propertyUrl = "/" + GET_PROPERTIES_URL + "?" + STAGE_PARAM + "=" + stageName;
+		fileUrl = "/" + FILE_URL + "?" + STAGE_PARAM + "=" + stageName;
+
 		keepLock = false;
-		
+
 		core = new HttpConnection(hostName, port);
 	}
-	
+
 	/**
 	 * Non-recurring, use this in all known cases except for in an output node.
-	 * 
+	 * <p/>
 	 * The fetched document will be tagged with the name of the stage which is
 	 * used to execute getDocument.
 	 */
 	public LocalDocument getDocument(LocalQuery query) throws IOException {
 		HttpResponse response;
 		long start = System.currentTimeMillis();
-			response = core.post(getUrl, query.toJson());
+		response = core.post(getUrl, query.toJson());
 
 		long startSerialize = System.currentTimeMillis();
 		long startJson = 0L;
@@ -124,41 +124,41 @@ public class RemotePipeline {
 		} else {
 			logUnexpected(response);
 		}
-		if(isPerformanceLogging()) {
+		if (isPerformanceLogging()) {
 			long end = System.currentTimeMillis();
 			Object docId = ld != null ? ld.getID() : null;
 			logger.info(String.format("type=performance event=query stage_name=%s doc_id=\"%s\" start=%d fetch=%d entitystring=%d serialize=%d end=%d total=%d", stageName, docId, start, startSerialize - start, startJson - startSerialize, end - startJson, end, end - start));
 		}
 		return ld;
 	}
-	
+
 	/**
 	 * Releases the most recently read document back to the pipeline
-	 * 
+	 *
 	 * @return true if there was a document to release
-	 * @throws HttpException 
-	 * @throws IOException 
+	 * @throws HttpException
+	 * @throws IOException
 	 */
 	public boolean releaseLastDocument() throws IOException {
-		if(currentDocument==null) {
+		if (currentDocument == null) {
 			internalLogger.debug("There is no document to release...");
 			return false;
 		}
 		HttpResponse response = core.post(releaseUrl, currentDocument.contentFieldsToJson(null));
 		currentDocument = null;
-		if(response.getStatusLine().getStatusCode()==HttpStatus.SC_OK) {
+		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
 			EntityUtils.consume(response.getEntity());
 			return true;
 		}
-		
+
 		logUnexpected(response);
-		
+
 		return false;
 	}
-	
+
 	private static void logUnexpected(HttpResponse response) throws IOException {
-		internalLogger.error("Node gave an unexpected response: "+response.getStatusLine());
-		internalLogger.error("Message: "+EntityUtils.toString(response.getEntity()));
+		internalLogger.error("Node gave an unexpected response: " + response.getStatusLine());
+		internalLogger.error("Message: " + EntityUtils.toString(response.getEntity()));
 	}
 
 	/**
@@ -167,7 +167,7 @@ public class RemotePipeline {
 	public void keepLock() {
 		keepLock = true;
 	}
-	
+
 	/**
 	 * Writes all outstanding updates to the last document fetched from the pipeline.
 	 */
@@ -190,134 +190,130 @@ public class RemotePipeline {
 	 */
 	public boolean saveFull(LocalDocument d) throws IOException, JsonException {
 		boolean res = save(d, false);
-		if(res) {
+		if (res) {
 			d.markSynced();
-			keepLock=false;
+			keepLock = false;
 		}
 		return res;
 	}
-	
+
 	/**
 	 * Writes all outstanding updates to the document since it was initialized.
 	 */
 	public boolean save(LocalDocument d) throws IOException, JsonException {
 		boolean res = save(d, true);
-		if(res) {
+		if (res) {
 			d.markSynced();
-			keepLock=false;
+			keepLock = false;
 		}
 		return res;
 	}
-	
+
 	private boolean save(LocalDocument d, boolean partialUpdate) throws IOException, JsonException {
-		boolean hasId = d.getID()!=null;
+		boolean hasId = d.getID() != null;
 		String s;
 		long start = System.currentTimeMillis();
-		if(partialUpdate) {
+		if (partialUpdate) {
 			s = d.modifiedFieldsToJson();
-		}
-		else {
+		} else {
 			s = d.toJson();
 		}
 		long startPost = System.currentTimeMillis();
 		HttpResponse response = core.post(getWriteUrl(partialUpdate), s);
-		if(response.getStatusLine().getStatusCode()==HttpStatus.SC_OK) {
-			if(!hasId) {
+		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+			if (!hasId) {
 				LocalDocument updated = new LocalDocument(EntityUtils.toString(response.getEntity()));
 				d.putAll(updated);
-			}
-			else {
+			} else {
 				EntityUtils.consume(response.getEntity());
 			}
-			if(isPerformanceLogging()) {
+			if (isPerformanceLogging()) {
 				long end = System.currentTimeMillis();
 				DocumentID<Local> docId = d.getID();
 				logger.info(String.format("type=performance event=update stage_name=%s doc_id=\"%s\" start=%d serialize=%d post=%d end=%d total=%d", stageName, docId, start, startPost - start, end - startPost, end, end - start));
 			}
 			return true;
 		}
-		
+
 		logUnexpected(response);
 		return false;
 	}
-	
+
 	public boolean markPending(LocalDocument d) throws IOException {
 		HttpResponse response = core.post(pendingUrl, d.contentFieldsToJson(null));
-		if(response.getStatusLine().getStatusCode()==HttpStatus.SC_OK) {
+		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
 			EntityUtils.consume(response.getEntity());
-		
+
 			return true;
 		}
-		
+
 		logUnexpected(response);
-		
+
 		return false;
 	}
-	
+
 	public boolean markFailed(LocalDocument d) throws IOException {
 		HttpResponse response = core.post(failedUrl, d.modifiedFieldsToJson());
-		if(response.getStatusLine().getStatusCode()==HttpStatus.SC_OK) {
+		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
 			EntityUtils.consume(response.getEntity());
-		
+
 			return true;
 		}
-		
+
 		logUnexpected(response);
-		
+
 		return false;
 	}
-	
+
 	public boolean markFailed(LocalDocument d, Throwable t) throws IOException {
 		d.addError(stageName, t);
 		return markFailed(d);
 	}
-	
+
 	public boolean markProcessed(LocalDocument d) throws IOException {
 		HttpResponse response = core.post(processedUrl, d.modifiedFieldsToJson());
-		if(response.getStatusLine().getStatusCode()==HttpStatus.SC_OK) {
+		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
 			EntityUtils.consume(response.getEntity());
-		
+
 			return true;
 		}
-		
+
 		logUnexpected(response);
-		
+
 		return false;
 	}
-	
+
 	public boolean markDiscarded(LocalDocument d) throws IOException {
 		HttpResponse response = core.post(discardedUrl, d.modifiedFieldsToJson());
-		if(response.getStatusLine().getStatusCode()==HttpStatus.SC_OK) {
+		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
 			EntityUtils.consume(response.getEntity());
-		
+
 			return true;
 		}
-		
+
 		logUnexpected(response);
-		
+
 		return false;
 	}
-	
+
 	private String getWriteUrl(boolean partialUpdate) {
 		String s = writeUrl;
-		if(keepLock) {
-			s+="&"+NORELEASE_PARAM+"=1";
+		if (keepLock) {
+			s += "&" + NORELEASE_PARAM + "=1";
+		} else {
+			s += "&" + NORELEASE_PARAM + "=0";
 		}
-		else {
-			s+="&"+NORELEASE_PARAM+"=0";
-		}
-		if(partialUpdate) {
-			s+="&"+PARTIAL_PARAM+"=1";
-		}
-		else {
-			s+="&"+PARTIAL_PARAM+"=0";
+		if (partialUpdate) {
+			s += "&" + PARTIAL_PARAM + "=1";
+		} else {
+			s += "&" + PARTIAL_PARAM + "=0";
 		}
 		return s;
 	}
-	
+
 	public Map<String, Object> getProperties() throws IOException {
 		HttpResponse response = core.get(propertyUrl);
-		
+
 		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
 			Map<String, Object> map;
 			try {
@@ -325,7 +321,7 @@ public class RemotePipeline {
 			} catch (JsonException e) {
 				throw new IOException(e);
 			}
-			internalLogger.debug("Successfully retrieved propertyMap with " + map.size()+" entries");
+			internalLogger.debug("Successfully retrieved propertyMap with " + map.size() + " entries");
 			return map;
 		} else if (response.getStatusLine().getStatusCode() == HttpStatus.SC_NOT_FOUND) {
 			internalLogger.debug("No document found matching query");
@@ -336,18 +332,18 @@ public class RemotePipeline {
 			return null;
 		}
 	}
-	
+
 	private String getFileUrl(DocumentFile<Local> df) throws UnsupportedEncodingException {
 		return getFileUrl(df.getFileName(), df.getDocumentId());
 	}
-	
+
 	private String getFileUrl(String fileName, DocumentID<Local> docid) throws UnsupportedEncodingException {
-		return fileUrl+"&"+RemotePipeline.FILENAME_PARAM+"="+fileName+"&"+RemotePipeline.DOCID_PARAM+"="+URLEncoder.encode(docid.toJSON(), "UTF-8");
+		return fileUrl + "&" + RemotePipeline.FILENAME_PARAM + "=" + fileName + "&" + RemotePipeline.DOCID_PARAM + "=" + URLEncoder.encode(docid.toJSON(), "UTF-8");
 	}
-	
+
 	public DocumentFile<Local> getFile(String fileName, DocumentID<Local> docid) throws IOException {
 		HttpResponse response = core.get(getFileUrl(fileName, docid));
-		
+
 		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
 			Object o;
 			try {
@@ -355,10 +351,10 @@ public class RemotePipeline {
 			} catch (JsonException e) {
 				throw new IOException(e);
 			}
-			if(!(o instanceof Map)) {
+			if (!(o instanceof Map)) {
 				return null;
 			}
-			
+
 			@SuppressWarnings("unchecked")
 			Map<String, Object> map = (Map<String, Object>) o;
 			Date d = (Date) map.get("uploadDate");
@@ -366,26 +362,25 @@ public class RemotePipeline {
 			String mimetype = (String) map.get("mimetype");
 			String savedByStage = (String) map.get("savedByStage");
 			InputStream is;
-			if(encoding == null) {
-				is = new ByteArrayInputStream(Base64.decodeBase64(((String)map.get("stream")).getBytes("UTF-8")));
+			if (encoding == null) {
+				is = new ByteArrayInputStream(Base64.decodeBase64(((String) map.get("stream")).getBytes("UTF-8")));
 			} else {
-				is = new ByteArrayInputStream(Base64.decodeBase64(((String)map.get("stream")).getBytes(encoding)));
+				is = new ByteArrayInputStream(Base64.decodeBase64(((String) map.get("stream")).getBytes(encoding)));
 			}
 
 			DocumentFile<Local> df = new DocumentFile<Local>(docid, fileName, is, savedByStage, d);
 			df.setEncoding(encoding);
 			df.setMimetype(mimetype);
-			
+
 			return df;
-		} 
-		else {
+		} else {
 			logUnexpected(response);
 			return null;
 		}
 	}
-	
+
 	public boolean saveFile(DocumentFile<Local> df) throws IOException {
-		HttpResponse response = core.post(getFileUrl(df),  SerializationUtils.toJson(df));
+		HttpResponse response = core.post(getFileUrl(df), SerializationUtils.toJson(df));
 		int code = response.getStatusLine().getStatusCode();
 		if (code == HttpStatus.SC_OK || code == HttpStatus.SC_NO_CONTENT) {
 			EntityUtils.consume(response.getEntity());
@@ -395,7 +390,7 @@ public class RemotePipeline {
 			return false;
 		}
 	}
-	
+
 	public boolean deleteFile(String fileName, DocumentID<Local> docid) throws IOException {
 		HttpResponse response = core.delete(getFileUrl(fileName, docid));
 
@@ -414,7 +409,7 @@ public class RemotePipeline {
 
 		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
 			try {
-				return (List<String>)SerializationUtils.toObject(EntityUtils.toString(response.getEntity()));
+				return (List<String>) SerializationUtils.toObject(EntityUtils.toString(response.getEntity()));
 			} catch (JsonException e) {
 				throw new IOException(e);
 			}
@@ -432,15 +427,15 @@ public class RemotePipeline {
 		}
 		return files;
 	}
-	
+
 	public String getStageName() {
 		return stageName;
 	}
-	
+
 	public void setPerformanceLogging(boolean performanceLogging) {
 		this.performanceLogging = performanceLogging;
 	}
-	
+
 	public boolean isPerformanceLogging() {
 		return performanceLogging;
 	}

--- a/api/src/test/java/com/findwise/hydra/SerializationUtilsTest.java
+++ b/api/src/test/java/com/findwise/hydra/SerializationUtilsTest.java
@@ -1,20 +1,32 @@
 package com.findwise.hydra;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
-
-import junit.framework.Assert;
 
 import org.junit.Test;
 
-import com.findwise.hydra.SerializationUtils;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SerializationUtilsTest {
 
 	@Test
-	public void testDates() throws Exception {
-		Assert.assertEquals(Date.class, SerializationUtils.toObject(SerializationUtils.toJson(new Date())).getClass());
-		
-		//SerializationUtils.toJson(SerializationUtils.fromJson("{_action=null, _id={_inc=-1320293295, _new=false, _time=1354236890, _machine=1951282283}, contents={id=xdIJbiV1BlSD, f=JsNOwXa1, d=DQkP, e=Umj9n, b=p5d4wNOtPbs2QC5VQ9, c=Fize, a=0SVtbmBhlPbOw, in=e, z=r1I0vOMlEs, y=f1mkaEna1L2iVdg, x=15}, metadata={touched={insertStage=Fri Nov 30 01:54:50 CET 2012, sleepy1=Fri Nov 30 01:56:42 CET 2012, sleepy3=Fri Nov 30 01:56:42 CET 2012, sleepy4=Fri Nov 30 01:56:41 CET 2012, sleepy5=Fri Nov 30 01:56:42 CET 2012, sleepy6=Fri Nov 30 01:56:41 CET 2012, sleepy7=Fri Nov 30 01:56:42 CET 2012, sleepy8=Fri Nov 30 01:56:42 CET 2012, sleepy9=Fri Nov 30 01:56:32 CET 2012}, fetched={sleepy1=Fri Nov 30 01:56:42 CET 2012, sleepy0=Fri Nov 30 01:56:42 CET 2012, sleepy3=Fri Nov 30 01:56:42 CET 2012, sleepy4=Fri Nov 30 01:56:41 CET 2012, sleepy5=Fri Nov 30 01:56:41 CET 2012, sleepy6=Fri Nov 30 01:56:41 CET 2012, sleepy7=Fri Nov 30 01:56:42 CET 2012, sleepy8=Fri Nov 30 01:56:42 CET 2012, sleepy9=Fri Nov 30 01:56:32 CET 2012}}}"));
+	public void testDate_serialization_equality() throws JsonException {
+		Date date = new Date();
+		Object deserializedDate = SerializationUtils.toObject(SerializationUtils.toJson(date));
+		assertEquals(Date.class, deserializedDate.getClass());
+		assertTrue(date.compareTo((Date)deserializedDate) == 0);
+	}
+
+	@Test
+	public void testDates_can_deserialize_legacy_date_format() throws JsonException {
+		Date date = new Date();
+		SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+		Object deserializedDate = SerializationUtils.toObject("\"" + format.format(date) + "\"");
+		assertEquals(Date.class, deserializedDate.getClass());
+		// Legacy date format does not handle sub-second time
+		assertTrue(date.after((Date)deserializedDate));
+		assertTrue(date.getTime() - ((Date)deserializedDate).getTime() < 1000L);
 	}
 
 }

--- a/api/src/test/java/com/findwise/hydra/local/RemotePipelineTest.java
+++ b/api/src/test/java/com/findwise/hydra/local/RemotePipelineTest.java
@@ -1,0 +1,136 @@
+package com.findwise.hydra.local;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import com.findwise.hydra.DocumentFile;
+import com.findwise.hydra.SerializationUtils;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+public class RemotePipelineTest {
+
+	RemotePipeline rp;
+
+	LocalDocument doc;
+
+	private static final String stageName = "teststage";
+	private static final String mockHost = "localhost";
+	private static final int mockPort = 37778;
+
+	@ClassRule
+	public static WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(mockPort));
+
+	@Before
+	public void setUp() {
+		rp = new RemotePipeline(mockHost, mockPort, stageName);
+		doc = new LocalDocument();
+		doc.setID(new LocalDocumentID("testdoc"));
+	}
+
+	@Test
+	public void testGetFileNames() throws IOException {
+		String fileUrl = "/" + RemotePipeline.FILE_URL
+				+ "?" + RemotePipeline.STAGE_PARAM + "=" + stageName
+				+ "&" + RemotePipeline.DOCID_PARAM + "=" + URLEncoder.encode(doc.getID().toJSON(), "UTF-8");
+
+		stubFor(get(urlEqualTo(fileUrl)).willReturn(aResponse().withBody("[\"file1\", \"file2\"]")));
+
+		List<String> expected = Arrays.asList("file1", "file2");
+		List<String> actual = rp.getFileNames(doc.getID());
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void testGetFile() throws IOException {
+		String fileName = "file1";
+		byte[] bytes = "file content".getBytes("UTF-8");
+		Date date = new Date();
+		String encoding = "UTF-8";
+		String mimetype = "text";
+		stubFile(fileName, doc.getID(), bytes, date, encoding, mimetype);
+
+		DocumentFile<Local> expected = new DocumentFile<Local>(doc.getID(), fileName, new ByteArrayInputStream(bytes), stageName, date);
+		expected.setEncoding(encoding);
+		expected.setMimetype(mimetype);
+		DocumentFile<Local> actual = rp.getFile(fileName, doc.getID());
+		documentFileEquals(expected, actual);
+	}
+
+	@Test
+	public void testGetFiles() throws IOException {
+		Date date = new Date();
+		String encoding = "UTF-8";
+		String mimetype = "text";
+		Map<String, byte[]> testFiles = new HashMap<String, byte[]>();
+		testFiles.put("file1", "file1 contents".getBytes(encoding));
+		testFiles.put("file2", "contents of file2".getBytes(encoding));
+
+		String fileNamesUrl = "/" + RemotePipeline.FILE_URL
+				+ "?" + RemotePipeline.STAGE_PARAM + "=" + stageName
+				+ "&" + RemotePipeline.DOCID_PARAM + "=" + URLEncoder.encode(doc.getID().toJSON(), "UTF-8");
+
+		stubFor(get(urlEqualTo(fileNamesUrl)).willReturn(aResponse().withBody("[\"file2\", \"file1\"]")));
+
+		List<DocumentFile<Local>> expected = new ArrayList<DocumentFile<Local>>();
+		for (Map.Entry<String, byte[]> testFile : testFiles.entrySet()) {
+			final String fileName = testFile.getKey();
+			final byte[] content = testFile.getValue();
+			stubFile(fileName, doc.getID(), content, date, encoding, mimetype);
+			DocumentFile<Local> df = new DocumentFile<Local>(doc.getID(), fileName, new ByteArrayInputStream(content), stageName, date);
+			df.setEncoding(encoding);
+			df.setMimetype(mimetype);
+			expected.add(df);
+		}
+
+		List<DocumentFile<Local>> actual = rp.getFiles(doc.getID());
+
+		assertEquals(expected.size(), actual.size());
+
+		for (DocumentFile<Local> expectedDf : expected) {
+			DocumentFile<Local> actualDf = actual.get(actual.indexOf(expectedDf));
+			documentFileEquals(expectedDf, actualDf);
+		}
+	}
+
+	private void stubFile(String fileName, LocalDocumentID docId, byte[] content, Date date, String encoding, String mimetype) throws UnsupportedEncodingException {
+		String fileUrl = "/" + RemotePipeline.FILE_URL
+				+ "?" + RemotePipeline.STAGE_PARAM + "=" + stageName
+				+ "&" + RemotePipeline.FILENAME_PARAM + "=" + fileName
+				+ "&" + RemotePipeline.DOCID_PARAM + "=" + URLEncoder.encode(docId.toJSON(), "UTF-8");
+
+		Map<String, Object> fileMap = new HashMap<String, Object>();
+		fileMap.put("uploadDate", date);
+		fileMap.put("encoding", encoding);
+		fileMap.put("mimetype", mimetype);
+		fileMap.put("savedByStage", stageName);
+		fileMap.put("stream", Base64.encodeBase64String(content));
+		stubFor(get(urlEqualTo(fileUrl)).willReturn(aResponse().withBody(SerializationUtils.toJson(fileMap))));
+	}
+
+	private void documentFileEquals(DocumentFile<Local> expected, DocumentFile<Local> actual) throws IOException {
+		assertEquals(expected, actual);
+		assertTrue(IOUtils.contentEquals(expected.getStream(), actual.getStream()));
+	}
+}


### PR DESCRIPTION
_NOTE_: This PR changes the serialization format of `Date` objects to include milliseconds. The old format is added as a legacy format that `SerializationUtils` can deserialize, but not serialize to. This affects all configuration (stage, stagegroup) as well as document serialization.
Previously, sub-second components were lost in serialization, which made tests difficult to write and required weird workarounds in test code.

Legacy format: `2013-01-13T14:02:56+0100`
New format: `2013-01-13T14:02:56.123+0100`

**Adds `getFiles` to `RemotePipeline`, for fetching all attachments to a document**. This addresses #240, by making it easier to get the attachments.

I also introduced the use of WireMock for testing `RemotePipeline`, something that should be expanded to all methods in the class.
