### PR TITLE
HttpFetcher shouldn't consume the HttpEntity

### DIFF
--- a/stages/utils/http/pom.xml
+++ b/stages/utils/http/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.findwise.hydra</groupId>
@@ -35,6 +35,11 @@
 			<version>1.7.5</version>
 		</dependency>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>log4j-over-slf4j</artifactId>
+			<version>1.7.5</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.11</version>
@@ -44,6 +49,28 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>1.9.5</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock</artifactId>
+			<version>1.40</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>junit</groupId>
+					<artifactId>junit-dep</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-nop</artifactId>
+			<version>1.7.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/stages/utils/http/src/main/java/com/findwise/utils/http/HttpFetcher.java
+++ b/stages/utils/http/src/main/java/com/findwise/utils/http/HttpFetcher.java
@@ -35,17 +35,16 @@ import org.apache.http.impl.client.cache.CachingHttpClient;
 import org.apache.http.impl.conn.BasicClientConnectionManager;
 import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpContext;
-import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Generic HTTP fetching utility.
- *
+ * 
  * <p>
  * This class takes care of opening and closing connections.
  * </p>
- *
+ * 
  * Supports:
  * <ul>
  * <li>Basic Auth</li>
@@ -53,7 +52,10 @@ import org.slf4j.LoggerFactory;
  * <li>SSL, with optional exceptions for trusted hosts</li>
  * <li>Fetching of session cookies</li>
  * </ul>
- *
+ * 
+ * Users of this class is responsible for releasing resources allocated by
+ * returned objects of type {@link HttpEntity}.
+ * 
  * @author olof.nilsson@findwise.com
  * @author martin.nycander@findwise.com
  */
@@ -122,12 +124,7 @@ public class HttpFetcher {
                 attempts++;
                 StatusLine status = response.getStatusLine();
                 if (HttpStatus.SC_OK == status.getStatusCode()) {
-                    HttpEntity entity = response.getEntity();
-                    try {
-                        return entity;
-                    } finally {
-                        EntityUtils.consume(entity);
-                    }
+                    return response.getEntity();
                 } else if (HttpStatus.SC_BAD_REQUEST == status.getStatusCode()) {
                     // Request has gone bad, recreate it and ignore attempt
                     logger.debug(

--- a/stages/utils/http/src/test/java/com/findwise/utils/http/HttpFetcherTest.java
+++ b/stages/utils/http/src/test/java/com/findwise/utils/http/HttpFetcherTest.java
@@ -1,0 +1,38 @@
+package com.findwise.utils.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.Assert.assertEquals;
+
+import java.io.InputStream;
+import java.util.Scanner;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.util.EntityUtils;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+public class HttpFetcherTest {
+
+	@Rule
+	public WireMockRule wireMockRule = new WireMockRule(37777);
+
+	@Test
+	public void testBodyShouldBeFetched() throws Exception {
+		HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().build();
+		HttpFetcher httpFetcher = new HttpFetcher(settings);
+		stubFor(get(urlEqualTo("/")).willReturn(aResponse().withBody("body")));
+		HttpEntity responseEntity = httpFetcher.fetch("http://localhost:37777", "*/*");
+		InputStream contentStream = responseEntity.getContent();
+		Scanner scanner = new Scanner(contentStream);
+		String bodyContent = scanner.useDelimiter("\\A").next();
+		scanner.close();
+		EntityUtils.consume(responseEntity);
+		assertEquals("body", bodyContent);
+	}
+
+}


### PR DESCRIPTION
HttpFetcher no longer consumes the HttpEntity making it possible to actually read the content stream.
