### PR TITLE
Fixups of some DRY violations when parsing command line arguments

### DIFF
--- a/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
+++ b/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
@@ -45,7 +45,8 @@ public class RemotePipeline {
 	public static final String FILENAME_PARAM = "filename";
 
 	public static final int DEFAULT_PORT = 12001;
-	public static final String DEFAULT_HOST = "127.0.0.1";
+	public static final String DEFAULT_HOST = "localhost";
+	public static final int DEFAULT_LOG_PORT = 12002;
 
 	private boolean performanceLogging = false;
 

--- a/api/src/main/java/com/findwise/hydra/stage/StageCommandLineArguments.java
+++ b/api/src/main/java/com/findwise/hydra/stage/StageCommandLineArguments.java
@@ -1,0 +1,78 @@
+package com.findwise.hydra.stage;
+
+import com.findwise.hydra.SerializationUtils;
+import com.findwise.hydra.local.RemotePipeline;
+
+import java.util.Map;
+
+public class StageCommandLineArguments {
+	private static final int STAGE_NAME_PARAM = 0;
+	private static final int PIPELINE_HOST_PARAM = 1;
+	private static final int PIPELINE_PORT_PARAM = 2;
+	private static final int PERFORMANCE_LOG_PARAM = 3;
+	private static final int LOG_PORT_PARAM = 4;
+	private static final int OVERRIDE_PROPERTIES_PARAM = 5;
+
+	private final String stageName;
+	private final String host;
+	private final int port;
+	private final boolean performanceLogging;
+	private final int logPort;
+
+	/* @Nullable */
+	private final Map<String, Object> stageOverrideProperties;
+
+	private StageCommandLineArguments(String stageName, String host, int port, boolean performanceLogging, int logPort, Map<String, Object> stageOverrideProperties) {
+		this.stageName = stageName;
+		this.host = host;
+		this.port = port;
+		this.performanceLogging = performanceLogging;
+		this.logPort = logPort;
+		this.stageOverrideProperties = stageOverrideProperties;
+	}
+
+	public static StageCommandLineArguments parse(String[] args) throws Exception {
+		if(args.length == 0) {
+			throw new RequiredArgumentMissingException("Missing stage(group) name");
+		}
+
+		String stageName = args[STAGE_NAME_PARAM];
+		String host = (args.length>PIPELINE_HOST_PARAM) ? args[PIPELINE_HOST_PARAM] : RemotePipeline.DEFAULT_HOST;
+		int port = (args.length>PIPELINE_PORT_PARAM) ? Integer.parseInt(args[PIPELINE_PORT_PARAM]) : RemotePipeline.DEFAULT_PORT;
+		boolean usePerformanceLogging = (args.length>PERFORMANCE_LOG_PARAM) ? Boolean.parseBoolean(args[PERFORMANCE_LOG_PARAM]) : false;
+		int logPort = (args.length>LOG_PORT_PARAM) ? Integer.parseInt(args[LOG_PORT_PARAM]) : RemotePipeline.DEFAULT_LOG_PORT;
+		Map<String, Object> stageOverrideProperties = (args.length>OVERRIDE_PROPERTIES_PARAM) ? SerializationUtils.fromJson(args[OVERRIDE_PROPERTIES_PARAM]) : null;
+
+		return new StageCommandLineArguments(stageName, host, port, usePerformanceLogging, logPort, stageOverrideProperties);
+	}
+
+	public String getStageName() {
+		return stageName;
+	}
+
+	// A bit of a hack here. AbstractStage and GroupStarter takes the same command line
+	// arguments, but in the case of GroupStarter, the first argument is the name of the stage group.
+	public String getStageGroupName() {
+		return stageName;
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	public boolean isPerformanceLogging() {
+		return performanceLogging;
+	}
+
+	public int getLogPort() {
+		return logPort;
+	}
+
+	public Map<String, Object> getStageOverrideProperties() {
+		return stageOverrideProperties;
+	}
+}

--- a/api/src/main/java/com/findwise/hydra/stage/StageFactory.java
+++ b/api/src/main/java/com/findwise/hydra/stage/StageFactory.java
@@ -1,0 +1,107 @@
+package com.findwise.hydra.stage;
+
+import com.findwise.hydra.local.RemotePipeline;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class StageFactory {
+	private Logger logger = LoggerFactory.getLogger(StageFactory.class);
+
+	private final String stageName;
+	private final String hostName;
+	private final int port;
+	private final boolean usePerformanceLogging;
+	private final Map<String, Object> stageOverrideProperties;
+
+	public StageFactory(String stageName, String hostName, int port, boolean usePerformanceLogging, Map<String, Object> stageOverrideProperties) {
+		this.stageName = stageName;
+		this.hostName = hostName;
+		this.port = port;
+		this.usePerformanceLogging = usePerformanceLogging;
+		this.stageOverrideProperties = stageOverrideProperties;
+	}
+
+	public void createAndStartStages() throws UnknownHostException {
+		List<AbstractStage> stages = createInstances();
+
+		for(AbstractStage stage : createInstances()) {
+			stage.start();
+		}
+		logger.info("Started "+stages.size()+" instances of stage: " + stages.get(0).getName()+". Running with the query: "+stages.get(0).getQuery());
+	}
+
+	private List<AbstractStage> createInstances() throws UnknownHostException {
+		List<AbstractStage> stageInstances = new ArrayList<AbstractStage>();
+
+		// Since the number of threads to spawn is an instance variable of the stage, we
+		// need to construct at least one in order to know how many to construct. That's
+		// why this logic is so strange. TODO: Code smell
+		AbstractStage stageInstance = createInstance();
+		stageInstances.add(stageInstance);
+		while(stageInstances.size() < stageInstance.getNumberOfThreads()) {
+			stageInstances.add(createInstance());
+		}
+		return stageInstances;
+	}
+
+	@SuppressWarnings("unchecked")
+	private AbstractStage createInstance() throws UnknownHostException {
+		try {
+			// TODO: Do we really want one per instance? Or can we reuse one for multiple instances?
+			RemotePipeline rp = createRemotePipeline();
+			Map<String, Object> properties = (stageOverrideProperties != null) ? stageOverrideProperties : rp.getProperties();
+
+			String stageClassName;
+			if(properties.containsKey(AbstractStage.ARG_NAME_STAGE_CLASS)) {
+				stageClassName = (String) properties.get(AbstractStage.ARG_NAME_STAGE_CLASS);
+			} else {
+				throw new RequiredArgumentMissingException("No class specified in the '"+ AbstractStage.ARG_NAME_STAGE_CLASS+"' property.");
+			}
+
+			AbstractStage stage = (AbstractStage) Class.forName(stageClassName).newInstance();
+
+			// stage.setName sets the name of the *thread*.
+			// TODO: Add a numeric identifier to the thread name (for stages with multiple threads).
+			stage.setName(stageName);
+			stage.setStageName(stageName);
+
+			stage.setUp(rp, properties);
+			stage.init();
+
+			return stage;
+		} catch (RequiredArgumentMissingException e) {
+			throw new StageCreationFailedException("Failed to read arguments", e);
+		} catch (InitFailedException e) {
+			throw new StageCreationFailedException("Failed to initialize Stage", e);
+		} catch (ClassNotFoundException e) {
+			throw new StageCreationFailedException("Could not find the Stage class in classpath", e);
+		} catch (InstantiationException e) {
+			throw new StageCreationFailedException("Could not instantiate the Stage class", e);
+		} catch (IllegalAccessException e) {
+			throw new StageCreationFailedException("Could not access constructor of Stage class", e);
+		} catch (UnknownHostException e) {
+			// TODO: Why are we throwing this without wrapping it?
+			throw e;
+		} catch (IOException e) {
+			throw new StageCreationFailedException("Communication failure when reading properties", e);
+		}
+	}
+
+	private RemotePipeline createRemotePipeline() {
+		RemotePipeline rp = new RemotePipeline(hostName, port, stageName);
+		rp.setPerformanceLogging(usePerformanceLogging);
+		return rp;
+	}
+
+	public class StageCreationFailedException extends RuntimeException {
+		public StageCreationFailedException(String message, Throwable cause) {
+			super(message, cause);
+		}
+	}
+}


### PR DESCRIPTION
Hi,

This is something I've wanted to do for a while, but finally got around to while trying to understand how StageGroups work. I noticed that the logic for parsing command line arguments was duplicated and not clearly defined. This is an attempt to fix that. I also took the opportunity to extract some stuff from AbstractStage (which is becoming a bit big imho).
- Created StageCommandLineArguments class for parsing String[] args
- Moved logic for stage creation from AbstractStage into a StageFactory
- Other misc. refactoring + additional comments
