### PR TITLE
Adds check for empty configuration to Admin Service stage config endpoint

### DIFF
--- a/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
@@ -1,13 +1,17 @@
 package com.findwise.hydra.admin.rest;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import com.findwise.hydra.DatabaseException;
+import com.google.gson.JsonParseException;
+import com.mongodb.MongoException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +28,8 @@ import com.findwise.hydra.admin.documents.DocumentsService;
 
 import com.findwise.hydra.admin.stages.StagesService;
 import com.findwise.hydra.JsonException;
+
+import javax.servlet.http.HttpServletRequest;
 
 
 @Controller("/rest")
@@ -188,5 +194,24 @@ public class ConfigurationController {
 			@RequestBody String content) {
 		return documentService.putDocument(action, content);
 	}
-	
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ResponseBody
+	@ExceptionHandler(JsonException.class)
+	public Map<String, Object> handleJsonError(Exception exception) {
+		Map<String, Object> ret = new HashMap<String, Object>();
+		ret.put("message", exception.getMessage());
+		ret.put("exception", exception.getClass());
+		return ret;
+	}
+
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	@ResponseBody
+	@ExceptionHandler({IOException.class, DatabaseException.class, MongoException.class})
+	public Map<String, Object> handleIoError(Exception exception) {
+		Map<String, Object> ret = new HashMap<String, Object>();
+		ret.put("message", exception.getMessage());
+		ret.put("exception", exception.getClass());
+		return ret;
+	}
 }

--- a/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/rest/ConfigurationController.java
@@ -199,16 +199,17 @@ public class ConfigurationController {
 	@ResponseBody
 	@ExceptionHandler(JsonException.class)
 	public Map<String, Object> handleJsonError(Exception exception) {
-		Map<String, Object> ret = new HashMap<String, Object>();
-		ret.put("message", exception.getMessage());
-		ret.put("exception", exception.getClass());
-		return ret;
+		return getErrorMap(exception);
 	}
 
 	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	@ResponseBody
 	@ExceptionHandler({IOException.class, DatabaseException.class, MongoException.class})
 	public Map<String, Object> handleIoError(Exception exception) {
+		return getErrorMap(exception);
+	}
+
+	private Map<String, Object> getErrorMap(Exception exception) {
 		Map<String, Object> ret = new HashMap<String, Object>();
 		ret.put("message", exception.getMessage());
 		ret.put("exception", exception.getClass());

--- a/admin-service/src/main/java/com/findwise/hydra/admin/stages/StagesService.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/stages/StagesService.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.gson.JsonParseException;
 import org.bson.types.ObjectId;
 
 import com.findwise.hydra.DatabaseConnector;
@@ -89,7 +90,13 @@ public class StagesService<T extends DatabaseType> {
 	public void addStage(String libraryId, String groupName, String name, String jsonConfig, boolean debug) throws JsonException, IOException {
 
 		Stage s = new Stage(name, toDatabaseFile(libraryId));
-		s.setProperties(SerializationUtils.fromJson(jsonConfig));
+		Map<String, Object> config = SerializationUtils.fromJson(jsonConfig);
+		if (null == config) {
+			throw new JsonException(new JsonParseException("Configuration was empty"));
+		} else if (!config.containsKey("stageClass")) {
+			throw new JsonException(new JsonParseException("Required configuration parameter 'stageClass' missing"));
+		}
+		s.setProperties(config);
 		if (debug) {
 			s.setMode(Stage.Mode.DEBUG);
 		} else {


### PR DESCRIPTION
The Admin Service will now throw an error if the supplied configuration is empty or missing the required `stageClass` parameter. This mostly fixes #245 as the config won't be written to the database, although you will get a syntax error instead - not entirely sure why the attached file breaks the request in that manner.

The Admin Service will now also respond with an error message body of its own when encountering problems, instead of falling back to the container's error page.

For example, a syntax error in the supplied JSON is now a client error, not a server error.
