### PR TITLE
Adds more generic exception to stages' init() method

### DIFF
--- a/api/src/main/java/com/findwise/hydra/stage/AbstractMappingProcessStage.java
+++ b/api/src/main/java/com/findwise/hydra/stage/AbstractMappingProcessStage.java
@@ -21,14 +21,14 @@ public abstract class AbstractMappingProcessStage extends AbstractProcessStage {
 	
 
 	@Override
-	public final void init() throws RequiredArgumentMissingException {
+	public final void init() throws RequiredArgumentMissingException, InitFailedException {
 		if(map==null || map.size()==0)  {
 			throw new RequiredArgumentMissingException("Required argument 'map' is missing or zero-size");
 		}
 		stageInit();
 	}
 
-	public abstract void stageInit() throws RequiredArgumentMissingException;
+	public abstract void stageInit() throws RequiredArgumentMissingException, InitFailedException;
 
 	public abstract void processField(LocalDocument doc, String fromField, String toField) throws ProcessException;
 }

--- a/api/src/main/java/com/findwise/hydra/stage/AbstractStage.java
+++ b/api/src/main/java/com/findwise/hydra/stage/AbstractStage.java
@@ -63,8 +63,9 @@ public abstract class AbstractStage extends Thread {
 	 * argName)
 	 * 
 	 * @throws RequiredArgumentMissingException
+	 * @throws InitFailedException
 	 */
-	public void init() throws RequiredArgumentMissingException {
+	public void init() throws RequiredArgumentMissingException, InitFailedException {
 		
 	}
 
@@ -276,6 +277,8 @@ public abstract class AbstractStage extends Thread {
 
 		} catch (RequiredArgumentMissingException e) {
 			logger.error("Failed to read arguments", e);
+		} catch (InitFailedException e) {
+			logger.error("Failed to initialize Stage", e);
 		} catch (ClassNotFoundException e) {
 			logger.error("Could not find the Stage class in classpath", e);
 		} catch (InstantiationException e) {

--- a/api/src/main/java/com/findwise/hydra/stage/InitFailedException.java
+++ b/api/src/main/java/com/findwise/hydra/stage/InitFailedException.java
@@ -1,0 +1,22 @@
+package com.findwise.hydra.stage;
+
+public class InitFailedException extends Exception {
+
+	private static final long serialVersionUID = 201311251624L;
+
+	public InitFailedException() {
+		super();
+	}
+
+	public InitFailedException(String message) {
+		super(message);
+	}
+
+	public InitFailedException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public InitFailedException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/stages/out/elasticsearch-out/src/main/java/com/findwise/hydra/output/elasticsearch/ElasticsearchOutputStage.java
+++ b/stages/out/elasticsearch-out/src/main/java/com/findwise/hydra/output/elasticsearch/ElasticsearchOutputStage.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.findwise.hydra.stage.InitFailedException;
 import org.elasticsearch.ElasticSearchException;
 import org.elasticsearch.action.ListenableActionFuture;
 import org.elasticsearch.action.delete.DeleteResponse;
@@ -56,8 +57,12 @@ public class ElasticsearchOutputStage extends AbstractOutputStage {
 	private Client client;
 
 	@Override
-	public void init() throws RequiredArgumentMissingException {
-		client = constructClient();
+	public void init() throws RequiredArgumentMissingException, InitFailedException {
+		try {
+			client = constructClient();
+		} catch (Exception e) {
+			throw new InitFailedException("Could not construct client", e);
+		}
 	}
 
 	@Override

--- a/stages/out/solr-out-3.6/src/main/java/com/findwise/hydra/output/solr/SolrOutputStage.java
+++ b/stages/out/solr-out-3.6/src/main/java/com/findwise/hydra/output/solr/SolrOutputStage.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.findwise.hydra.stage.InitFailedException;
 import org.apache.solr.client.solrj.SolrServer;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrServer;
@@ -60,11 +61,11 @@ public class SolrOutputStage extends AbstractOutputStage {
 	}
 
 	@Override
-	public void init() throws RequiredArgumentMissingException {
+	public void init() throws RequiredArgumentMissingException, InitFailedException {
 		try {
 			solr = getSolrServer();
 		} catch (MalformedURLException e) {
-			throw new RequiredArgumentMissingException("Solr URL malformed.");
+			throw new InitFailedException("Solr URL malformed", e);
 		}
 	}
 	

--- a/stages/out/solr-out/src/main/java/com/findwise/hydra/output/solr/SolrOutputStage.java
+++ b/stages/out/solr-out/src/main/java/com/findwise/hydra/output/solr/SolrOutputStage.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.findwise.hydra.stage.InitFailedException;
 import org.apache.solr.client.solrj.SolrServer;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrServer;
@@ -63,11 +64,11 @@ public class SolrOutputStage extends AbstractOutputStage {
 	}
 
 	@Override
-	public void init() throws RequiredArgumentMissingException {
+	public void init() throws RequiredArgumentMissingException, InitFailedException {
 		try {
 			solr = getSolrServer();
 		} catch (MalformedURLException e) {
-			throw new RequiredArgumentMissingException("Solr URL malformed.");
+			throw new InitFailedException("Solr URL malformed", e);
 		}
 	}
 	


### PR DESCRIPTION
Fixes #189

`init()` now declares a second, more generic exception (`InitFailedException`) for when initialization of a stage fails due to factors other than missing or incorrect arguments (such as connection failure to external service).

Changes output stages to use the new exception.
