### PR TITLE
Fixes "socket closed" bug and failing HTTPutils test

### DIFF
--- a/stages/processing/basic/pom.xml
+++ b/stages/processing/basic/pom.xml
@@ -29,6 +29,11 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.4</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.11</version>

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/AbstractHttpFetchingProcessStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/AbstractHttpFetchingProcessStage.java
@@ -1,24 +1,23 @@
 package com.findwise.hydra.stage;
 
+import com.findwise.hydra.local.LocalDocument;
+import com.findwise.utils.http.HttpFetchConfiguration;
+import com.findwise.utils.http.HttpFetchConfigurationBuilder;
+import com.findwise.utils.http.HttpFetcher;
+import com.findwise.utils.http.RequestProvider;
+import com.findwise.utils.http.UriProvider;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.CookieStore;
+import org.apache.http.client.HttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.http.HttpEntity;
-import org.apache.http.client.CookieStore;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.findwise.hydra.local.LocalDocument;
-import com.findwise.utils.http.HttpFetchConfiguration;
-import com.findwise.utils.http.HttpFetchConfigurationBuilder;
-import com.findwise.utils.http.HttpFetcher;
-import com.findwise.utils.http.UriProvider;
 
 /**
  * Generic HTTP fetching stage. Subclasses operate on one fetched URL at a time.
@@ -103,17 +102,17 @@ public abstract class AbstractHttpFetchingProcessStage extends AbstractProcessSt
     }
 
     public void setClient(HttpClient client) {
-        fetcher = new HttpFetcher(fetcher.getCookieStore(), client, fetcher.getRequest(),
+        fetcher = new HttpFetcher(fetcher.getCookieStore(), client, fetcher.getRequestProvider(),
                 fetcher.getConfiguration());
     }
 
     public void setCookieStore(CookieStore cookieStore) {
-        fetcher = new HttpFetcher(cookieStore, fetcher.getClient(), fetcher.getRequest(),
+        fetcher = new HttpFetcher(cookieStore, fetcher.getClient(), fetcher.getRequestProvider(),
                 fetcher.getConfiguration());
     }
 
-    public void setRequest(HttpGet request) {
-        fetcher = new HttpFetcher(fetcher.getCookieStore(), fetcher.getClient(), request,
+    public void setRequestProvider(RequestProvider requestProvider) {
+        fetcher = new HttpFetcher(fetcher.getCookieStore(), fetcher.getClient(), requestProvider,
                 fetcher.getConfiguration());
     }
 

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/AbstractHttpFetchingProcessStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/AbstractHttpFetchingProcessStage.java
@@ -35,161 +35,161 @@ import java.util.Map;
  * @author olof.nilsson@findwise.com
  */
 public abstract class AbstractHttpFetchingProcessStage extends AbstractProcessStage
