### PR TITLE
Travis now runs "mvn verify" instead of "mvn test"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ jdk:
   - oraclejdk7
   - openjdk6
 services: mongodb
+script: mvn verify


### PR DESCRIPTION
Our failsafe tests (*IT.java) were not being run by travis.
