### PR TITLE
Add a basic stage for converting dates to iso8601Z date (zulu date)

### DIFF
--- a/api/src/test/java/com/findwise/hydra/local/LocalDocumentTest.java
+++ b/api/src/test/java/com/findwise/hydra/local/LocalDocumentTest.java
@@ -1,7 +1,5 @@
 package com.findwise.hydra.local;
 
-import static org.junit.Assert.*;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -13,11 +11,16 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.findwise.hydra.Document;
+import com.findwise.hydra.Document.Action;
 import com.findwise.hydra.JsonException;
 import com.findwise.hydra.SerializationUtils;
-import com.findwise.hydra.Document.Action;
 import com.findwise.tools.Comparator;
-import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 public class LocalDocumentTest {

--- a/api/src/test/java/com/findwise/hydra/local/RemotePipelineTest.java
+++ b/api/src/test/java/com/findwise/hydra/local/RemotePipelineTest.java
@@ -1,23 +1,9 @@
 package com.findwise.hydra.local;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import com.findwise.hydra.DocumentFile;
-import com.findwise.hydra.SerializationUtils;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.slf4j.LoggerFactory;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -25,9 +11,23 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.findwise.hydra.DocumentFile;
+import com.findwise.hydra.SerializationUtils;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class RemotePipelineTest {
 

--- a/api/src/test/java/com/findwise/hydra/stage/AbstractStageTest.java
+++ b/api/src/test/java/com/findwise/hydra/stage/AbstractStageTest.java
@@ -1,20 +1,22 @@
 package com.findwise.hydra.stage;
 
-import static org.junit.Assert.*;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.findwise.hydra.JsonException;
 import org.junit.Test;
 
 import com.findwise.hydra.Document.Action;
+import com.findwise.hydra.JsonException;
 import com.findwise.hydra.SerializationUtils;
 import com.findwise.hydra.local.LocalQuery;
 import com.findwise.hydra.stage.AbstractStageTest.TestStage.Enumerable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class AbstractStageTest {
 

--- a/core/src/main/java/com/findwise/hydra/StreamLogger.java
+++ b/core/src/main/java/com/findwise/hydra/StreamLogger.java
@@ -1,10 +1,12 @@
 package com.findwise.hydra;
 
-import java.io.*;
-
-import org.slf4j.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**

--- a/core/src/test/java/com/findwise/hydra/net/MarkHandlerTest.java
+++ b/core/src/test/java/com/findwise/hydra/net/MarkHandlerTest.java
@@ -2,7 +2,6 @@ package com.findwise.hydra.net;
 
 import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 import com.findwise.hydra.Document.Status;
 import com.findwise.hydra.local.LocalDocument;
@@ -11,6 +10,8 @@ import com.findwise.hydra.local.RemotePipeline;
 import com.findwise.hydra.memorydb.MemoryConnector;
 import com.findwise.hydra.memorydb.MemoryDocument;
 import com.findwise.hydra.memorydb.MemoryType;
+
+import static org.junit.Assert.fail;
 
 public class MarkHandlerTest {
 	private MemoryConnector mc;

--- a/database-impl/inmemory/src/test/java/com/findwise/hydra/memorydb/MemoryDocumentIOTest.java
+++ b/database-impl/inmemory/src/test/java/com/findwise/hydra/memorydb/MemoryDocumentIOTest.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Random;
 
 import junit.framework.Assert;
-
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,10 +22,15 @@ import com.findwise.hydra.Document.Status;
 import com.findwise.hydra.DocumentFile;
 import com.findwise.hydra.SerializationUtils;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
 
 @RunWith(RepeatRunner.class)
 public class MemoryDocumentIOTest {

--- a/database/src/test/java/com/findwise/hydra/MemoryCacheTest.java
+++ b/database/src/test/java/com/findwise/hydra/MemoryCacheTest.java
@@ -1,8 +1,5 @@
 package com.findwise.hydra;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -14,6 +11,19 @@ import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings({"rawtypes", "unchecked"})

--- a/database/src/test/java/com/findwise/hydra/StageGroupTest.java
+++ b/database/src/test/java/com/findwise/hydra/StageGroupTest.java
@@ -1,13 +1,13 @@
 package com.findwise.hydra;
 
-import static org.junit.Assert.*;
-
 import java.util.Date;
 import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
 
 public class StageGroupTest {
 

--- a/examples/src/main/java/com/findwise/hydra/json/PipelineConfiguration.java
+++ b/examples/src/main/java/com/findwise/hydra/json/PipelineConfiguration.java
@@ -1,6 +1,9 @@
 package com.findwise.hydra.json;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Representation of a pipeline configuration. The corresponding json format

--- a/examples/src/test/java/com/findwise/hydra/json/JsonPipelineUtilTest.java
+++ b/examples/src/test/java/com/findwise/hydra/json/JsonPipelineUtilTest.java
@@ -3,12 +3,13 @@ package com.findwise.hydra.json;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author johan.sjoberg

--- a/stages/processing/basic/pom.xml
+++ b/stages/processing/basic/pom.xml
@@ -48,18 +48,24 @@
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.6</version>
-			<type>jar</type>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.1</version>
-			<type>jar</type>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                        <version>1.6</version>
+                        <type>jar</type>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                    <version>2.1</version>
+                    <type>jar</type>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                    <version>2.3</version>
+                    <type>jar</type>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<finalName>${project.name}</finalName>

--- a/stages/processing/basic/pom.xml
+++ b/stages/processing/basic/pom.xml
@@ -52,6 +52,12 @@
             <type>jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.3</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
 
     <build>

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/DateFormatterStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/DateFormatterStage.java
@@ -23,12 +23,16 @@ import org.slf4j.LoggerFactory;
  * Zulu time is ISO 8601 where the time zone is +0. The format has the following
  * pattern YYYY-MM-DDTHH:MM:SS.000Z
  * 
+ * At the moment, this stage only transforms date to zulu date. The plan is
+ * to extend functionality to transform from one given format to another given 
+ * format. See issue {@link https://github.com/Findwise/Hydra/pull/296}
+ * 
  *
  * Sample configuration:
  * <pre>
  * {@code 
         {
-          "stageClass": "com.findwise.hydra.stage.ZuluDateFormatter",
+          "stageClass": "com.findwise.hydra.stage.DateFormatterStage",
           "query": {
               "touched" : {"remove-blank-fields": true}
           },
@@ -43,9 +47,9 @@ import org.slf4j.LoggerFactory;
  */
 @Stage(description = "A stage that transfroms EPOCH and ISO8601 time to "
         + "Zulu Date format")
-public class ZuluDateFormatter extends AbstractProcessStage {
+public class DateFormatterStage extends AbstractProcessStage {
 
-    private Logger logger = LoggerFactory.getLogger(ZuluDateFormatter.class);
+    private Logger logger = LoggerFactory.getLogger(DateFormatterStage.class);
     
     private static final String EPOCH_PATTERN = "^[0-9]+$";
     private static final String ISO8601_PATTERN = 
@@ -92,8 +96,7 @@ public class ZuluDateFormatter extends AbstractProcessStage {
         } else if(iso8601Pattern.matcher(dateStr).matches()){
             dateStr = fromISO8601ToZuluDate((String) contentField.getValue());
         } else {
-            logger.info("Faild to parse date: " + dateStr + 
-                    " to Zulu date format");
+            logger.info("Faild to parse date: " + dateStr);
         }
         
         doc.putContentField(contentField.getKey(), dateStr);
@@ -106,10 +109,10 @@ public class ZuluDateFormatter extends AbstractProcessStage {
         return d.toString(DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss'Z"));
     }
 
-    private String fromEpocToZuluDate(String epoc) {
+    private String fromEpocToZuluDate(String epoch) {
         SimpleDateFormat formatter = 
                 new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
-        long timestampInSec = Long.parseLong(epoc) * 1000;
+        long timestampInSec = Long.parseLong(epoch) * 1000;
         String formatedWithTimezoneInfo = 
                 formatter.format(new Date(timestampInSec));
         String[] atTimeZone = formatedWithTimezoneInfo.split("\\+");

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/ZuluDateFormatter.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/ZuluDateFormatter.java
@@ -1,0 +1,118 @@
+package com.findwise.hydra.stage;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import com.findwise.hydra.local.LocalDocument;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.regex.Pattern;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Converts epoch time and ISO 8601 with different time zones to Zulu time. 
+ * Zulu time is ISO 8601 where the time zone is +0. The format has the following
+ * pattern YYYY-MM-DDTHH:MM:SS.000Z
+ * 
+ *
+ * Sample configuration:
+ * <pre>
+ * {@code 
+        {
+          "stageClass": "com.findwise.hydra.stage.ZuluDateFormatter",
+          "query": {
+              "touched" : {"remove-blank-fields": true}
+          },
+          "dateFields":
+              ["updated","created"]
+        }
+ * }
+ * </pre>
+ * 
+ * @author magnus.ebbesson
+ * @author leonard.saers
+ */
+@Stage(description = "A stage that transfroms EPOCH and ISO8601 time to "
+        + "Zulu Date format")
+public class ZuluDateFormatter extends AbstractProcessStage {
+
+    private Logger logger = LoggerFactory.getLogger(ZuluDateFormatter.class);
+    
+    private static final String EPOCH_PATTERN = "^[0-9]+$";
+    private static final String ISO8601_PATTERN = 
+            "^(\\d{4}\\-\\d\\d\\-\\d\\d([tT][\\d:\\.]*)?)"
+            + "([zZ]|([+\\-])(\\d\\d):?(\\d\\d))?$";
+    Pattern epochPattern;
+    Pattern iso8601Pattern;
+    
+    @Parameter(description = "List<String> - A list of field names that are to "
+            + "be considered date fields")
+    List<String> dateFields = new ArrayList<String>();
+
+    Set<String> dateFieldsSet;
+
+    @Override
+    public void init() {
+        dateFieldsSet = new HashSet<String>(dateFields);
+        
+        epochPattern = Pattern.compile(EPOCH_PATTERN);
+        iso8601Pattern = Pattern.compile(ISO8601_PATTERN);
+    }
+
+    @Override
+    public void process(LocalDocument doc) throws ProcessException {
+        Map<String, Object> contentMap = doc.getContentMap();
+
+        for (Entry<String, Object> contentField : contentMap.entrySet()) {
+            if (dateFieldsSet.contains(contentField.getKey())) {
+                
+                if ((contentField.getValue() instanceof String)) {
+                                
+                    parseDate(contentField, doc);
+                }
+            }
+        }
+    }
+
+    private void parseDate
+        (Entry<String, Object> contentField, LocalDocument doc) {
+        String dateStr = (String) contentField.getValue();
+        
+        if(epochPattern.matcher(dateStr).matches()){
+            dateStr = fromEpocToZuluDate((String) contentField.getValue());
+        } else if(iso8601Pattern.matcher(dateStr).matches()){
+            dateStr = fromISO8601ToZuluDate((String) contentField.getValue());
+        } else {
+            logger.info("Faild to parse date: " + dateStr + 
+                    " to Zulu date format");
+        }
+        
+        doc.putContentField(contentField.getKey(), dateStr);
+    }
+
+    private String fromISO8601ToZuluDate(String date) {
+        DateTimeFormatter formatter = 
+                DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZ");
+        DateTime d = formatter.parseDateTime(date).withZone(DateTimeZone.UTC);
+        return d.toString(DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss'Z"));
+    }
+
+    private String fromEpocToZuluDate(String epoc) {
+        SimpleDateFormat formatter = 
+                new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+        long timestampInSec = Long.parseLong(epoc) * 1000;
+        String formatedWithTimezoneInfo = 
+                formatter.format(new Date(timestampInSec));
+        String[] atTimeZone = formatedWithTimezoneInfo.split("\\+");
+        return atTimeZone[0] + "Z";
+    }
+}

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/ConcatenatingHashStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/ConcatenatingHashStageTest.java
@@ -4,15 +4,18 @@
  */
 package com.findwise.hydra.stage;
 
-import com.findwise.hydra.local.LocalDocument;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
-import static org.junit.Assert.*;
+
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Test;
+
+import com.findwise.hydra.local.LocalDocument;
+
+import static org.junit.Assert.fail;
 
 /**
  *

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/DateFormatterStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/DateFormatterStageTest.java
@@ -14,18 +14,18 @@ import static org.junit.Assert.*;
  * @author magnus.ebbesson
  * @author leonard.saers
  */
-public class ZuluDateFormatterTest {
+public class DateFormatterStageTest {
 
-    ZuluDateFormatter subject;
+    DateFormatterStage subject;
     Map<String, Object> settings;
     List<String> fields;
 
-    public ZuluDateFormatterTest() {
+    public DateFormatterStageTest() {
     }
 
     @Before
     public void setUp() {
-        subject = new ZuluDateFormatter();
+        subject = new DateFormatterStage();
 
         fields = new ArrayList<String>();
         fields.add("date");

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/RemoveFieldsTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/RemoveFieldsTest.java
@@ -1,9 +1,14 @@
 package com.findwise.hydra.stage;
 
-import com.findwise.hydra.local.LocalDocument;
 import java.util.LinkedList;
+
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import com.findwise.hydra.local.LocalDocument;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /** 
  * @author Roar Granevang & Joel Westberg

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/ZuluDateFormatterTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/ZuluDateFormatterTest.java
@@ -1,0 +1,82 @@
+package com.findwise.hydra.stage;
+
+import com.findwise.hydra.local.LocalDocument;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * @author magnus.ebbesson
+ * @author leonard.saers
+ */
+public class ZuluDateFormatterTest {
+
+    ZuluDateFormatter subject;
+    Map<String, Object> settings;
+    List<String> fields;
+
+    public ZuluDateFormatterTest() {
+    }
+
+    @Before
+    public void setUp() {
+        subject = new ZuluDateFormatter();
+
+        fields = new ArrayList<String>();
+        fields.add("date");
+
+        settings = new HashMap<String, Object>();
+        settings.put("fields", fields);
+
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void testFromEpocToZuluDate()
+            throws ProcessException, IllegalArgumentException,
+            IllegalAccessException, RequiredArgumentMissingException {
+
+        String epochTest = "1377174053";
+        String expected = "2013-08-22T14:20:53Z";
+        setupStage();
+
+        LocalDocument ld = new LocalDocument();
+        ld.putContentField("date", epochTest);
+
+        subject.process(ld);
+
+        assertEquals(expected, ld.getContentField("date"));
+    }
+
+    @Test
+    public void testISO8601FormatToZuluDate()
+            throws IllegalArgumentException, IllegalAccessException,
+            ProcessException, RequiredArgumentMissingException {
+        String iso8601 = "2012-06-29T10:42:53+02:00";
+        String expected = "2012-06-29T08:42:53Z";
+        setupStage();
+
+        LocalDocument ld = new LocalDocument();
+        ld.putContentField("date", iso8601);
+
+        subject.process(ld);
+
+        assertEquals(expected, ld.getContentField("date"));
+    }
+
+    private void setupStage() throws IllegalArgumentException,
+            IllegalAccessException,
+            RequiredArgumentMissingException {
+        settings.put("dateFields", fields);
+        subject.setParameters(settings);
+        subject.init();
+    }
+}

--- a/stages/processing/hydra-groovy-runner/src/test/groovy/com/findwise/hydra/stage/groovyrunner/FieldAddingGroovyStageTest.groovy
+++ b/stages/processing/hydra-groovy-runner/src/test/groovy/com/findwise/hydra/stage/groovyrunner/FieldAddingGroovyStageTest.groovy
@@ -1,9 +1,9 @@
-package com.findwise.hydra.stage.groovyrunner;
+package com.findwise.hydra.stage.groovyrunner
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import com.findwise.hydra.local.LocalDocument
+import org.junit.Test
 
-import com.findwise.hydra.local.LocalDocument;
+import static org.junit.Assert.assertEquals;
 
 class FieldAddingGroovyStageTest {
 

--- a/stages/processing/hydra-groovy-runner/src/test/java/com/findwise/hydra/stage/groovyrunner/GroovyRunnerStageTest.java
+++ b/stages/processing/hydra-groovy-runner/src/test/java/com/findwise/hydra/stage/groovyrunner/GroovyRunnerStageTest.java
@@ -1,21 +1,17 @@
 package com.findwise.hydra.stage.groovyrunner;
 
-import static org.junit.Assert.*;
-
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.commons.io.FileUtils;
+import junit.framework.Assert;
 import org.apache.commons.io.IOUtils;
-import org.codehaus.groovy.tools.groovydoc.ClasspathResourceManager;
 import org.junit.Test;
 
 import com.findwise.hydra.local.LocalDocument;
 import com.findwise.hydra.stage.ProcessException;
 import com.findwise.hydra.stage.RequiredArgumentMissingException;
 
-import junit.framework.Assert;
+import static org.junit.Assert.assertEquals;
 
 public class GroovyRunnerStageTest {
 

--- a/stages/processing/tika/src/main/java/com/findwise/hydra/stage/tika/TikaStage.java
+++ b/stages/processing/tika/src/main/java/com/findwise/hydra/stage/tika/TikaStage.java
@@ -11,7 +11,10 @@ import org.xml.sax.SAXException;
 import com.findwise.hydra.DocumentFile;
 import com.findwise.hydra.local.Local;
 import com.findwise.hydra.local.LocalDocument;
-import com.findwise.hydra.stage.*;
+import com.findwise.hydra.stage.AbstractProcessStage;
+import com.findwise.hydra.stage.Parameter;
+import com.findwise.hydra.stage.ProcessException;
+import com.findwise.hydra.stage.Stage;
 import com.findwise.hydra.stage.tika.utils.TikaUtils;
 
 /**

--- a/stages/processing/tika/src/test/java/com/findwise/hydra/stage/tika/SimpleFetchingTikaStageTest.java
+++ b/stages/processing/tika/src/test/java/com/findwise/hydra/stage/tika/SimpleFetchingTikaStageTest.java
@@ -4,23 +4,28 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.Arrays;
 
-import org.junit.Assert;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-
 import com.google.common.io.ByteStreams;
-import org.junit.*;
-
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.parser.AutoDetectParser;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.sax.BodyContentHandler;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.findwise.hydra.local.LocalDocument;
 import com.findwise.hydra.stage.ProcessException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 
 public class SimpleFetchingTikaStageTest {
 

--- a/stages/processing/tika/src/test/java/com/findwise/hydra/stage/tika/utils/TikaUtilsTest.java
+++ b/stages/processing/tika/src/test/java/com/findwise/hydra/stage/tika/utils/TikaUtilsTest.java
@@ -1,8 +1,6 @@
 package com.findwise.hydra.stage.tika.utils;
 
 
-import static org.junit.Assert.*;
-
 import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -19,6 +17,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.findwise.hydra.local.LocalDocument;
+
+import static org.junit.Assert.fail;
 
 public class TikaUtilsTest {
 	private LocalDocument doc;

--- a/stages/processing/web/src/main/java/com/findwise/hydra/stage/webstages/RenderHTMLStage.java
+++ b/stages/processing/web/src/main/java/com/findwise/hydra/stage/webstages/RenderHTMLStage.java
@@ -1,13 +1,15 @@
 package com.findwise.hydra.stage.webstages;
 
-import net.htmlparser.jericho.*;
+import java.util.List;
+
+import net.htmlparser.jericho.Source;
+
 import com.findwise.hydra.local.LocalDocument;
 import com.findwise.hydra.stage.AbstractProcessStage;
 import com.findwise.hydra.stage.Parameter;
 import com.findwise.hydra.stage.ProcessException;
 import com.findwise.hydra.stage.RequiredArgumentMissingException;
 import com.findwise.hydra.stage.Stage;
-import java.util.List;
 
 /**
  * @author Roar Granevang

--- a/test-suite/functional-tests/src/test/java/com/findwise/hydra/FullScaleIT.java
+++ b/test-suite/functional-tests/src/test/java/com/findwise/hydra/FullScaleIT.java
@@ -1,23 +1,36 @@
 package com.findwise.hydra;
 
-import com.findwise.hydra.mongodb.*;
+import java.io.InputStream;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
 import com.mongodb.DB;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 import com.mongodb.WriteConcern;
 import com.mongodb.gridfs.GridFS;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.InputStream;
-import java.net.UnknownHostException;
-import java.util.*;
+import com.findwise.hydra.mongodb.MongoConfiguration;
+import com.findwise.hydra.mongodb.MongoConnector;
+import com.findwise.hydra.mongodb.MongoDocument;
+import com.findwise.hydra.mongodb.MongoDocumentIO;
+import com.findwise.hydra.mongodb.MongoQuery;
+import com.findwise.hydra.mongodb.MongoTailableIterator;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 @RunWith(Parameterized.class)

--- a/test-suite/functional-tests/src/test/java/com/findwise/hydra/LinearPipelineBuilder.java
+++ b/test-suite/functional-tests/src/test/java/com/findwise/hydra/LinearPipelineBuilder.java
@@ -1,9 +1,13 @@
 package com.findwise.hydra;
 
-import com.findwise.hydra.mongodb.MongoConnector;
-
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.findwise.hydra.mongodb.MongoConnector;
 
 class LinearPipelineBuilder {
 	private boolean useOneStageGroupPerStage = true;


### PR DESCRIPTION
Solr consumes dates strictly formatted as iso8601 with time zone +0. The format is sometimes called zulu time. This stage formats dates into ISO8601 zulu format. So far it handles epoch time and ISO8601 with different time zones.

Is this stage worth adding to Hydras basic stages?