-        implements UriProvider, RequestProvider {
-    private final Logger logger = LoggerFactory.getLogger(
-            AbstractHttpFetchingProcessStage.class);
+		implements UriProvider, RequestProvider {
+	private final Logger logger = LoggerFactory.getLogger(
+			AbstractHttpFetchingProcessStage.class);
 
-    /**
-     * Subclasses can decide what an identifier is
-     */
-    @Parameter(name = "identifierField",
-            description = "Field name where the identifier or list of identifiers " +
-                    "to use can be found. Defaults to 'url'")
-    protected String identifierField = "url";
+	/**
+	 * Subclasses can decide what an identifier is
+	 */
+	@Parameter(name = "identifierField",
+			description = "Field name where the identifier or list of identifiers " +
+					"to use can be found. Defaults to 'url'")
+	protected String identifierField = "url";
 
-    @Parameter(name = "basicAuthUsername", description = "Username for Basic Auth")
-    protected String basicAuthUsername = null;
+	@Parameter(name = "basicAuthUsername", description = "Username for Basic Auth")
+	protected String basicAuthUsername = null;
 
-    @Parameter(name = "basicAuthPassword", description = "Password for Basic Auth")
-    protected String basicAuthPassword = null;
+	@Parameter(name = "basicAuthPassword", description = "Password for Basic Auth")
+	protected String basicAuthPassword = null;
 
-    @Parameter(name = "basicAuthHost", description = "Host for Basic Auth")
-    protected String basicAuthHost = null;
+	@Parameter(name = "basicAuthHost", description = "Host for Basic Auth")
+	protected String basicAuthHost = null;
 
-    @Parameter(name = "basicAuthPort", description = "Port for Basic Auth")
-    protected int basicAuthPort = -1;
+	@Parameter(name = "basicAuthPort", description = "Port for Basic Auth")
+	protected int basicAuthPort = -1;
 
-    @Parameter(name = "sessionCookieUri",
-            description = "URI to retrieve session cookie from")
-    protected String sessionCookieUri = null;
+	@Parameter(name = "sessionCookieUri",
+			description = "URI to retrieve session cookie from")
+	protected String sessionCookieUri = null;
 
-    @Parameter(
-            description = "List of hostnames for which to accept invalid SSL certificates, default empty")
-    protected List<String> sslHostExceptions = new ArrayList<String>();
+	@Parameter(
+			description = "List of hostnames for which to accept invalid SSL certificates, default empty")
+	protected List<String> sslHostExceptions = new ArrayList<String>();
 
-    @Parameter(description = "Number of retries. May be to fallback URLs")
-    protected int retries = 1;
+	@Parameter(description = "Number of retries. May be to fallback URLs")
+	protected int retries = 1;
 
-    @Parameter(
-            description = "Identifiers to map directly to output, skipping fetch. Map from identifier to field.")
-    private Map<String, String> ignoredIdentifiers = new HashMap<String, String>();
+	@Parameter(
+			description = "Identifiers to map directly to output, skipping fetch. Map from identifier to field.")
+	private Map<String, String> ignoredIdentifiers = new HashMap<String, String>();
 
-    @Parameter(
-            description = "Expiration time for cached responses, in seconds. Any positive value enables caching. Default -1")
-    private long cacheExpiration = -1L;
+	@Parameter(
+			description = "Expiration time for cached responses, in seconds. Any positive value enables caching. Default -1")
+	private long cacheExpiration = -1L;
 
-    private HttpFetcher fetcher;
+	private HttpFetcher fetcher;
 
-    public AbstractHttpFetchingProcessStage() {
-        fetcher = new HttpFetcher(getSettings());
-    }
+	public AbstractHttpFetchingProcessStage() {
+		fetcher = new HttpFetcher(getSettings());
+	}
 
-    private HttpFetchConfiguration getSettings() {
-        HttpFetchConfigurationBuilder c = new HttpFetchConfigurationBuilder();
-        c.setBasicAuthHost(basicAuthHost);
-        c.setBasicAuthPassword(basicAuthPassword);
-        c.setBasicAuthPort(basicAuthPort);
-        c.setBasicAuthUsername(basicAuthUsername);
-        c.setCacheExpiration(cacheExpiration);
-        c.setRetries(retries);
-        c.setSessionCookieUri(sessionCookieUri);
-        c.setSslHostExceptions(sslHostExceptions);
-        return c.build();
-    }
+	private HttpFetchConfiguration getSettings() {
+		HttpFetchConfigurationBuilder c = new HttpFetchConfigurationBuilder();
+		c.setBasicAuthHost(basicAuthHost);
+		c.setBasicAuthPassword(basicAuthPassword);
+		c.setBasicAuthPort(basicAuthPort);
+		c.setBasicAuthUsername(basicAuthUsername);
+		c.setCacheExpiration(cacheExpiration);
+		c.setRetries(retries);
+		c.setSessionCookieUri(sessionCookieUri);
+		c.setSslHostExceptions(sslHostExceptions);
+		return c.build();
+	}
 
-    @Override
-    public void init() throws RequiredArgumentMissingException, InitFailedException {
-        super.init();
-        fetcher = new HttpFetcher(getSettings());
-    }
+	@Override
+	public void init() throws RequiredArgumentMissingException, InitFailedException {
+		super.init();
+		fetcher = new HttpFetcher(getSettings());
+	}
 
-    public void setFetcher(HttpFetcher fetcher) {
-        this.fetcher = fetcher;
-    }
+	public void setFetcher(HttpFetcher fetcher) {
+		this.fetcher = fetcher;
+	}
 
-    @SuppressWarnings("unchecked")
-    @Override
-    public void process(LocalDocument doc) throws ProcessException {
-        List<String> identifiers = new ArrayList<String>();
-        try {
-            identifiers.add(doc.getContentFieldAsString(identifierField));
-        } catch (IncorrectFieldTypeException e1) {
-            try {
-                identifiers.addAll(doc.getContentFieldAsStrings(identifierField));
-            } catch (IncorrectFieldTypeException e2) {
-                throw new ProcessException("Field '" + identifierField + "' was not a String or List", e2);
-            }
-        }
-        try {
-            fetcher.ensureCookie();
-            logger.debug("Processing identifiers '{}'", identifiers.toString());
-            for (String identifier : identifiers) {
-                if (!identifier.isEmpty()) {
-                    processIdentifier(identifier, doc);
-                }
-            }
-        } finally {
-            fetcher.clearCookie();
-        }
-    }
+	@SuppressWarnings("unchecked")
+	@Override
+	public void process(LocalDocument doc) throws ProcessException {
+		List<String> identifiers = new ArrayList<String>();
+		try {
+			identifiers.add(doc.getContentFieldAsString(identifierField));
+		} catch (IncorrectFieldTypeException e1) {
+			try {
+				identifiers.addAll(doc.getContentFieldAsStrings(identifierField));
+			} catch (IncorrectFieldTypeException e2) {
+				throw new ProcessException("Field '" + identifierField + "' was not a String or List", e2);
+			}
+		}
+		try {
+			fetcher.ensureCookie();
+			logger.debug("Processing identifiers '{}'", identifiers.toString());
+			for (String identifier : identifiers) {
+				if (!identifier.isEmpty()) {
+					processIdentifier(identifier, doc);
+				}
+			}
+		} finally {
+			fetcher.clearCookie();
+		}
+	}
 
-    private void processIdentifier(String identifier, LocalDocument doc)
-            throws ProcessException {
-        if (ignoredIdentifiers.containsKey(identifier)) {
-            String fieldName = ignoredIdentifiers.get(identifier);
-            logger.debug("Ignoring identifier '{}', copying it to '{}'", identifier,
-                    fieldName);
-            doc.appendToContentField(fieldName, identifier);
-            return;
-        }
-        HttpEntity entity = fetcher.fetch(identifier, getAcceptedContentHeader(),
-                this, this);
+	private void processIdentifier(String identifier, LocalDocument doc)
+			throws ProcessException {
+		if (ignoredIdentifiers.containsKey(identifier)) {
+			String fieldName = ignoredIdentifiers.get(identifier);
+			logger.debug("Ignoring identifier '{}', copying it to '{}'", identifier,
+					fieldName);
+			doc.appendToContentField(fieldName, identifier);
+			return;
+		}
+		HttpEntity entity = fetcher.fetch(identifier, getAcceptedContentHeader(),
+				this, this);
 
-        try {
-            processResponseEntity(entity, doc);
-        } finally {
-            EntityUtils.consumeQuietly(entity);
-        }
-    }
+		try {
+			processResponseEntity(entity, doc);
+		} finally {
+			EntityUtils.consumeQuietly(entity);
+		}
+	}
 
-    /**
-     * Converts an identifier found in the identifierField to a URL string for
-     * fetching
-     *
-     * @return converted identifiers
-     */
-    public abstract URI getUriFromIdentifier(String identifier, int attempts)
-            throws URISyntaxException;
+	/**
+	 * Converts an identifier found in the identifierField to a URL string for
+	 * fetching
+	 *
+	 * @return converted identifiers
+	 */
+	public abstract URI getUriFromIdentifier(String identifier, int attempts)
+			throws URISyntaxException;
 
-    /**
-     * Process the response and do work on the document
-     * When this method returns, the superclass will consume the response enitity.
-     *
-     * @param responseEntity
-     */
-    public abstract void processResponseEntity(HttpEntity responseEntity,
-            LocalDocument doc) throws ProcessException;
+	/**
+	 * Process the response and do work on the document
+	 * When this method returns, the superclass will consume the response enitity.
+	 *
+	 * @param responseEntity
+	 */
+	public abstract void processResponseEntity(HttpEntity responseEntity,
+	                                           LocalDocument doc) throws ProcessException;
 
-    /**
-     * Value of the HTTP header 'ACCEPT'. This will be set on all requests.
-     *
-     * @return accept header value
-     */
-    public abstract String getAcceptedContentHeader();
+	/**
+	 * Value of the HTTP header 'ACCEPT'. This will be set on all requests.
+	 *
+	 * @return accept header value
+	 */
+	public abstract String getAcceptedContentHeader();
 
-    /**
-     * Request object to use for requests. Should return a new object.
-     * This method can be used to set headers on all requests.
-     *
-     * @return request object to use
-     */
-    public abstract HttpRequestBase getRequest();
+	/**
+	 * Request object to use for requests. Should return a new object.
+	 * This method can be used to set headers on all requests.
+	 *
+	 * @return request object to use
+	 */
+	public abstract HttpRequestBase getRequest();
 
-    public Map<String, String> getIgnoredIdentifiers() {
-        return ignoredIdentifiers;
-    }
+	public Map<String, String> getIgnoredIdentifiers() {
+		return ignoredIdentifiers;
+	}
 
-    public void setIgnoredIdentifiers(Map<String, String> ignoredIdentifiers) {
-        this.ignoredIdentifiers = ignoredIdentifiers;
-    }
+	public void setIgnoredIdentifiers(Map<String, String> ignoredIdentifiers) {
+		this.ignoredIdentifiers = ignoredIdentifiers;
+	}
 }

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/AbstractHttpFetchingProcessStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/AbstractHttpFetchingProcessStage.java
@@ -80,10 +80,6 @@ public abstract class AbstractHttpFetchingProcessStage extends AbstractProcessSt
 
 	private HttpFetcher fetcher;
 
-	public AbstractHttpFetchingProcessStage() {
-		fetcher = new HttpFetcher(getSettings());
-	}
-
 	private HttpFetchConfiguration getSettings() {
 		HttpFetchConfigurationBuilder c = new HttpFetchConfigurationBuilder();
 		c.setBasicAuthHost(basicAuthHost);
@@ -100,7 +96,9 @@ public abstract class AbstractHttpFetchingProcessStage extends AbstractProcessSt
 	@Override
 	public void init() throws RequiredArgumentMissingException, InitFailedException {
 		super.init();
-		fetcher = new HttpFetcher(getSettings());
+		if(fetcher == null) {
+			fetcher = new HttpFetcher(getSettings());
+		}
 	}
 
 	public void setFetcher(HttpFetcher fetcher) {

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/AbstractHttpFetchingProcessStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/AbstractHttpFetchingProcessStage.java
@@ -11,6 +11,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,7 +145,11 @@ public abstract class AbstractHttpFetchingProcessStage extends AbstractProcessSt
         HttpEntity entity = fetcher.fetch(identifier, getAcceptedContentHeader(),
                 this, this);
 
-        processResponseEntity(entity, doc);
+        try {
+            processResponseEntity(entity, doc);
+        } finally {
+            EntityUtils.consumeQuietly(entity);
+        }
     }
 
     /**
@@ -158,6 +163,7 @@ public abstract class AbstractHttpFetchingProcessStage extends AbstractProcessSt
 
     /**
      * Process the response and do work on the document
+     * When this method returns, the superclass will consume the response enitity.
      *
      * @param responseEntity
      */

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/SimpleHttpFetchingStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/SimpleHttpFetchingStage.java
@@ -16,7 +16,7 @@ import java.nio.charset.UnsupportedCharsetException;
 /**
  * Simple implementation of a fetching stage.
  */
-@Stage( description = "Fetches content over HTTP, using a URL from a field in the document. Outputs content as-is to a specified output field.")
+@Stage(description = "Fetches content over HTTP, using a URL from a field in the document. Outputs content as-is to a specified output field.")
 public class SimpleHttpFetchingStage extends AbstractHttpFetchingProcessStage {
 
 	@Parameter(description = "Content-type headers to accept")
@@ -49,8 +49,8 @@ public class SimpleHttpFetchingStage extends AbstractHttpFetchingProcessStage {
 		return acceptedContent;
 	}
 
-    @Override
-    public HttpRequestBase getRequest() {
-        return new HttpGet();
-    }
+	@Override
+	public HttpRequestBase getRequest() {
+		return new HttpGet();
+	}
 }

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/SimpleHttpFetchingStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/SimpleHttpFetchingStage.java
@@ -44,6 +44,14 @@ public class SimpleHttpFetchingStage extends AbstractHttpFetchingProcessStage {
 		}
 	}
 
+	public void setOutputField(String outputField) {
+		this.outputField = outputField;
+	}
+
+	public void setAcceptedContent(String acceptedContent) {
+		this.acceptedContent = acceptedContent;
+	}
+
 	@Override
 	public String getAcceptedContentHeader() {
 		return acceptedContent;

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/SimpleHttpFetchingStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/SimpleHttpFetchingStage.java
@@ -1,0 +1,56 @@
+package com.findwise.hydra.stage;
+
+import com.findwise.hydra.local.LocalDocument;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.util.EntityUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
+
+@Stage
+public class SimpleHttpFetchingStage extends AbstractHttpFetchingProcessStage {
+
+	@Parameter(description = "Content-type headers to accept")
+	private String acceptedContent = "*/*";
+
+	@Parameter(required = true, description = "Destination field for fetched content")
+	private String outputField;
+
+	@Override
+	public URI getUriFromIdentifier(String identifier, int attempts) throws URISyntaxException {
+		return new URI(identifier);
+	}
+
+	@Override
+	public void processResponseEntity(HttpEntity responseEntity, LocalDocument doc) throws ProcessException {
+		try {
+			InputStream inputStream = responseEntity.getContent();
+			Charset encoding = Charset.forName(responseEntity.getContentEncoding().getValue());
+			String content = IOUtils.toString(inputStream, encoding);
+			doc.putContentField(outputField, content);
+		} catch (IOException e) {
+			throw new ProcessException("Failed to read HTTP entity body", e);
+		} catch (UnsupportedCharsetException e) {
+			throw new ProcessException("Response used unsupported encoding", e);
+		} finally {
+			EntityUtils.consumeQuietly(responseEntity);
+		}
+	}
+
+	@Override
+	public String getAcceptedContentHeader() {
+		return acceptedContent;
+	}
+
+    @Override
+    public HttpRequestBase getRequest() {
+        return new HttpGet();
+    }
+}

--- a/stages/processing/basic/src/main/java/com/findwise/hydra/stage/SimpleHttpFetchingStage.java
+++ b/stages/processing/basic/src/main/java/com/findwise/hydra/stage/SimpleHttpFetchingStage.java
@@ -5,7 +5,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,7 +13,10 @@ import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 
-@Stage
+/**
+ * Simple implementation of a fetching stage.
+ */
+@Stage( description = "Fetches content over HTTP, using a URL from a field in the document. Outputs content as-is to a specified output field.")
 public class SimpleHttpFetchingStage extends AbstractHttpFetchingProcessStage {
 
 	@Parameter(description = "Content-type headers to accept")
@@ -39,8 +41,6 @@ public class SimpleHttpFetchingStage extends AbstractHttpFetchingProcessStage {
 			throw new ProcessException("Failed to read HTTP entity body", e);
 		} catch (UnsupportedCharsetException e) {
 			throw new ProcessException("Response used unsupported encoding", e);
-		} finally {
-			EntityUtils.consumeQuietly(responseEntity);
 		}
 	}
 

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/AbstractHttpFetchingProcessStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/AbstractHttpFetchingProcessStageTest.java
@@ -1,21 +1,8 @@
 package com.findwise.hydra.stage;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import com.findwise.hydra.local.LocalDocument;
+import com.findwise.utils.http.RequestProvider;
+import junit.framework.Assert;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -33,9 +20,21 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
-import junit.framework.Assert;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import com.findwise.hydra.local.LocalDocument;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author olof.nilsson@findwise.com
@@ -49,6 +48,8 @@ public abstract class AbstractHttpFetchingProcessStageTest {
     protected LocalDocument doc;
     @Mock
     protected HttpClient client;
+    @Mock
+    protected RequestProvider requestProvider;
     @Mock
     protected HttpGet request;
     @Mock
@@ -83,7 +84,8 @@ public abstract class AbstractHttpFetchingProcessStageTest {
         when(client.execute(any(HttpUriRequest.class))).thenReturn(response);
         stage.setCookieStore(new BasicCookieStore());
         stage.setClient(client);
-        stage.setRequest(request);
+        when(requestProvider.getRequest()).thenReturn(request);
+        stage.setRequestProvider(requestProvider);
     }
 
     @Test

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/AbstractHttpFetchingProcessStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/AbstractHttpFetchingProcessStageTest.java
@@ -34,91 +34,91 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public abstract class AbstractHttpFetchingProcessStageTest {
 
-    protected AbstractHttpFetchingProcessStage stage;
-    @Mock
-    protected LocalDocument doc;
-    @Mock
-    protected HttpEntity entity;
-    @Mock
-    protected Header encodingHeader;
-    @Mock
-    protected HttpFetcher fetcher;
+	protected AbstractHttpFetchingProcessStage stage;
+	@Mock
+	protected LocalDocument doc;
+	@Mock
+	protected HttpEntity entity;
+	@Mock
+	protected Header encodingHeader;
+	@Mock
+	protected HttpFetcher fetcher;
 
-    abstract public void setUpStage() throws RequiredArgumentMissingException, IllegalAccessException;
+	abstract public void setUpStage() throws RequiredArgumentMissingException, IllegalAccessException;
 
-    abstract protected InputStream getContentStream();
+	abstract protected InputStream getContentStream();
 
-    abstract protected String getStreamEncoding();
+	abstract protected String getStreamEncoding();
 
-    abstract protected String createTestIdentifier(String identifier);
+	abstract protected String createTestIdentifier(String identifier);
 
-    @Before
-    public void setUp() throws IOException, RequiredArgumentMissingException, IllegalAccessException {
-        setUpStage();
-        when(encodingHeader.getValue()).thenReturn(getStreamEncoding());
-        when(entity.getContent()).thenAnswer(new ContentStreamAnswer(this));
-        when(entity.getContentEncoding()).thenReturn(encodingHeader);
-        when(fetcher.fetch(anyString(), anyString(), any(UriProvider.class), any(RequestProvider.class))).thenReturn(entity);
-        stage.setFetcher(fetcher);
-    }
+	@Before
+	public void setUp() throws IOException, RequiredArgumentMissingException, IllegalAccessException {
+		setUpStage();
+		when(encodingHeader.getValue()).thenReturn(getStreamEncoding());
+		when(entity.getContent()).thenAnswer(new ContentStreamAnswer(this));
+		when(entity.getContentEncoding()).thenReturn(encodingHeader);
+		when(fetcher.fetch(anyString(), anyString(), any(UriProvider.class), any(RequestProvider.class))).thenReturn(entity);
+		stage.setFetcher(fetcher);
+	}
 
-    @Test
-    public void testProcess_calls_fetch()
-            throws ProcessException, IOException,
-            URISyntaxException {
-        doc = new LocalDocument();
-        String testIdentifier = createTestIdentifier("someidentifier");
-        doc.putContentField("url", testIdentifier);
-        stage.process(doc);
-        verify(fetcher).fetch(testIdentifier, stage.getAcceptedContentHeader(), stage, stage);
-    }
+	@Test
+	public void testProcess_calls_fetch()
+			throws ProcessException, IOException,
+			URISyntaxException {
+		doc = new LocalDocument();
+		String testIdentifier = createTestIdentifier("someidentifier");
+		doc.putContentField("url", testIdentifier);
+		stage.process(doc);
+		verify(fetcher).fetch(testIdentifier, stage.getAcceptedContentHeader(), stage, stage);
+	}
 
-    @Test
-    public void testProcess_calls_client_with_request_for_url_list()
-            throws ProcessException, IOException,
-            URISyntaxException {
-        doc = new LocalDocument();
-        List<String> urls = Arrays.asList(
-                createTestIdentifier("someidentifier1"),
-                createTestIdentifier("someidentifier2"),
-                createTestIdentifier("someidentifier3"));
-        doc.putContentField("url", urls);
-        stage.process(doc);
-        for (String testIdentifier : urls) {
-            verify(fetcher).fetch(testIdentifier, stage.getAcceptedContentHeader(), stage, stage);
-        }
-    }
+	@Test
+	public void testProcess_calls_client_with_request_for_url_list()
+			throws ProcessException, IOException,
+			URISyntaxException {
+		doc = new LocalDocument();
+		List<String> urls = Arrays.asList(
+				createTestIdentifier("someidentifier1"),
+				createTestIdentifier("someidentifier2"),
+				createTestIdentifier("someidentifier3"));
+		doc.putContentField("url", urls);
+		stage.process(doc);
+		for (String testIdentifier : urls) {
+			verify(fetcher).fetch(testIdentifier, stage.getAcceptedContentHeader(), stage, stage);
+		}
+	}
 
-    @Test
-    public void testProcess_adds_ignored_identifier_to_mapped_field() throws
-            ProcessException,
-            IOException,
-            URISyntaxException {
-        doc = new LocalDocument();
-        List<String> urls = Arrays.asList(
-                createTestIdentifier("someidentifier1"),
-                createTestIdentifier("someidentifier2"));
-        doc.putContentField("url", urls);
-        doc.putContentField("some_output_field", "not an identifier");
-        Map<String, String> ignored = new HashMap<String, String>();
-        ignored.put("someidentifier1", "some_output_field");
-        stage.setIgnoredIdentifiers(ignored);
-        stage.process(doc);
-        assertEquals(Arrays.asList("not an identifier", "someidentifier1"),
-                doc.getContentField("some_output_field"));
-    }
+	@Test
+	public void testProcess_adds_ignored_identifier_to_mapped_field() throws
+			ProcessException,
+			IOException,
+			URISyntaxException {
+		doc = new LocalDocument();
+		List<String> urls = Arrays.asList(
+				createTestIdentifier("someidentifier1"),
+				createTestIdentifier("someidentifier2"));
+		doc.putContentField("url", urls);
+		doc.putContentField("some_output_field", "not an identifier");
+		Map<String, String> ignored = new HashMap<String, String>();
+		ignored.put("someidentifier1", "some_output_field");
+		stage.setIgnoredIdentifiers(ignored);
+		stage.process(doc);
+		assertEquals(Arrays.asList("not an identifier", "someidentifier1"),
+				doc.getContentField("some_output_field"));
+	}
 
-    protected class ContentStreamAnswer implements Answer<InputStream> {
+	protected class ContentStreamAnswer implements Answer<InputStream> {
 
-        AbstractHttpFetchingProcessStageTest test;
+		AbstractHttpFetchingProcessStageTest test;
 
-        public ContentStreamAnswer(AbstractHttpFetchingProcessStageTest test) {
-            this.test = test;
-        }
+		public ContentStreamAnswer(AbstractHttpFetchingProcessStageTest test) {
+			this.test = test;
+		}
 
-        @Override
-        public InputStream answer(InvocationOnMock invocation) throws Throwable {
-            return test.getContentStream();
-        }
-    }
+		@Override
+		public InputStream answer(InvocationOnMock invocation) throws Throwable {
+			return test.getContentStream();
+		}
+	}
 }

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/SimpleHttpFetchingStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/SimpleHttpFetchingStageTest.java
@@ -3,8 +3,10 @@ package com.findwise.hydra.stage;
 import com.findwise.hydra.local.IncorrectFieldTypeException;
 import com.findwise.hydra.local.LocalDocument;
 import org.apache.commons.io.IOUtils;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.*;
+
 import org.junit.Test;
 
 import java.io.InputStream;
@@ -13,34 +15,34 @@ import java.util.Map;
 
 public class SimpleHttpFetchingStageTest extends AbstractHttpFetchingProcessStageTest {
 
-    @Override
-    public void setUpStage() throws RequiredArgumentMissingException, IllegalAccessException {
-        stage = new SimpleHttpFetchingStage();
-        Map<String, Object> parameters = new HashMap<String, Object>();
-        parameters.put("outputField", "out");
-        stage.setParameters(parameters);
-    }
+	@Override
+	public void setUpStage() throws RequiredArgumentMissingException, IllegalAccessException {
+		stage = new SimpleHttpFetchingStage();
+		Map<String, Object> parameters = new HashMap<String, Object>();
+		parameters.put("outputField", "out");
+		stage.setParameters(parameters);
+	}
 
-    @Override
-    protected InputStream getContentStream() {
-        return IOUtils.toInputStream("content string");
-    }
+	@Override
+	protected InputStream getContentStream() {
+		return IOUtils.toInputStream("content string");
+	}
 
-    @Override
-    protected String getStreamEncoding() {
-        return "UTF-8";
-    }
+	@Override
+	protected String getStreamEncoding() {
+		return "UTF-8";
+	}
 
-    @Override
-    protected String createTestIdentifier(String identifier) {
-        return identifier;
-    }
+	@Override
+	protected String createTestIdentifier(String identifier) {
+		return identifier;
+	}
 
-    @Test
-    public void testAddsContentToOutput() throws ProcessException, IncorrectFieldTypeException {
-        LocalDocument doc = new LocalDocument();
-        doc.putContentField("url", "testurl");
-        stage.process(doc);
-        assertThat(doc.getContentFieldAsString("out"), equalTo("content string"));
-    }
+	@Test
+	public void testAddsContentToOutput() throws ProcessException, IncorrectFieldTypeException {
+		LocalDocument doc = new LocalDocument();
+		doc.putContentField("url", "testurl");
+		stage.process(doc);
+		assertThat(doc.getContentFieldAsString("out"), equalTo("content string"));
+	}
 }

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/SimpleHttpFetchingStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/SimpleHttpFetchingStageTest.java
@@ -1,0 +1,46 @@
+package com.findwise.hydra.stage;
+
+import com.findwise.hydra.local.IncorrectFieldTypeException;
+import com.findwise.hydra.local.LocalDocument;
+import org.apache.commons.io.IOUtils;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SimpleHttpFetchingStageTest extends AbstractHttpFetchingProcessStageTest {
+
+    @Override
+    public void setUpStage() throws RequiredArgumentMissingException, IllegalAccessException {
+        stage = new SimpleHttpFetchingStage();
+        Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("outputField", "out");
+        stage.setParameters(parameters);
+    }
+
+    @Override
+    protected InputStream getContentStream() {
+        return IOUtils.toInputStream("content string");
+    }
+
+    @Override
+    protected String getStreamEncoding() {
+        return "UTF-8";
+    }
+
+    @Override
+    protected String createTestIdentifier(String identifier) {
+        return identifier;
+    }
+
+    @Test
+    public void testAddsContentToOutput() throws ProcessException, IncorrectFieldTypeException {
+        LocalDocument doc = new LocalDocument();
+        doc.putContentField("url", "testurl");
+        stage.process(doc);
+        assertThat(doc.getContentFieldAsString("out"), equalTo("content string"));
+    }
+}

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/SimpleHttpFetchingStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/SimpleHttpFetchingStageTest.java
@@ -17,10 +17,9 @@ public class SimpleHttpFetchingStageTest extends AbstractHttpFetchingProcessStag
 
 	@Override
 	public void setUpStage() throws RequiredArgumentMissingException, IllegalAccessException {
-		stage = new SimpleHttpFetchingStage();
-		Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("outputField", "out");
-		stage.setParameters(parameters);
+		SimpleHttpFetchingStage simpleHttpFetchingStage = new SimpleHttpFetchingStage();
+		simpleHttpFetchingStage.setOutputField("out");
+		stage = simpleHttpFetchingStage;
 	}
 
 	@Override

--- a/stages/utils/http/pom.xml
+++ b/stages/utils/http/pom.xml
@@ -25,11 +25,6 @@
 			<version>4.2.1</version>
 		</dependency>
 		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>1.7.1</version>
-		</dependency>
-		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>1.7.5</version>

--- a/stages/utils/http/src/main/java/com/findwise/utils/http/HttpFetchConfiguration.java
+++ b/stages/utils/http/src/main/java/com/findwise/utils/http/HttpFetchConfiguration.java
@@ -3,78 +3,78 @@ package com.findwise.utils.http;
 import java.util.List;
 
 public class HttpFetchConfiguration {
-    // Username for Basic Auth
-    private final String basicAuthUsername;
-    // Password for Basic Auth
-    private final String basicAuthPassword;
-    // Host for Basic Auth
-    private final String basicAuthHost;
-    // Port for Basic Auth
-    private final int basicAuthPort;
-    // URI to retrieve session cookie from
-    private final String sessionCookieUri;
-    // List of hostnames for which to accept invalid SSL certificates, default empty
-    private final List<String> sslHostExceptions;
-    // Number of retries. May be to fallback URLs
-    private final int retries;
-    // Expiration time for cached responses, in seconds. Any positive value enables caching. Default -1
-    private final long cacheExpiration;
+	// Username for Basic Auth
+	private final String basicAuthUsername;
+	// Password for Basic Auth
+	private final String basicAuthPassword;
+	// Host for Basic Auth
+	private final String basicAuthHost;
+	// Port for Basic Auth
+	private final int basicAuthPort;
+	// URI to retrieve session cookie from
+	private final String sessionCookieUri;
+	// List of hostnames for which to accept invalid SSL certificates, default empty
+	private final List<String> sslHostExceptions;
+	// Number of retries. May be to fallback URLs
+	private final int retries;
+	// Expiration time for cached responses, in seconds. Any positive value enables caching. Default -1
+	private final long cacheExpiration;
 
-    public HttpFetchConfiguration(String basicAuthUsername,
-            String basicAuthPassword,
-            String basicAuthHost,
-            int basicAuthPort,
-            String sessionCookieUri,
-            List<String> sslHostExceptions,
-            int retries,
-            long cacheExpiration) {
-        this.basicAuthUsername = basicAuthUsername;
-        this.basicAuthPassword = basicAuthPassword;
-        this.basicAuthHost = basicAuthHost;
-        this.basicAuthPort = basicAuthPort;
-        this.sessionCookieUri = sessionCookieUri;
-        this.sslHostExceptions = sslHostExceptions;
-        this.retries = retries;
-        this.cacheExpiration = cacheExpiration;
-    }
+	public HttpFetchConfiguration(String basicAuthUsername,
+	                              String basicAuthPassword,
+	                              String basicAuthHost,
+	                              int basicAuthPort,
+	                              String sessionCookieUri,
+	                              List<String> sslHostExceptions,
+	                              int retries,
+	                              long cacheExpiration) {
+		this.basicAuthUsername = basicAuthUsername;
+		this.basicAuthPassword = basicAuthPassword;
+		this.basicAuthHost = basicAuthHost;
+		this.basicAuthPort = basicAuthPort;
+		this.sessionCookieUri = sessionCookieUri;
+		this.sslHostExceptions = sslHostExceptions;
+		this.retries = retries;
+		this.cacheExpiration = cacheExpiration;
+	}
 
-    public boolean hasCookieUri() {
-        return getSessionCookieUri() != null;
-    }
+	public boolean hasCookieUri() {
+		return getSessionCookieUri() != null;
+	}
 
-    public boolean shouldUseBasicAuth() {
-        return getBasicAuthUsername() != null && getBasicAuthPassword() != null;
-    }
+	public boolean shouldUseBasicAuth() {
+		return getBasicAuthUsername() != null && getBasicAuthPassword() != null;
+	}
 
-    public String getBasicAuthUsername() {
-        return basicAuthUsername;
-    }
+	public String getBasicAuthUsername() {
+		return basicAuthUsername;
+	}
 
-    public String getBasicAuthPassword() {
-        return basicAuthPassword;
-    }
+	public String getBasicAuthPassword() {
+		return basicAuthPassword;
+	}
 
-    public String getBasicAuthHost() {
-        return basicAuthHost;
-    }
+	public String getBasicAuthHost() {
+		return basicAuthHost;
+	}
 
-    public int getBasicAuthPort() {
-        return basicAuthPort;
-    }
+	public int getBasicAuthPort() {
+		return basicAuthPort;
+	}
 
-    public String getSessionCookieUri() {
-        return sessionCookieUri;
-    }
+	public String getSessionCookieUri() {
+		return sessionCookieUri;
+	}
 
-    public List<String> getSslHostExceptions() {
-        return sslHostExceptions;
-    }
+	public List<String> getSslHostExceptions() {
+		return sslHostExceptions;
+	}
 
-    public int getRetries() {
-        return retries;
-    }
+	public int getRetries() {
+		return retries;
+	}
 
-    public long getCacheExpiration() {
-        return cacheExpiration;
-    }
+	public long getCacheExpiration() {
+		return cacheExpiration;
+	}
 }

--- a/stages/utils/http/src/main/java/com/findwise/utils/http/HttpFetcher.java
+++ b/stages/utils/http/src/main/java/com/findwise/utils/http/HttpFetcher.java
@@ -61,27 +61,25 @@ import java.util.List;
  */
 public class HttpFetcher {
     private static final PlainUriProvider PLAIN_URI_PROVIDER = new PlainUriProvider();
+    private static final RequestProvider PLAIN_GET_REQUEST_PROVIDER = new PlainGetRequestProvider();
     private final Logger logger = LoggerFactory.getLogger(HttpFetcher.class);
     private final HttpFetchConfiguration settings;
 
     private final CookieStore cookieStore;
     private final HttpClient client;
 
-    private final RequestProvider requestProvider;
 
     public HttpFetcher(CookieStore cookieStore,
-            HttpClient client, RequestProvider requestProvider, HttpFetchConfiguration settings) {
+            HttpClient client, HttpFetchConfiguration settings) {
         this.cookieStore = cookieStore;
         this.client = client;
         this.settings = settings;
-        this.requestProvider = requestProvider;
     }
 
     public HttpFetcher(HttpFetchConfiguration settings) {
         this.settings = settings;
         this.cookieStore = new BasicCookieStore();
         this.client = newDefaultClient();
-        this.requestProvider = newDefaultRequestProvider();
     }
 
     public void ensureCookie() throws FailedFetchingCookieException {
@@ -97,12 +95,12 @@ public class HttpFetcher {
     }
 
     public HttpEntity fetch(String url, String acceptHeader) throws HttpFetchException {
-        return fetch(url, acceptHeader, PLAIN_URI_PROVIDER);
+        return fetch(url, acceptHeader, PLAIN_URI_PROVIDER, PLAIN_GET_REQUEST_PROVIDER);
     }
 
     public HttpEntity fetch(String identifier,
             String acceptHeader,
-            UriProvider uriProvider) throws HttpFetchException {
+            UriProvider uriProvider, RequestProvider requestProvider) throws HttpFetchException {
         try {
             int attempts = 0;
             while (true) {
@@ -230,10 +228,6 @@ public class HttpFetcher {
 
     public HttpClient getClient() {
         return client;
-    }
-
-    public RequestProvider getRequestProvider() {
-        return requestProvider;
     }
 
     public HttpFetchConfiguration getConfiguration() {

--- a/stages/utils/http/src/main/java/com/findwise/utils/http/HttpFetcher.java
+++ b/stages/utils/http/src/main/java/com/findwise/utils/http/HttpFetcher.java
@@ -108,10 +108,11 @@ public class HttpFetcher {
         try {
             int attempts = 0;
             while (true) {
+                request.reset();
                 request.setURI(uriProvider.getUriFromIdentifier(identifier, attempts));
                 request.addHeader(HttpHeaders.ACCEPT, acceptHeader);
                 logger.debug("Performing request, uriProvider:'{}', headers:'{}'",
-                        request.getURI(), request.getMethod(), request.getAllHeaders());
+                request.getURI(), request.getMethod(), request.getAllHeaders());
                 HttpResponse response = client.execute(request);
                 if (logger.isDebugEnabled()) {
                     List<String> headers = new ArrayList<String>();
@@ -131,12 +132,10 @@ public class HttpFetcher {
                             "Recreating request for identifier '{}' due to response '{}'",
                             identifier, status.getStatusCode());
                     --attempts;
-                    request.reset();
                     request = newDefaultRequest();
                 } else if (attempts <= settings.getRetries()) {
                     logger.debug("Retrying identifier '{}' due to response '{}'",
                             identifier, status.getStatusCode());
-                    request.reset();
                     continue;
                 } else {
                     throw new HttpResponseException(status.getStatusCode(),
@@ -156,8 +155,6 @@ public class HttpFetcher {
             throw new HttpFetchException(
                     "Could not construct URI from identifier '" + identifier
                             + "'", e);
-        } finally {
-            request.reset();
         }
     }
 

--- a/stages/utils/http/src/main/java/com/findwise/utils/http/HttpFetcher.java
+++ b/stages/utils/http/src/main/java/com/findwise/utils/http/HttpFetcher.java
@@ -118,14 +118,15 @@ public class HttpFetcher {
 					logger.debug("Received response, status:'{}', headers:'{}'",
 							response.getStatusLine().getStatusCode(), headers);
 				}
-				attempts++;
 				StatusLine status = response.getStatusLine();
 				if (HttpStatus.SC_OK == status.getStatusCode()) {
 					return response.getEntity();
-				} else if (attempts <= settings.getRetries()) {
+				} else if (attempts < settings.getRetries()) {
 					logger.debug("Retrying identifier '{}' due to response '{}'",
 							identifier, status.getStatusCode());
 					EntityUtils.consumeQuietly(response.getEntity());
+					attempts++;
+					continue;
 				} else {
 					throw new HttpResponseException(status.getStatusCode(),
 							status.getReasonPhrase());

--- a/stages/utils/http/src/main/java/com/findwise/utils/http/HttpFetcher.java
+++ b/stages/utils/http/src/main/java/com/findwise/utils/http/HttpFetcher.java
@@ -40,11 +40,11 @@ import java.util.List;
 
 /**
  * Generic HTTP fetching utility.
- * 
+ *
  * <p>
  * This class takes care of opening and closing connections.
  * </p>
- * 
+ *
  * Supports:
  * <ul>
  * <li>Basic Auth</li>
@@ -52,185 +52,185 @@ import java.util.List;
  * <li>SSL, with optional exceptions for trusted hosts</li>
  * <li>Fetching of session cookies</li>
  * </ul>
- * 
+ *
  * Users of this class is responsible for releasing resources allocated by
  * returned objects of type {@link HttpEntity}.
- * 
+ *
  * @author olof.nilsson@findwise.com
  * @author martin.nycander@findwise.com
  */
 public class HttpFetcher {
-    private static final PlainUriProvider PLAIN_URI_PROVIDER = new PlainUriProvider();
-    private static final RequestProvider PLAIN_GET_REQUEST_PROVIDER = new PlainGetRequestProvider();
-    private final Logger logger = LoggerFactory.getLogger(HttpFetcher.class);
-    private final HttpFetchConfiguration settings;
+	private static final PlainUriProvider PLAIN_URI_PROVIDER = new PlainUriProvider();
+	private static final RequestProvider PLAIN_GET_REQUEST_PROVIDER = new PlainGetRequestProvider();
+	private final Logger logger = LoggerFactory.getLogger(HttpFetcher.class);
+	private final HttpFetchConfiguration settings;
 
-    private final CookieStore cookieStore;
-    private final HttpClient client;
+	private final CookieStore cookieStore;
+	private final HttpClient client;
 
 
-    public HttpFetcher(CookieStore cookieStore,
-            HttpClient client, HttpFetchConfiguration settings) {
-        this.cookieStore = cookieStore;
-        this.client = client;
-        this.settings = settings;
-    }
+	public HttpFetcher(CookieStore cookieStore,
+	                   HttpClient client, HttpFetchConfiguration settings) {
+		this.cookieStore = cookieStore;
+		this.client = client;
+		this.settings = settings;
+	}
 
-    public HttpFetcher(HttpFetchConfiguration settings) {
-        this.settings = settings;
-        this.cookieStore = new BasicCookieStore();
-        this.client = newDefaultClient();
-    }
+	public HttpFetcher(HttpFetchConfiguration settings) {
+		this.settings = settings;
+		this.cookieStore = new BasicCookieStore();
+		this.client = newDefaultClient();
+	}
 
-    public void ensureCookie() throws FailedFetchingCookieException {
-        if (settings.hasCookieUri()) {
-            updateSessionCookie();
-        }
-    }
+	public void ensureCookie() throws FailedFetchingCookieException {
+		if (settings.hasCookieUri()) {
+			updateSessionCookie();
+		}
+	}
 
-    public void clearCookie() {
-        if (settings.hasCookieUri()) {
-            cookieStore.clear();
-        }
-    }
+	public void clearCookie() {
+		if (settings.hasCookieUri()) {
+			cookieStore.clear();
+		}
+	}
 
-    public HttpEntity fetch(String url, String acceptHeader) throws HttpFetchException {
-        return fetch(url, acceptHeader, PLAIN_URI_PROVIDER, PLAIN_GET_REQUEST_PROVIDER);
-    }
+	public HttpEntity fetch(String url, String acceptHeader) throws HttpFetchException {
+		return fetch(url, acceptHeader, PLAIN_URI_PROVIDER, PLAIN_GET_REQUEST_PROVIDER);
+	}
 
-    public HttpEntity fetch(String identifier,
-            String acceptHeader,
-            UriProvider uriProvider, RequestProvider requestProvider) throws HttpFetchException {
-        try {
-            int attempts = 0;
-            while (true) {
-                HttpRequestBase request = requestProvider.getRequest();
-                request.setURI(uriProvider.getUriFromIdentifier(identifier, attempts));
-                request.addHeader(HttpHeaders.ACCEPT, acceptHeader);
-                logger.debug("Performing request, uriProvider:'{}', headers:'{}'",
-                request.getURI(), request.getMethod(), request.getAllHeaders());
-                HttpResponse response = client.execute(request);
-                if (logger.isDebugEnabled()) {
-                    List<String> headers = new ArrayList<String>();
-                    for (Header header : response.getAllHeaders()) {
-                        headers.add(header.getName() + "=" + header.getValue());
-                    }
-                    logger.debug("Received response, status:'{}', headers:'{}'",
-                            response.getStatusLine().getStatusCode(), headers);
-                }
-                attempts++;
-                StatusLine status = response.getStatusLine();
-                if (HttpStatus.SC_OK == status.getStatusCode()) {
-                    return response.getEntity();
-                } else if (attempts <= settings.getRetries()) {
-                    logger.debug("Retrying identifier '{}' due to response '{}'",
-                            identifier, status.getStatusCode());
-                    EntityUtils.consumeQuietly(response.getEntity());
-                } else {
-                    throw new HttpResponseException(status.getStatusCode(),
-                            status.getReasonPhrase());
-                }
-            }
-        } catch (HttpResponseException e) {
-            throw new HttpFetchException("Could not process identifier '"
-                    + identifier + "', got response '" + e.getStatusCode() + "'", e);
-        } catch (ClientProtocolException e) {
-            throw new HttpFetchException("Could not process identifier '"
-                    + identifier + "', HTTPClient reported error", e);
-        } catch (IOException e) {
-            throw new HttpFetchException("Could not process identifier '"
-                    + identifier + "'", e);
-        } catch (URISyntaxException e) {
-            throw new HttpFetchException(
-                    "Could not construct URI from identifier '" + identifier
-                            + "'", e);
-        }
-    }
+	public HttpEntity fetch(String identifier,
+	                        String acceptHeader,
+	                        UriProvider uriProvider, RequestProvider requestProvider) throws HttpFetchException {
+		try {
+			int attempts = 0;
+			while (true) {
+				HttpRequestBase request = requestProvider.getRequest();
+				request.setURI(uriProvider.getUriFromIdentifier(identifier, attempts));
+				request.addHeader(HttpHeaders.ACCEPT, acceptHeader);
+				logger.debug("Performing request, uriProvider:'{}', headers:'{}'",
+						request.getURI(), request.getMethod(), request.getAllHeaders());
+				HttpResponse response = client.execute(request);
+				if (logger.isDebugEnabled()) {
+					List<String> headers = new ArrayList<String>();
+					for (Header header : response.getAllHeaders()) {
+						headers.add(header.getName() + "=" + header.getValue());
+					}
+					logger.debug("Received response, status:'{}', headers:'{}'",
+							response.getStatusLine().getStatusCode(), headers);
+				}
+				attempts++;
+				StatusLine status = response.getStatusLine();
+				if (HttpStatus.SC_OK == status.getStatusCode()) {
+					return response.getEntity();
+				} else if (attempts <= settings.getRetries()) {
+					logger.debug("Retrying identifier '{}' due to response '{}'",
+							identifier, status.getStatusCode());
+					EntityUtils.consumeQuietly(response.getEntity());
+				} else {
+					throw new HttpResponseException(status.getStatusCode(),
+							status.getReasonPhrase());
+				}
+			}
+		} catch (HttpResponseException e) {
+			throw new HttpFetchException("Could not process identifier '"
+					+ identifier + "', got response '" + e.getStatusCode() + "'", e);
+		} catch (ClientProtocolException e) {
+			throw new HttpFetchException("Could not process identifier '"
+					+ identifier + "', HTTPClient reported error", e);
+		} catch (IOException e) {
+			throw new HttpFetchException("Could not process identifier '"
+					+ identifier + "'", e);
+		} catch (URISyntaxException e) {
+			throw new HttpFetchException(
+					"Could not construct URI from identifier '" + identifier
+							+ "'", e);
+		}
+	}
 
-    private HttpClient newDefaultClient() {
-        try {
-            // Set up SSL exceptions
-            SchemeRegistry registry = new SchemeRegistry();
-            SSLSocketFactory defaultSocketFactory = SSLSocketFactory.getSocketFactory();
-            SSLContext context = SSLContext.getDefault();
-            X509HostnameVerifier hostnameVerifier = new SelectiveHostnameVerifier(
-                    defaultSocketFactory.getHostnameVerifier(),
-                    settings.getSslHostExceptions());
-            SSLSocketFactory socketFactory = new SSLSocketFactory(context,
-                    hostnameVerifier);
-            registry.register(new Scheme("https", 443, socketFactory));
-            registry.register(
-                    new Scheme("http", 80, PlainSocketFactory.getSocketFactory()));
-            BasicClientConnectionManager mgr = new BasicClientConnectionManager(registry);
-            DefaultHttpClient defaultClient = new DefaultHttpClient(mgr);
-            // Set up Basic Auth
-            if (settings.shouldUseBasicAuth()) {
-                defaultClient.getCredentialsProvider()
-                        .setCredentials(new AuthScope(
-                                settings.getBasicAuthHost(),
-                                settings.getBasicAuthPort()),
-                                new UsernamePasswordCredentials(
-                                        settings.getBasicAuthUsername(),
-                                        settings.getBasicAuthPassword()));
-            }
-            // Set up cookies
-            defaultClient.setCookieStore(cookieStore);
-            // Set up caching
-            if (settings.getCacheExpiration() >= 0L) {
-                CacheConfig cacheConfig = new CacheConfig();
-                cacheConfig.setMaxCacheEntries(1000);
-                cacheConfig.setHeuristicCachingEnabled(true);
-                cacheConfig.setHeuristicDefaultLifetime(
-                        settings.getCacheExpiration());
-                cacheConfig.setHeuristicCoefficient(0.9f);
-                CachingHttpClient cachingClient = new CachingHttpClient(
-                        defaultClient, cacheConfig);
-                return cachingClient;
-            } else {
-                return defaultClient;
-            }
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("Could not create HTTP client", e);
-        }
-    }
+	private HttpClient newDefaultClient() {
+		try {
+			// Set up SSL exceptions
+			SchemeRegistry registry = new SchemeRegistry();
+			SSLSocketFactory defaultSocketFactory = SSLSocketFactory.getSocketFactory();
+			SSLContext context = SSLContext.getDefault();
+			X509HostnameVerifier hostnameVerifier = new SelectiveHostnameVerifier(
+					defaultSocketFactory.getHostnameVerifier(),
+					settings.getSslHostExceptions());
+			SSLSocketFactory socketFactory = new SSLSocketFactory(context,
+					hostnameVerifier);
+			registry.register(new Scheme("https", 443, socketFactory));
+			registry.register(
+					new Scheme("http", 80, PlainSocketFactory.getSocketFactory()));
+			BasicClientConnectionManager mgr = new BasicClientConnectionManager(registry);
+			DefaultHttpClient defaultClient = new DefaultHttpClient(mgr);
+			// Set up Basic Auth
+			if (settings.shouldUseBasicAuth()) {
+				defaultClient.getCredentialsProvider()
+						.setCredentials(new AuthScope(
+								settings.getBasicAuthHost(),
+								settings.getBasicAuthPort()),
+								new UsernamePasswordCredentials(
+										settings.getBasicAuthUsername(),
+										settings.getBasicAuthPassword()));
+			}
+			// Set up cookies
+			defaultClient.setCookieStore(cookieStore);
+			// Set up caching
+			if (settings.getCacheExpiration() >= 0L) {
+				CacheConfig cacheConfig = new CacheConfig();
+				cacheConfig.setMaxCacheEntries(1000);
+				cacheConfig.setHeuristicCachingEnabled(true);
+				cacheConfig.setHeuristicDefaultLifetime(
+						settings.getCacheExpiration());
+				cacheConfig.setHeuristicCoefficient(0.9f);
+				CachingHttpClient cachingClient = new CachingHttpClient(
+						defaultClient, cacheConfig);
+				return cachingClient;
+			} else {
+				return defaultClient;
+			}
+		} catch (NoSuchAlgorithmException e) {
+			throw new RuntimeException("Could not create HTTP client", e);
+		}
+	}
 
-    private void updateSessionCookie() throws FailedFetchingCookieException {
-        if (cookieStore.getCookies().isEmpty()) {
-            try {
-                // Fetch session cookie
-                logger.debug("Fetching session cookie from '{}'",
-                        settings.getSessionCookieUri());
-                HttpContext cookieContext = new BasicHttpContext();
-                cookieContext.setAttribute(ClientContext.COOKIE_STORE, cookieStore);
-                HttpHead cookieRequest = new HttpHead(
-                        settings.getSessionCookieUri());
-                client.execute(cookieRequest, cookieContext);
-                cookieRequest.reset();
-            } catch (ClientProtocolException e) {
-                throw new FailedFetchingCookieException(
-                        "Failed to fetch cookie at URI '" +
-                                settings.getSessionCookieUri() + "'", e);
-            } catch (IOException e) {
-                throw new FailedFetchingCookieException(
-                        "Failed to fetch cookie at URI '" +
-                                settings.getSessionCookieUri() + "'", e);
-            }
-        }
-    }
+	private void updateSessionCookie() throws FailedFetchingCookieException {
+		if (cookieStore.getCookies().isEmpty()) {
+			try {
+				// Fetch session cookie
+				logger.debug("Fetching session cookie from '{}'",
+						settings.getSessionCookieUri());
+				HttpContext cookieContext = new BasicHttpContext();
+				cookieContext.setAttribute(ClientContext.COOKIE_STORE, cookieStore);
+				HttpHead cookieRequest = new HttpHead(
+						settings.getSessionCookieUri());
+				client.execute(cookieRequest, cookieContext);
+				cookieRequest.reset();
+			} catch (ClientProtocolException e) {
+				throw new FailedFetchingCookieException(
+						"Failed to fetch cookie at URI '" +
+								settings.getSessionCookieUri() + "'", e);
+			} catch (IOException e) {
+				throw new FailedFetchingCookieException(
+						"Failed to fetch cookie at URI '" +
+								settings.getSessionCookieUri() + "'", e);
+			}
+		}
+	}
 
-    private RequestProvider newDefaultRequestProvider() {
-        return new PlainGetRequestProvider();
-    }
+	private RequestProvider newDefaultRequestProvider() {
+		return new PlainGetRequestProvider();
+	}
 
-    public CookieStore getCookieStore() {
-        return cookieStore;
-    }
+	public CookieStore getCookieStore() {
+		return cookieStore;
+	}
 
-    public HttpClient getClient() {
-        return client;
-    }
+	public HttpClient getClient() {
+		return client;
+	}
 
-    public HttpFetchConfiguration getConfiguration() {
-        return settings;
-    }
+	public HttpFetchConfiguration getConfiguration() {
+		return settings;
+	}
 }

--- a/stages/utils/http/src/main/java/com/findwise/utils/http/PlainGetRequestProvider.java
+++ b/stages/utils/http/src/main/java/com/findwise/utils/http/PlainGetRequestProvider.java
@@ -1,0 +1,11 @@
+package com.findwise.utils.http;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.client.methods.HttpGet;
+
+public class PlainGetRequestProvider implements RequestProvider {
+	@Override
+	public HttpGet getRequest() {
+		return new HttpGet();
+	}
+}

--- a/stages/utils/http/src/main/java/com/findwise/utils/http/PlainUriProvider.java
+++ b/stages/utils/http/src/main/java/com/findwise/utils/http/PlainUriProvider.java
@@ -8,9 +8,9 @@ import java.net.URISyntaxException;
  * of attempts.
  */
 public class PlainUriProvider implements UriProvider {
-    @Override
-    public URI getUriFromIdentifier(String identifier, int attempts) throws
-            URISyntaxException {
-        return new URI(identifier);
-    }
+	@Override
+	public URI getUriFromIdentifier(String identifier, int attempts) throws
+			URISyntaxException {
+		return new URI(identifier);
+	}
 }

--- a/stages/utils/http/src/main/java/com/findwise/utils/http/RequestProvider.java
+++ b/stages/utils/http/src/main/java/com/findwise/utils/http/RequestProvider.java
@@ -1,0 +1,8 @@
+package com.findwise.utils.http;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.client.methods.HttpRequestBase;
+
+public interface RequestProvider {
+	HttpRequestBase getRequest();
+}

--- a/stages/utils/http/src/test/java/com/findwise/utils/http/HttpFetcherTest.java
+++ b/stages/utils/http/src/test/java/com/findwise/utils/http/HttpFetcherTest.java
@@ -27,79 +27,79 @@ import static org.mockito.Mockito.when;
 
 public class HttpFetcherTest {
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(37777);
+	@Rule
+	public WireMockRule wireMockRule = new WireMockRule(37777);
 
-    @Test
-    public void testBodyShouldBeFetched() throws Exception {
-        HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().build();
-        HttpFetcher httpFetcher = new HttpFetcher(settings);
-        stubFor(get(urlEqualTo("/")).willReturn(aResponse().withBody("body")));
-        HttpEntity responseEntity = httpFetcher.fetch("http://localhost:37777", "*/*");
-        String bodyContent = readStream(responseEntity.getContent());
-        EntityUtils.consume(responseEntity);
-        assertEquals("body", bodyContent);
-    }
+	@Test
+	public void testBodyShouldBeFetched() throws Exception {
+		HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().build();
+		HttpFetcher httpFetcher = new HttpFetcher(settings);
+		stubFor(get(urlEqualTo("/")).willReturn(aResponse().withBody("body")));
+		HttpEntity responseEntity = httpFetcher.fetch("http://localhost:37777", "*/*");
+		String bodyContent = readStream(responseEntity.getContent());
+		EntityUtils.consume(responseEntity);
+		assertEquals("body", bodyContent);
+	}
 
-    @Test
-    public void testRetriesRequests() throws IOException {
-        final int retries = 3;
-        HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().setRetries(retries).build();
-        HttpFetcher httpFetcher = new HttpFetcher(settings);
-        stubFor(get(urlEqualTo("/1")).willReturn(aResponse().withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)));
-        stubFor(get(urlEqualTo("/2")).willReturn(aResponse().withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)));
-        stubFor(get(urlEqualTo("/3")).willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("body")));
-        HttpEntity responseEntity = httpFetcher.fetch("http://localhost:37777", "*/*", new IncrementingUriProvider(), new PlainGetRequestProvider());
-        String bodyContent = readStream(responseEntity.getContent());
-        EntityUtils.consume(responseEntity);
-        assertThat(bodyContent, equalTo("body"));
-    }
+	@Test
+	public void testRetriesRequests() throws IOException {
+		final int retries = 3;
+		HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().setRetries(retries).build();
+		HttpFetcher httpFetcher = new HttpFetcher(settings);
+		stubFor(get(urlEqualTo("/1")).willReturn(aResponse().withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)));
+		stubFor(get(urlEqualTo("/2")).willReturn(aResponse().withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)));
+		stubFor(get(urlEqualTo("/3")).willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("body")));
+		HttpEntity responseEntity = httpFetcher.fetch("http://localhost:37777", "*/*", new IncrementingUriProvider(), new PlainGetRequestProvider());
+		String bodyContent = readStream(responseEntity.getContent());
+		EntityUtils.consume(responseEntity);
+		assertThat(bodyContent, equalTo("body"));
+	}
 
-    @Test
-    public void testRetriesRequests_for_bad_request() throws IOException {
-        final int retries = 2;
-        HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().setRetries(retries).build();
-        HttpFetcher httpFetcher = new HttpFetcher(settings);
-        stubFor(get(urlEqualTo("/1")).willReturn(aResponse().withStatus(HttpStatus.SC_BAD_REQUEST)));
-        stubFor(get(urlEqualTo("/2")).willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("body")));
-        HttpEntity responseEntity = httpFetcher.fetch("http://localhost:37777", "*/*", new IncrementingUriProvider(), new PlainGetRequestProvider());
-        String bodyContent = readStream(responseEntity.getContent());
-        EntityUtils.consume(responseEntity);
-        assertThat(bodyContent, equalTo("body"));
-    }
+	@Test
+	public void testRetriesRequests_for_bad_request() throws IOException {
+		final int retries = 2;
+		HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().setRetries(retries).build();
+		HttpFetcher httpFetcher = new HttpFetcher(settings);
+		stubFor(get(urlEqualTo("/1")).willReturn(aResponse().withStatus(HttpStatus.SC_BAD_REQUEST)));
+		stubFor(get(urlEqualTo("/2")).willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("body")));
+		HttpEntity responseEntity = httpFetcher.fetch("http://localhost:37777", "*/*", new IncrementingUriProvider(), new PlainGetRequestProvider());
+		String bodyContent = readStream(responseEntity.getContent());
+		EntityUtils.consume(responseEntity);
+		assertThat(bodyContent, equalTo("body"));
+	}
 
-    @Test
-    public void testUsesProviders() throws IOException {
-        RequestProvider requestProvider = mock(RequestProvider.class);
-        when(requestProvider.getRequest()).thenReturn(new HttpGet());
-        HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().build();
-        HttpFetcher httpFetcher = new HttpFetcher(settings);
-        stubFor(get(urlEqualTo("/1")).willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("body")));
-        HttpEntity responseEntity = httpFetcher.fetch("1", "*/*", new AppendingUriProvider(), requestProvider);
-        String bodyContent = readStream(responseEntity.getContent());
-        EntityUtils.consume(responseEntity);
-        assertThat(bodyContent, equalTo("body"));
-        verify(requestProvider).getRequest();
-    }
+	@Test
+	public void testUsesProviders() throws IOException {
+		RequestProvider requestProvider = mock(RequestProvider.class);
+		when(requestProvider.getRequest()).thenReturn(new HttpGet());
+		HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().build();
+		HttpFetcher httpFetcher = new HttpFetcher(settings);
+		stubFor(get(urlEqualTo("/1")).willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("body")));
+		HttpEntity responseEntity = httpFetcher.fetch("1", "*/*", new AppendingUriProvider(), requestProvider);
+		String bodyContent = readStream(responseEntity.getContent());
+		EntityUtils.consume(responseEntity);
+		assertThat(bodyContent, equalTo("body"));
+		verify(requestProvider).getRequest();
+	}
 
-    private String readStream(InputStream contentStream) {
-        Scanner scanner = new Scanner(contentStream);
-        String content = scanner.useDelimiter("\\A").next();
-        scanner.close();
-        return content;
-    }
+	private String readStream(InputStream contentStream) {
+		Scanner scanner = new Scanner(contentStream);
+		String content = scanner.useDelimiter("\\A").next();
+		scanner.close();
+		return content;
+	}
 
-    private static class IncrementingUriProvider implements UriProvider {
-        @Override
-        public URI getUriFromIdentifier(String identifier, int attempts) throws URISyntaxException {
-            return new URI(identifier + "/" + attempts);
-        }
-    }
+	private static class IncrementingUriProvider implements UriProvider {
+		@Override
+		public URI getUriFromIdentifier(String identifier, int attempts) throws URISyntaxException {
+			return new URI(identifier + "/" + attempts);
+		}
+	}
 
-    private static class AppendingUriProvider implements UriProvider {
-        @Override
-        public URI getUriFromIdentifier(String identifier, int attempts) throws URISyntaxException {
-            return new URI("http://localhost:37777/" + identifier);
-        }
-    }
+	private static class AppendingUriProvider implements UriProvider {
+		@Override
+		public URI getUriFromIdentifier(String identifier, int attempts) throws URISyntaxException {
+			return new URI("http://localhost:37777/" + identifier);
+		}
+	}
 }

--- a/stages/utils/http/src/test/java/com/findwise/utils/http/HttpFetcherTest.java
+++ b/stages/utils/http/src/test/java/com/findwise/utils/http/HttpFetcherTest.java
@@ -3,6 +3,7 @@ package com.findwise.utils.http;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,61 +21,85 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class HttpFetcherTest {
 
-	@Rule
-	public WireMockRule wireMockRule = new WireMockRule(37777);
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(37777);
 
-	@Test
-	public void testBodyShouldBeFetched() throws Exception {
-		HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().build();
-		HttpFetcher httpFetcher = new HttpFetcher(settings);
-		stubFor(get(urlEqualTo("/")).willReturn(aResponse().withBody("body")));
-		HttpEntity responseEntity = httpFetcher.fetch("http://localhost:37777", "*/*");
-		String bodyContent = readStream(responseEntity.getContent());
-		EntityUtils.consume(responseEntity);
-		assertEquals("body", bodyContent);
-	}
+    @Test
+    public void testBodyShouldBeFetched() throws Exception {
+        HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().build();
+        HttpFetcher httpFetcher = new HttpFetcher(settings);
+        stubFor(get(urlEqualTo("/")).willReturn(aResponse().withBody("body")));
+        HttpEntity responseEntity = httpFetcher.fetch("http://localhost:37777", "*/*");
+        String bodyContent = readStream(responseEntity.getContent());
+        EntityUtils.consume(responseEntity);
+        assertEquals("body", bodyContent);
+    }
 
-	@Test
-	public void testRetriesRequests() throws IOException {
-		final int retries = 3;
-		HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().setRetries(retries).build();
-		HttpFetcher httpFetcher = new HttpFetcher(settings);
-		stubFor(get(urlEqualTo("/1")).willReturn(aResponse().withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)));
-		stubFor(get(urlEqualTo("/2")).willReturn(aResponse().withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)));
-		stubFor(get(urlEqualTo("/3")).willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("body")));
-		HttpEntity responseEntity = httpFetcher.fetch("http://localhost:37777", "*/*", new IncrementingUriProvider());
-		String bodyContent = readStream(responseEntity.getContent());
-		EntityUtils.consume(responseEntity);
-		assertThat(bodyContent, equalTo("body"));
-	}
+    @Test
+    public void testRetriesRequests() throws IOException {
+        final int retries = 3;
+        HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().setRetries(retries).build();
+        HttpFetcher httpFetcher = new HttpFetcher(settings);
+        stubFor(get(urlEqualTo("/1")).willReturn(aResponse().withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)));
+        stubFor(get(urlEqualTo("/2")).willReturn(aResponse().withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)));
+        stubFor(get(urlEqualTo("/3")).willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("body")));
+        HttpEntity responseEntity = httpFetcher.fetch("http://localhost:37777", "*/*", new IncrementingUriProvider(), new PlainGetRequestProvider());
+        String bodyContent = readStream(responseEntity.getContent());
+        EntityUtils.consume(responseEntity);
+        assertThat(bodyContent, equalTo("body"));
+    }
 
