### PR TITLE
Ensures functional tests clean up their database use

### DIFF
--- a/test-suite/functional-tests/src/test/java/com/findwise/hydra/FullScaleIT.java
+++ b/test-suite/functional-tests/src/test/java/com/findwise/hydra/FullScaleIT.java
@@ -75,6 +75,7 @@ public class FullScaleIT {
 	@After
 	public void tearDown() throws Exception {
 		core.shutdown();
+		mongoConnector.getDB().dropDatabase();
 	}
 
 	// A reasonable setting for this timeout is unfortunately very dependent on the


### PR DESCRIPTION
I noticed the functional tests were leaving behind a database in MongoDB. This should make sure they don't.
