### PR TITLE
Improvements to MongoDB integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ nbactions.xml
 nb-configuration.xml
 .DS_Store
 admin-service/tmp
+pipeline/

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/DatabaseConfigurationFactory.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/DatabaseConfigurationFactory.java
@@ -8,4 +8,5 @@ public class DatabaseConfigurationFactory {
 		config.setNamespace(namespace);
 		return config;
 	}
+
 }

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/DocumentInserterThread.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/DocumentInserterThread.java
@@ -1,0 +1,66 @@
+package com.findwise.hydra.mongodb;
+
+import com.findwise.hydra.DatabaseDocument;
+
+public class DocumentInserterThread extends Thread {
+
+	private final int testReadCount;
+	private final MongoConnector mdc;
+
+	public DocumentInserterThread(final int testReadCount, final MongoConnector mongoConnector) {
+		super();
+		this.testReadCount = testReadCount;
+		this.mdc = mongoConnector;
+	}
+
+	public void run() {
+		try {
+			insertDocuments(testReadCount);
+			processDocuments(testReadCount/3);
+			failDocuments(testReadCount/3);
+			discardDocuments(testReadCount - (testReadCount/3)*2);
+		} catch (Exception e) {
+			System.out.println(e.getMessage());
+		}
+	}
+
+	public long processDocuments(int count) throws Exception {
+		long start = System.currentTimeMillis();
+		DatabaseDocument<MongoType> dd;
+		for(int i=0; i<count; i++) {
+			dd = mdc.getDocumentReader().getDocument(new MongoQuery());
+			mdc.getDocumentWriter().markProcessed(dd, "x");
+		}
+		return System.currentTimeMillis()-start;
+	}
+
+	public long failDocuments(int count) throws Exception {
+		long start = System.currentTimeMillis();
+		DatabaseDocument<MongoType> dd;
+		for(int i=0; i<count; i++) {
+			dd = mdc.getDocumentReader().getDocument(new MongoQuery());
+			mdc.getDocumentWriter().markFailed(dd, "x");
+		}
+		return System.currentTimeMillis()-start;
+	}
+
+	public long discardDocuments(int count) throws Exception {
+		long start = System.currentTimeMillis();
+		DatabaseDocument<MongoType> dd;
+		for(int i=0; i<count; i++) {
+			dd = mdc.getDocumentReader().getDocument(new MongoQuery());
+			mdc.getDocumentWriter().markDiscarded(dd, "x");
+		}
+		return System.currentTimeMillis()-start;
+	}
+
+	public long insertDocuments(int count) throws Exception {
+		long start = System.currentTimeMillis();
+		for(int i=0; i<count; i++) {
+			MongoDocument d = new MongoDocument();
+			d.putContentField("some_field_" + i, "a string with number " + i);
+			mdc.getDocumentWriter().insert(d);
+		}
+		return System.currentTimeMillis()-start;
+	}
+}

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoConfigurationBuilder.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoConfigurationBuilder.java
@@ -1,0 +1,44 @@
+package com.findwise.hydra.mongodb;
+
+public class MongoConfigurationBuilder {
+
+	private MongoConfiguration mongoConfiguration;
+
+	public MongoConfigurationBuilder() {
+		this.mongoConfiguration = new MongoConfiguration();
+	}
+
+	public MongoConfiguration build() {
+		return mongoConfiguration;
+	}
+
+	public MongoConfigurationBuilder setNamespace(String namespace) {
+		mongoConfiguration.setNamespace(namespace);
+		return this;
+	}
+
+	public MongoConfigurationBuilder setDatabaseUrl(String value) {
+		mongoConfiguration.setDatabaseUrl(value);
+		return this;
+	}
+
+	public MongoConfigurationBuilder setDatabaseUser(String user) {
+		mongoConfiguration.setDatabaseUser(user);
+		return this;
+	}
+
+	public MongoConfigurationBuilder setDatabasePassword(String password) {
+		mongoConfiguration.setDatabasePassword(password);
+		return this;
+	}
+
+	public MongoConfigurationBuilder setOldMaxSize(int size) {
+		mongoConfiguration.setOldMaxSize(size);
+		return this;
+	}
+
+	public MongoConfigurationBuilder setOldMaxCount(int count) {
+		mongoConfiguration.setOldMaxCount(count);
+		return this;
+	}
+}

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoConnectorResource.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoConnectorResource.java
@@ -13,10 +13,18 @@ public class MongoConnectorResource extends ExternalResource {
 	private final String dbName;
 
 	private MongoConnector mdc;
+	private DatabaseConfiguration databaseConfiguration;
 	private MongoClient mongo;
 	
 	public MongoConnectorResource(Class<?> testClass) {
 		this.dbName = DB_PREFIX + testClass.getSimpleName();
+		databaseConfiguration = DatabaseConfigurationFactory.getDatabaseConfiguration(dbName);
+	}
+
+	public MongoConnectorResource(Class<?> testClass, MongoConfiguration mongoConfiguration) {
+		this.dbName = DB_PREFIX + testClass.getSimpleName();
+		mongoConfiguration.setNamespace(dbName);
+		databaseConfiguration = mongoConfiguration;
 	}
 	
 	@Override
@@ -40,8 +48,7 @@ public class MongoConnectorResource extends ExternalResource {
 
 	private void connect() throws IOException {
 		mongo = new MongoClient();
-		DatabaseConfiguration conf = DatabaseConfigurationFactory.getDatabaseConfiguration(dbName);
-		mdc = new MongoConnector(conf);
+		mdc = new MongoConnector(databaseConfiguration);
 		mdc.waitForWrites(true);
 		mdc.connect(mongo, false);
 	}

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOIT.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOIT.java
@@ -3,6 +3,7 @@ package com.findwise.hydra.mongodb;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -24,14 +25,11 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.findwise.hydra.DatabaseDocument;
 import com.findwise.hydra.Document;
-import com.findwise.hydra.Document.Status;
 import com.findwise.hydra.DocumentFile;
 import com.findwise.hydra.DocumentID;
 import com.findwise.hydra.DocumentWriter;
 import com.findwise.hydra.SerializationUtils;
-import com.findwise.hydra.TailableIterator;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 import com.mongodb.WriteConcern;
@@ -91,38 +89,6 @@ public class MongoDocumentIOIT {
 	}
 	
 	@Test
-	public void testRollover() throws Exception {
-		MongoConnector mdc = mongoConnectorResource.getConnector();
-		DocumentWriter<MongoType> dw = mdc.getDocumentWriter();
-		dw.prepare();
-
-		for(int i=0; i<mdc.getStatusReader().getStatus().getNumberToKeep(); i++) {
-			dw.insert(new MongoDocument());
-			DatabaseDocument<MongoType> dd = dw.getAndTag(new MongoQuery(), "tag");
-			dw.markProcessed(dd, "tag");
-		}
-		
-		if(mdc.getDocumentReader().getActiveDatabaseSize()!=0) {
-			fail("Still some active docs..");
-		}
-		
-		if(mdc.getDocumentReader().getInactiveDatabaseSize()!=mdc.getStatusReader().getStatus().getNumberToKeep()) {
-			fail("Incorrect number of old documents kept");
-		}
-		
-		dw.insert(new MongoDocument());
-		DatabaseDocument<MongoType> dd = dw.getAndTag(new MongoQuery(), "tag");
-		dw.markProcessed(dd, "tag");
-		
-		if(mdc.getDocumentReader().getActiveDatabaseSize()!=0) {
-			fail("Still some active docs..");
-		}
-		if(mdc.getDocumentReader().getInactiveDatabaseSize()!=mdc.getStatusReader().getStatus().getNumberToKeep()) {
-			fail("Incorrect number of old documents kept: "+ mdc.getDocumentReader().getInactiveDatabaseSize());
-		}
-	}
-	
-	@Test
 	public void testNullFields() throws Exception {
 		MongoConnector mdc = mongoConnectorResource.getConnector();
 		MongoDocumentIO dw = mdc.getDocumentWriter();
@@ -163,73 +129,6 @@ public class MongoDocumentIOIT {
 		deserialized = mdc.getDocumentReader().toDocumentId(SerializationUtils.toObject(serialized));
 		if(!id.equals(deserialized.getID())) {
 			fail("Serialization failed from primitive");
-		}
-	}
-	
-	@Test
-	public void testInactiveIterator() throws Exception {
-		MongoConnector mdc = mongoConnectorResource.getConnector();
-		DocumentWriter<MongoType> dw = mdc.getDocumentWriter();
-		dw.prepare();
-		
-		TailableIterator<MongoType> it = mdc.getDocumentReader().getInactiveIterator();
-		
-		TailReader tr = new TailReader(it);
-		tr.start();
-		
-		MongoDocument first = new MongoDocument();
-		first.putContentField("num", 1);
-		dw.insert(first);
-		DatabaseDocument<MongoType> dd = dw.getAndTag(new MongoQuery(), "tag");
-		dw.markProcessed(dd, "tag");
-		
-		while(tr.lastRead>System.currentTimeMillis() && tr.isAlive()) {
-			Thread.sleep(50);
-		}
-		
-		if(!tr.isAlive()) {
-			fail("TailableReader died");
-		}
-		
-		long lastRead = tr.lastRead;
-		
-		if(!tr.lastReadDoc.getContentField("num").equals(1)) {
-			fail("Last doc read was not the correct document!");
-		}
-		
-		MongoDocument second = new MongoDocument();
-		second.putContentField("num", 2);
-		dw.insert(second);
-		dd = dw.getAndTag(new MongoQuery(), "tag");
-		dw.markProcessed(dd, "tag");
-		
-		while(tr.lastRead==lastRead) {
-			Thread.sleep(50);
-		}
-
-		if (!tr.lastReadDoc.getContentField("num").equals(2)) {
-			fail("Last doc read was not the correct document!");
-		}
-
-		
-		if(tr.hasError) {
-			fail("An exception was thrown by the TailableIterator prior to interrupt");
-		}
-		
-		tr.interrupt();
-
-		long interrupt = System.currentTimeMillis();
-		
-		while (tr.isAlive() && (System.currentTimeMillis()-interrupt)<10000) {
-			Thread.sleep(50);
-		}
-		
-		if(tr.isAlive()) {
-			fail("Unable to interrupt the tailableiterator");
-		}
-		
-		if(tr.hasError) {
-			fail("An exception was thrown by the TailableIterator after interrupt");
 		}
 	}
 	
@@ -358,7 +257,7 @@ public class MongoDocumentIOIT {
 		
 		assertFalse(dw.getDocumentById(d2.getID()).fetchedBy("tag"));
 	}
-	
+
 	@Ignore
 	@Test
 	public void testInsertLargeDocument() throws Exception {
@@ -402,106 +301,49 @@ public class MongoDocumentIOIT {
 			d.putContentField(getRandomString(5), getRandomString(1000000));
 		}
 	}
-	
-	int testReadCount = 1;
+
 	@Test
 	public void testReadStatus() throws Exception {
 		MongoConnector mdc = mongoConnectorResource.getConnector();
 		mdc.getDocumentWriter().prepare();
+
+		final int testReadCount = (int)mdc.getStatusReader().getStatus().getNumberToKeep();
 		
-		testReadCount = (int)mdc.getStatusReader().getStatus().getNumberToKeep(); 
+		TailReaderThread tailReaderThread = new TailReaderThread(mdc.getDocumentReader().getInactiveIterator());
+		tailReaderThread.start();
 		
-		TailReader tr = new TailReader(mdc.getDocumentReader().getInactiveIterator());
-		tr.start();
-		
-		Thread t = new Thread() {
-			public void run() {
-				try {
-					insertDocuments(testReadCount);
-					processDocuments(testReadCount/3);
-					failDocuments(testReadCount/3);
-					discardDocuments(testReadCount - (testReadCount/3)*2);
-				} catch (Exception e) {
-					System.out.println(e.getMessage());
-				}
-			}
-		};
-		t.start();
+		DocumentInserterThread documentInserterThread = new DocumentInserterThread(testReadCount, mdc);
+		documentInserterThread.start();
 		
 		long timer = System.currentTimeMillis();
 		
-		while (tr.count < testReadCount && (System.currentTimeMillis()-timer)<10000) {
+		while (tailReaderThread.count < testReadCount && (System.currentTimeMillis()-timer)<10000) {
 			Thread.sleep(50);
 		}
 		
-		if(tr.count < testReadCount) {
+		if(tailReaderThread.count < testReadCount) {
 			fail("Did not see all documents");
 		}
 		
-		if(tr.count > testReadCount) {
+		if(tailReaderThread.count > testReadCount) {
 			fail("Saw too many documents");
 		}
 		
-		if(tr.countProcessed != testReadCount/3) {
-			fail("Incorrect number of processed documents. Expected "+testReadCount/3+" but saw "+tr.countProcessed);
+		if(tailReaderThread.countProcessed != testReadCount/3) {
+			fail("Incorrect number of processed documents. Expected "+testReadCount/3+" but saw "+tailReaderThread.countProcessed);
 		}
 		
-		if(tr.countFailed != testReadCount/3) {
-			fail("Incorrect number of failed documents. Expected "+testReadCount/3+" but saw "+tr.countFailed);
+		if(tailReaderThread.countFailed != testReadCount/3) {
+			fail("Incorrect number of failed documents. Expected "+testReadCount/3+" but saw "+tailReaderThread.countFailed);
 		}
 		
-		if(tr.countDiscarded != testReadCount - (testReadCount/3)*2) {
-			fail("Incorrect number of discarded documents. Expected "+(testReadCount - (testReadCount/3)*2)+" but saw "+tr.countDiscarded);
+		if(tailReaderThread.countDiscarded != testReadCount - (testReadCount/3)*2) {
+			fail("Incorrect number of discarded documents. Expected "+(testReadCount - (testReadCount/3)*2)+" but saw "+tailReaderThread.countDiscarded);
 		}
 		
-		tr.interrupt();
-	}
-	
-	public long processDocuments(int count) throws Exception {
-		MongoConnector mdc = mongoConnectorResource.getConnector();
-		long start = System.currentTimeMillis();
-		DatabaseDocument<MongoType> dd;
-		for(int i=0; i<count; i++) {
-			dd = mdc.getDocumentReader().getDocument(new MongoQuery());
-			mdc.getDocumentWriter().markProcessed(dd, "x");
-		}
-		return System.currentTimeMillis()-start;
-	}
-	
-	public long failDocuments(int count) throws Exception {
-		MongoConnector mdc = mongoConnectorResource.getConnector();
-		long start = System.currentTimeMillis();
-		DatabaseDocument<MongoType> dd;
-		for(int i=0; i<count; i++) {
-			dd = mdc.getDocumentReader().getDocument(new MongoQuery());
-			mdc.getDocumentWriter().markFailed(dd, "x");
-		}
-		return System.currentTimeMillis()-start;
-	}
-	
-	public long discardDocuments(int count) throws Exception {
-		MongoConnector mdc = mongoConnectorResource.getConnector();
-		long start = System.currentTimeMillis();
-		DatabaseDocument<MongoType> dd;
-		for(int i=0; i<count; i++) {
-			dd = mdc.getDocumentReader().getDocument(new MongoQuery());
-			mdc.getDocumentWriter().markDiscarded(dd, "x");
-		}
-		return System.currentTimeMillis()-start;
-	}
-	
-	public long insertDocuments(int count) throws Exception {
-		MongoConnector mdc = mongoConnectorResource.getConnector();
-		long start = System.currentTimeMillis();
-		for(int i=0; i<count; i++) {
-			MongoDocument d = new MongoDocument();
-			d.putContentField(getRandomString(5), getRandomString(20));
-			mdc.getDocumentWriter().insert(d);
-		}
-		return System.currentTimeMillis()-start;
+		tailReaderThread.interrupt();
 	}
 
-	
 	private String getRandomString(int length) {
 		char[] ca = new char[length];
 
@@ -510,51 +352,5 @@ public class MongoDocumentIOIT {
 		}
 
 		return new String(ca);
-	}
-	
-
-	public static class TailReader extends Thread {
-		private TailableIterator<MongoType> it;
-		public long lastRead = Long.MAX_VALUE;
-		public DatabaseDocument<MongoType> lastReadDoc = null;
-		boolean hasError = false;
-		
-		int countFailed = 0;
-		int countProcessed = 0;
-		int countDiscarded = 0;
-		
-		int count = 0;
-		
-		public TailReader(TailableIterator<MongoType> it) {
-			this.it = it;
-		}
-
-		public void run() {
-			try {
-				while (it.hasNext()) {
-					lastRead = System.currentTimeMillis();
-					lastReadDoc = it.next();
-					
-					Status s = lastReadDoc.getStatus();
-					
-					if(s==Status.DISCARDED) {
-						countDiscarded++;
-					} else if (s == Status.PROCESSED) {
-						countProcessed++;
-					} else if (s == Status.FAILED) {
-						countFailed++;
-					}
-					
-					count++;
-				}
-			} catch (Exception e) {
-				e.printStackTrace();
-				hasError = true;
-			}
-		}
-
-		public void interrupt() {
-			it.interrupt();
-		}
 	}
 }

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOIT.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOIT.java
@@ -258,7 +258,6 @@ public class MongoDocumentIOIT {
 		assertFalse(dw.getDocumentById(d2.getID()).fetchedBy("tag"));
 	}
 
-	@Ignore
 	@Test
 	public void testInsertLargeDocument() throws Exception {
 		MongoConnector mdc = mongoConnectorResource.getConnector();
@@ -274,13 +273,10 @@ public class MongoDocumentIOIT {
 	}
 	
 	@Test
-	@Ignore
 	public void testUpdateLargeDocument() throws Exception {
 		MongoConnector mdc = mongoConnectorResource.getConnector();
 		DocumentWriter<MongoType> dw = mdc.getDocumentWriter();
 		dw.prepare();
-		
-		
 		
 		MongoDocument d = new MongoDocument();
 		d.putContentField("some_field", "some data");
@@ -297,8 +293,10 @@ public class MongoDocumentIOIT {
 	private void makeDocumentTooLarge(MongoDocument d) {
 		MongoConnector mdc = mongoConnectorResource.getConnector();
 		int maxMongoDBObjectSize = mdc.getDB().getMongo().getConnector().getMaxBsonObjectSize();
-		while(d.toJson().getBytes().length <= maxMongoDBObjectSize) {
-			d.putContentField(getRandomString(5), getRandomString(1000000));
+		int fieldNameSize = 8;
+		int fieldSize = 1024*1024;
+		for (int i = 0 ; i <= maxMongoDBObjectSize / (fieldNameSize + fieldSize) ; i++) {
+			d.putContentField(getRandomString(fieldNameSize), getRandomString(fieldSize));
 		}
 	}
 

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoOldDocumentsIT.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoOldDocumentsIT.java
@@ -1,0 +1,120 @@
+package com.findwise.hydra.mongodb;
+
+import com.findwise.hydra.DatabaseDocument;
+import com.findwise.hydra.DocumentWriter;
+import com.findwise.hydra.TailableIterator;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class MongoOldDocumentsIT {
+
+	private final int discardedToKeep = 10;
+
+	@Rule
+	public MongoConnectorResource mongoConnectorResource = new MongoConnectorResource(getClass(),
+			new MongoConfigurationBuilder().setOldMaxCount(discardedToKeep).build());
+
+	@Test
+	public void testRollover() throws Exception {
+		MongoConnector mdc = mongoConnectorResource.getConnector();
+		DocumentWriter<MongoType> dw = mdc.getDocumentWriter();
+		dw.prepare();
+		assertTrue("NumberToKeep not correctly set", mdc.getStatusReader().getStatus().getNumberToKeep() == discardedToKeep);
+
+		final int additionalDocuments = 1;
+		for (int i = 0; i <= discardedToKeep + additionalDocuments; i++) {
+			dw.insert(new MongoDocument());
+			DatabaseDocument<MongoType> dd = dw.getAndTag(new MongoQuery(), "tag");
+			dw.markProcessed(dd, "tag");
+		}
+
+		if (mdc.getDocumentReader().getActiveDatabaseSize() != 0 ) {
+			fail("Still some active docs..");
+		}
+
+		if (mdc.getDocumentReader().getInactiveDatabaseSize() != discardedToKeep) {
+			fail("Incorrect number of old documents kept");
+		}
+
+		dw.insert(new MongoDocument());
+		DatabaseDocument<MongoType> dd = dw.getAndTag(new MongoQuery(), "tag");
+		dw.markProcessed(dd, "tag");
+
+		if (mdc.getDocumentReader().getActiveDatabaseSize() != 0) {
+			fail("Still some active docs..");
+		}
+		if (mdc.getDocumentReader().getInactiveDatabaseSize() != discardedToKeep) {
+			fail("Incorrect number of old documents kept: "+ mdc.getDocumentReader().getInactiveDatabaseSize());
+		}
+	}
+
+	@Test
+	public void testInactiveIterator() throws Exception {
+		MongoConnector mdc = mongoConnectorResource.getConnector();
+		DocumentWriter<MongoType> dw = mdc.getDocumentWriter();
+		dw.prepare();
+
+		TailableIterator<MongoType> it = mdc.getDocumentReader().getInactiveIterator();
+
+		TailReaderThread tr = new TailReaderThread(it);
+		tr.start();
+
+		MongoDocument first = new MongoDocument();
+		first.putContentField("num", 1);
+		dw.insert(first);
+		DatabaseDocument<MongoType> dd = dw.getAndTag(new MongoQuery(), "tag");
+		dw.markProcessed(dd, "tag");
+
+		while(tr.lastRead>System.currentTimeMillis() && tr.isAlive()) {
+			Thread.sleep(50);
+		}
+
+		if(!tr.isAlive()) {
+			fail("TailableReader died");
+		}
+
+		long lastRead = tr.lastRead;
+
+		if(!tr.lastReadDoc.getContentField("num").equals(1)) {
+			fail("Last doc read was not the correct document!");
+		}
+
+		MongoDocument second = new MongoDocument();
+		second.putContentField("num", 2);
+		dw.insert(second);
+		dd = dw.getAndTag(new MongoQuery(), "tag");
+		dw.markProcessed(dd, "tag");
+
+		while(tr.lastRead==lastRead) {
+			Thread.sleep(50);
+		}
+
+		if (!tr.lastReadDoc.getContentField("num").equals(2)) {
+			fail("Last doc read was not the correct document!");
+		}
+
+
+		if(tr.hasError) {
+			fail("An exception was thrown by the TailableIterator prior to interrupt");
+		}
+
+		tr.interrupt();
+
+		long interrupt = System.currentTimeMillis();
+
+		while (tr.isAlive() && (System.currentTimeMillis()-interrupt)<10000) {
+			Thread.sleep(50);
+		}
+
+		if(tr.isAlive()) {
+			fail("Unable to interrupt the tailableiterator");
+		}
+
+		if(tr.hasError) {
+			fail("An exception was thrown by the TailableIterator after interrupt");
+		}
+	}
+}

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/TailReaderThread.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/TailReaderThread.java
@@ -1,0 +1,50 @@
+package com.findwise.hydra.mongodb;
+
+import com.findwise.hydra.DatabaseDocument;
+import com.findwise.hydra.Document;
+import com.findwise.hydra.TailableIterator;
+
+public class TailReaderThread extends Thread {
+	private TailableIterator<MongoType> it;
+	public long lastRead = Long.MAX_VALUE;
+	public DatabaseDocument<MongoType> lastReadDoc = null;
+	boolean hasError = false;
+
+	int countFailed = 0;
+	int countProcessed = 0;
+	int countDiscarded = 0;
+
+	int count = 0;
+
+	public TailReaderThread(TailableIterator<MongoType> it) {
+		this.it = it;
+	}
+
+	public void run() {
+		try {
+			while (it.hasNext()) {
+				lastRead = System.currentTimeMillis();
+				lastReadDoc = it.next();
+
+				Document.Status s = lastReadDoc.getStatus();
+
+				if(s== Document.Status.DISCARDED) {
+					countDiscarded++;
+				} else if (s == Document.Status.PROCESSED) {
+					countProcessed++;
+				} else if (s == Document.Status.FAILED) {
+					countFailed++;
+				}
+
+				count++;
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+			hasError = true;
+		}
+	}
+
+	public void interrupt() {
+		it.interrupt();
+	}
+}

--- a/test-suite/functional-tests/.gitignore
+++ b/test-suite/functional-tests/.gitignore
@@ -1,0 +1,1 @@
+hydra-test-FullScaleIT


### PR DESCRIPTION
Separates the integration tests to allow different configurations for different tests, for example to make sure the connector in the `oldDocuments` tests actually uses that collections, and sets the correct limit.
Should probably speed up the tests marginally, as they no longer insert 2000 documents just to test that the collection is capped.

Removes the many calls to the status updater thread in `testRollover`, hopefully making it more stable.

Fixes two ignored tests for handling of documents large than MongoDB max size. They were ignored a long time ago, probably because they cause OOM errors due to serializing 16 MB JSON in memory. There should also be a speed up here, since the serialization of such large documents take up to several seconds.

Adds ignores for temporary pipeline directories created by the test-suite and when starting the Hydra Core jar from the root.