-	@Test
-	public void testRetriesRequests_for_bad_request() throws IOException {
-		final int retries = 2;
-		HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().setRetries(retries).build();
-		HttpFetcher httpFetcher = new HttpFetcher(settings);
-		stubFor(get(urlEqualTo("/1")).willReturn(aResponse().withStatus(HttpStatus.SC_BAD_REQUEST)));
-		stubFor(get(urlEqualTo("/2")).willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("body")));
-		HttpEntity responseEntity = httpFetcher.fetch("http://localhost:37777", "*/*", new IncrementingUriProvider());
-		String bodyContent = readStream(responseEntity.getContent());
-		EntityUtils.consume(responseEntity);
-		assertThat(bodyContent, equalTo("body"));
-	}
+    @Test
+    public void testRetriesRequests_for_bad_request() throws IOException {
+        final int retries = 2;
+        HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().setRetries(retries).build();
+        HttpFetcher httpFetcher = new HttpFetcher(settings);
+        stubFor(get(urlEqualTo("/1")).willReturn(aResponse().withStatus(HttpStatus.SC_BAD_REQUEST)));
+        stubFor(get(urlEqualTo("/2")).willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("body")));
+        HttpEntity responseEntity = httpFetcher.fetch("http://localhost:37777", "*/*", new IncrementingUriProvider(), new PlainGetRequestProvider());
+        String bodyContent = readStream(responseEntity.getContent());
+        EntityUtils.consume(responseEntity);
+        assertThat(bodyContent, equalTo("body"));
+    }
 
-	private String readStream(InputStream contentStream) {
-		Scanner scanner = new Scanner(contentStream);
-		String content = scanner.useDelimiter("\\A").next();
-		scanner.close();
-		return content;
-	}
+    @Test
+    public void testUsesProviders() throws IOException {
+        RequestProvider requestProvider = mock(RequestProvider.class);
+        when(requestProvider.getRequest()).thenReturn(new HttpGet());
+        HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().build();
+        HttpFetcher httpFetcher = new HttpFetcher(settings);
+        stubFor(get(urlEqualTo("/1")).willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("body")));
+        HttpEntity responseEntity = httpFetcher.fetch("1", "*/*", new AppendingUriProvider(), requestProvider);
+        String bodyContent = readStream(responseEntity.getContent());
+        EntityUtils.consume(responseEntity);
+        assertThat(bodyContent, equalTo("body"));
+        verify(requestProvider).getRequest();
+    }
 
-	private static class IncrementingUriProvider implements UriProvider {
-		@Override
-		public URI getUriFromIdentifier(String identifier, int attempts) throws URISyntaxException {
-			return new URI(identifier + "/" + attempts);
-		}
-	}
+    private String readStream(InputStream contentStream) {
+        Scanner scanner = new Scanner(contentStream);
+        String content = scanner.useDelimiter("\\A").next();
+        scanner.close();
+        return content;
+    }
+
+    private static class IncrementingUriProvider implements UriProvider {
+        @Override
+        public URI getUriFromIdentifier(String identifier, int attempts) throws URISyntaxException {
+            return new URI(identifier + "/" + attempts);
+        }
+    }
+
+    private static class AppendingUriProvider implements UriProvider {
+        @Override
+        public URI getUriFromIdentifier(String identifier, int attempts) throws URISyntaxException {
+            return new URI("http://localhost:37777/" + identifier);
+        }
+    }
 }

--- a/stages/utils/http/src/test/java/com/findwise/utils/http/HttpFetcherTest.java
+++ b/stages/utils/http/src/test/java/com/findwise/utils/http/HttpFetcherTest.java
@@ -1,20 +1,25 @@
 package com.findwise.utils.http;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.junit.Assert.assertEquals;
-
-import java.io.InputStream;
-import java.util.Scanner;
-
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
 import org.apache.http.util.EntityUtils;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Scanner;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class HttpFetcherTest {
 
@@ -27,12 +32,49 @@ public class HttpFetcherTest {
 		HttpFetcher httpFetcher = new HttpFetcher(settings);
 		stubFor(get(urlEqualTo("/")).willReturn(aResponse().withBody("body")));
 		HttpEntity responseEntity = httpFetcher.fetch("http://localhost:37777", "*/*");
-		InputStream contentStream = responseEntity.getContent();
-		Scanner scanner = new Scanner(contentStream);
-		String bodyContent = scanner.useDelimiter("\\A").next();
-		scanner.close();
+		String bodyContent = readStream(responseEntity.getContent());
 		EntityUtils.consume(responseEntity);
 		assertEquals("body", bodyContent);
 	}
 
+	@Test
+	public void testRetriesRequests() throws IOException {
+		final int retries = 3;
+		HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().setRetries(retries).build();
+		HttpFetcher httpFetcher = new HttpFetcher(settings);
+		stubFor(get(urlEqualTo("/1")).willReturn(aResponse().withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)));
+		stubFor(get(urlEqualTo("/2")).willReturn(aResponse().withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)));
+		stubFor(get(urlEqualTo("/3")).willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("body")));
+		HttpEntity responseEntity = httpFetcher.fetch("http://localhost:37777", "*/*", new IncrementingUriProvider());
+		String bodyContent = readStream(responseEntity.getContent());
+		EntityUtils.consume(responseEntity);
+		assertThat(bodyContent, equalTo("body"));
+	}
+
+	@Test
+	public void testRetriesRequests_for_bad_request() throws IOException {
+		final int retries = 2;
+		HttpFetchConfiguration settings = new HttpFetchConfigurationBuilder().setRetries(retries).build();
+		HttpFetcher httpFetcher = new HttpFetcher(settings);
+		stubFor(get(urlEqualTo("/1")).willReturn(aResponse().withStatus(HttpStatus.SC_BAD_REQUEST)));
+		stubFor(get(urlEqualTo("/2")).willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("body")));
+		HttpEntity responseEntity = httpFetcher.fetch("http://localhost:37777", "*/*", new IncrementingUriProvider());
+		String bodyContent = readStream(responseEntity.getContent());
+		EntityUtils.consume(responseEntity);
+		assertThat(bodyContent, equalTo("body"));
+	}
+
+	private String readStream(InputStream contentStream) {
+		Scanner scanner = new Scanner(contentStream);
+		String content = scanner.useDelimiter("\\A").next();
+		scanner.close();
+		return content;
+	}
+
+	private static class IncrementingUriProvider implements UriProvider {
+		@Override
+		public URI getUriFromIdentifier(String identifier, int attempts) throws URISyntaxException {
+			return new URI(identifier + "/" + attempts);
+		}
+	}
 }


### PR DESCRIPTION
A request entity was returned by `httputils.fetch()`, then a finally block reset the request. This caused unpredictable behaviour with "Socket Closed" thrown by anything that read the entity body.

This also fixes the test failing on some platforms and machines (such as mine, and the Findwise Jenkins build server).

Fixes #302 
