### PR TITLE
Fixes deprecation, Maven, javadoc and unchecked warnings

### DIFF
--- a/api/src/main/java/com/findwise/hydra/SerializationUtils.java
+++ b/api/src/main/java/com/findwise/hydra/SerializationUtils.java
@@ -128,8 +128,8 @@ public final class SerializationUtils {
 	
 	/**
 	 * Serializes any object to Json. 
-	 * @param o
-	 * @return
+	 * @param o object to serialize
+	 * @return json
 	 */
 	public static String toJson(Object o) {
 		while(true) {

--- a/api/src/main/java/com/findwise/hydra/local/LocalDocument.java
+++ b/api/src/main/java/com/findwise/hydra/local/LocalDocument.java
@@ -509,7 +509,7 @@ public class LocalDocument implements Document<Local> {
 	 * Must be nullsafe, for all parameters and other operations. 
 	 * @param contentFields
 	 * @param metadataFields
-	 * @return
+	 * @return json map with id, contents, metadata and action
 	 */
 	private String fieldsToJson(Iterable<String> contentFields, Iterable<String> metadataFields) {
 		HashMap<String, Object> map = new HashMap<String, Object>();

--- a/api/src/main/java/com/findwise/hydra/stage/AbstractProcessStageMapper.java
+++ b/api/src/main/java/com/findwise/hydra/stage/AbstractProcessStageMapper.java
@@ -23,6 +23,7 @@ public class AbstractProcessStageMapper {
 		return fromMap(properties);
 	}
 
+    @SuppressWarnings("unchecked")
 	private static AbstractProcessStage fromMap(Map<String, Object> properties) throws RequiredArgumentMissingException, ClassNotFoundException, IllegalAccessException, InstantiationException, InitFailedException {
 		String stageClass;
 		if (properties.containsKey(ARG_NAME_STAGE_CLASS)) {
@@ -43,7 +44,7 @@ public class AbstractProcessStageMapper {
 	/**
 	 * Injects the parameters found in the map to any fields annotated with @Stage, whose names matches
 	 * the keys in this map.
-	 * @param map
+	 * @param map stage parameter map
 	 * @throws IllegalArgumentException
 	 * @throws IllegalAccessException
 	 */

--- a/api/src/main/java/com/findwise/tools/Comparator.java
+++ b/api/src/main/java/com/findwise/tools/Comparator.java
@@ -152,7 +152,7 @@ public final class Comparator {
 	 * @param c
 	 * @param o
 	 * @param o2
-	 * @return
+	 * @return true if o and o2 have the getters of c and their values are equal
 	 */
 	@SuppressWarnings("rawtypes")
 	public static boolean getterEqual(Class c, Object o, Object o2) {

--- a/core/src/test/java/com/findwise/hydra/local/RemotePipelineIT.java
+++ b/core/src/test/java/com/findwise/hydra/local/RemotePipelineIT.java
@@ -18,7 +18,6 @@ import com.findwise.hydra.net.HttpRESTHandler;
 import com.findwise.hydra.net.RESTServer;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
-import junit.framework.Assert;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -27,6 +26,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class RemotePipelineIT {
@@ -403,13 +404,13 @@ public class RemotePipelineIT {
 		RemotePipeline rp = new RemotePipeline("localhost", server.getPort(), "stage");
 		
 		LocalDocument ld = rp.getDocument(new LocalQuery());
-		Assert.assertTrue(ld.hasContentField("field"));
+		assertTrue(ld.hasContentField("field"));
 		ld.removeContentField("field");
 		
 		rp.save(ld);
 		
 		rp = new RemotePipeline("localhost", server.getPort(), "stage2");
 		ld = rp.getDocument(new LocalQuery());
-		Assert.assertFalse(ld.hasContentField("field"));
+		assertFalse(ld.hasContentField("field"));
 	}
 }

--- a/core/src/test/java/com/findwise/hydra/net/PropertiesHandlerTest.java
+++ b/core/src/test/java/com/findwise/hydra/net/PropertiesHandlerTest.java
@@ -2,10 +2,10 @@ package com.findwise.hydra.net;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.util.List;
-
-import junit.framework.Assert;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -47,9 +47,9 @@ public class PropertiesHandlerTest {
 		
 		List<String> stages = GroupStarter.getStages("localhost", server.getPort(), "1");
 
-		Assert.assertTrue(stages.contains("stage"));
-		Assert.assertTrue(stages.contains("stage2"));
-		Assert.assertFalse(stages.contains("notingroup"));
+		assertTrue(stages.contains("stage"));
+		assertTrue(stages.contains("stage2"));
+		assertFalse(stages.contains("notingroup"));
 
 		StageGroup g2 = new StageGroup("2");
 		g2.addStage(new Stage("debug", Mockito.mock(DatabaseFile.class)));
@@ -59,8 +59,8 @@ public class PropertiesHandlerTest {
 		Mockito.when(reader.getDebugPipeline()).thenReturn(p2);
 		stages = GroupStarter.getStages("localhost", server.getPort(), "2");
 
-		Assert.assertTrue(stages.contains("debug"));
-		Assert.assertFalse(stages.contains("stage"));
+		assertTrue(stages.contains("debug"));
+		assertFalse(stages.contains("stage"));
 	}
 
 }

--- a/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryTailableIterator.java
+++ b/database-impl/inmemory/src/main/java/com/findwise/hydra/memorydb/MemoryTailableIterator.java
@@ -21,7 +21,6 @@ public class MemoryTailableIterator implements TailableIterator<MemoryType> {
 	private boolean closed = false;
 	
 	/**
-	 * @param dbc
 	 * @throws BackingStoreException if there is a problem in getting an iterator
 	 */
 	public MemoryTailableIterator(BlockingQueue<MemoryDocument> queue, boolean[] modified) {
@@ -29,7 +28,6 @@ public class MemoryTailableIterator implements TailableIterator<MemoryType> {
 	}
 	
 	/**
-	 * @param dbc
 	 * @throws BackingStoreException if there is a problem in getting an iterator
 	 */
 	public MemoryTailableIterator(BlockingQueue<MemoryDocument> queue, boolean[] modified, MemoryQuery query) {

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOMongoLessTest.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOMongoLessTest.java
@@ -3,7 +3,9 @@ package com.findwise.hydra.mongodb;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
-import junit.framework.Assert;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.bson.types.ObjectId;
 import org.junit.Before;
@@ -77,8 +79,8 @@ public class MongoDocumentIOMongoLessTest {
 
 		boolean processed = documentIO.markProcessed(document, "Test stage");
 
-		Assert.assertFalse("Processing should not be fine", processed);
-		Assert.assertTrue("The document should have logged errors", document.hasErrors());
+		assertFalse("Processing should not be fine", processed);
+		assertTrue("The document should have logged errors", document.hasErrors());
 	}
 
 	@Test
@@ -103,10 +105,10 @@ public class MongoDocumentIOMongoLessTest {
 
 		boolean processed = documentIO.markProcessed(document, "Test stage");
 
-		Assert.assertTrue("Processing should return successfully.", processed);
-		Assert.assertTrue("The field 'body' should be removed.",
+		assertTrue("Processing should return successfully.", processed);
+		assertTrue("The field 'body' should be removed.",
 				document.getContentField(contentField).equals("<Removed>"));
-		Assert.assertTrue("The document should have logged errors", document.hasErrors());
+		assertTrue("The document should have logged errors", document.hasErrors());
 	}
 
 	@Test
@@ -135,9 +137,9 @@ public class MongoDocumentIOMongoLessTest {
 		boolean processed = documentIO.markProcessed(document, "Test stage");
 
 		// One field should have been removed now, and it should be the longest one.
-		Assert.assertEquals(shortValue, document.getContentField("short"));
-		Assert.assertEquals("<Removed>", document.getContentField("long"));
-		Assert.assertTrue("Processing should return successfully.", processed);
+		assertEquals(shortValue, document.getContentField("short"));
+		assertEquals("<Removed>", document.getContentField("long"));
+		assertTrue("Processing should return successfully.", processed);
 	}
 
 }

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentTest.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentTest.java
@@ -1,10 +1,10 @@
 package com.findwise.hydra.mongodb;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Date;
 

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoPipelineIOIT.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoPipelineIOIT.java
@@ -1,6 +1,7 @@
 package com.findwise.hydra.mongodb;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
@@ -8,8 +9,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
-
-import junit.framework.Assert;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -108,25 +107,25 @@ public class MongoPipelineIOIT {
 		p.addGroup(multiGroup);
 		p.addGroup(singleGroup);
 		
-		Assert.assertEquals(2, p.getStageGroups().size());
-		Assert.assertTrue(p.hasGroup("multi"));
-		Assert.assertTrue(p.hasGroup("singleStage"));
+		assertEquals(2, p.getStageGroups().size());
+		assertTrue(p.hasGroup("multi"));
+		assertTrue(p.hasGroup("singleStage"));
 		
 		mongoConnectorResource.reset();
 		mdc = mongoConnectorResource.getConnector();
 		MongoPipelineReader reader = new MongoPipelineReader(mdc.getDB());
 		MongoPipelineWriter writer = new MongoPipelineWriter(reader, WriteConcern.SAFE);
 		
-		Assert.assertEquals(0, reader.getPipeline().getStages().size());
+		assertEquals(0, reader.getPipeline().getStages().size());
 		writer.write(p);
 		
-		Assert.assertEquals(3, reader.getPipeline().getStages().size());
+		assertEquals(3, reader.getPipeline().getStages().size());
 
-		Assert.assertTrue(reader.getPipeline().hasGroup("multi"));
-		Assert.assertTrue(reader.getPipeline().hasGroup("singleStage"));
+		assertTrue(reader.getPipeline().hasGroup("multi"));
+		assertTrue(reader.getPipeline().hasGroup("singleStage"));
 
-		Assert.assertEquals(2, reader.getPipeline().getGroup("multi").getSize());
-		Assert.assertEquals(1, reader.getPipeline().getGroup("singleStage").getSize());
+		assertEquals(2, reader.getPipeline().getGroup("multi").getSize());
+		assertEquals(1, reader.getPipeline().getGroup("singleStage").getSize());
 	}
 	
 	@Test
@@ -158,9 +157,9 @@ public class MongoPipelineIOIT {
 		writer.write(p);
 		
 		StageGroup g2 = reader.getPipeline().getGroup("multi");
-		Assert.assertEquals(multiGroup.getJvmParameters(), g2.getJvmParameters());
-		Assert.assertEquals(multiGroup.getRetries(), g2.getRetries());
-		Assert.assertEquals(multiGroup.isLogging(), g2.isLogging());
-		Assert.assertEquals(multiGroup.getCmdlineArgs(), g2.getCmdlineArgs());
+		assertEquals(multiGroup.getJvmParameters(), g2.getJvmParameters());
+		assertEquals(multiGroup.getRetries(), g2.getRetries());
+		assertEquals(multiGroup.isLogging(), g2.isLogging());
+		assertEquals(multiGroup.getCmdlineArgs(), g2.getCmdlineArgs());
 	}
 }

--- a/database/src/main/java/com/findwise/hydra/Cache.java
+++ b/database/src/main/java/com/findwise/hydra/Cache.java
@@ -6,7 +6,7 @@ import java.util.Collection;
  * Interface specifying the operations that must be supported for a
  * DatabaseDocument cache.
  * 
- * Bear in mind when using, that a cache that does absolutely nothing {@see
+ * Bear in mind when using, that a cache that does absolutely nothing {@link
  * NoopCache} is a valid implementation. As such it can not be trusted that just
  * because you added something to the cache, it means you can get it out again.
  * 

--- a/database/src/main/java/com/findwise/hydra/DocumentWriter.java
+++ b/database/src/main/java/com/findwise/hydra/DocumentWriter.java
@@ -71,7 +71,6 @@ public interface DocumentWriter<T extends DatabaseType> {
 	 * 
 	 * @param id
 	 * @param tag
-	 * @return
 	 */
 	boolean markTouched(DocumentID<T> id, String tag);
 
@@ -101,7 +100,6 @@ public interface DocumentWriter<T extends DatabaseType> {
 	 *            the document to discard
 	 * @param stage
 	 *            the name of the stage that discarded this document.
-	 * @return
 	 */
 	boolean markDiscarded(DatabaseDocument<T> d, String stage);
 	
@@ -117,7 +115,6 @@ public interface DocumentWriter<T extends DatabaseType> {
 	 *            the document to fail
 	 * @param stage
 	 *            the name of the stage that discarded this document.
-	 * @return
 	 */
 	boolean markFailed(DatabaseDocument<T> d, String stage);
 
@@ -138,7 +135,6 @@ public interface DocumentWriter<T extends DatabaseType> {
 	 *            the document to mark as pending
 	 * @param stage
 	 *            the stage marking the document
-	 * @return
 	 */
 	boolean markPending(DatabaseDocument<T> d, String stage);
 

--- a/database/src/main/java/com/findwise/hydra/DocumentWriter.java
+++ b/database/src/main/java/com/findwise/hydra/DocumentWriter.java
@@ -39,21 +39,6 @@ public interface DocumentWriter<T extends DatabaseType> {
 	 * more clever.
 	 */
 	Collection<DatabaseDocument<T>> getAndTag(DatabaseQuery<T> query, int n, String ... tag);
-	
-	/**
-	 * Calls getAndTagRecurring(DatabaseQuery query, String tag, int
-	 * intervalMillis) with a default value specified by the implementing class.
-	 */
-//	DatabaseDocument<T> getAndTagRecurring(DatabaseQuery<T> query, String tag);
-
-	/**
-	 * Functionally the same as getAndTag(), but instead of rejecting all
-	 * documents that have been tagged by the supplied tag, it will return them,
-	 * should <code>intervalMillis</code> be less than the less than the time
-	 * elapsed since the document was last tagged.
-	 */
-//	DatabaseDocument<T> getAndTagRecurring(DatabaseQuery<T> query, String tag,
-//			int intervalMillis);
 
 	/**
 	 * Upon returning, will have updated the document with the specified ID with

--- a/database/src/main/java/com/findwise/hydra/PipelineStatus.java
+++ b/database/src/main/java/com/findwise/hydra/PipelineStatus.java
@@ -19,7 +19,7 @@ public interface PipelineStatus<T extends DatabaseType> {
 	/**
 	 * Set whether or not to discard old documents.
 	 * 
-	 * @param discard
+	 * @param discardOld
 	 */
 	void setDiscardOldDocuments(boolean discardOld);
 	
@@ -28,7 +28,7 @@ public interface PipelineStatus<T extends DatabaseType> {
 	/**
 	 * If set to discard old documents, this dictates how many to keep.
 	 * 
-	 * @param number
+	 * @param numberToKeep
 	 */
 	void setDiscardedToKeep(long numberToKeep);
 	

--- a/database/src/main/java/com/findwise/hydra/PipelineWriter.java
+++ b/database/src/main/java/com/findwise/hydra/PipelineWriter.java
@@ -29,7 +29,7 @@ public interface PipelineWriter {
 	/**
 	 * Removes a file from the database.
 	 * @param id
-	 * @return
+	 * @return true if successful
 	 */
 	boolean deleteFile(Object id);
 

--- a/examples/src/main/java/com/findwise/hydra/InsertFileDocument.java
+++ b/examples/src/main/java/com/findwise/hydra/InsertFileDocument.java
@@ -9,8 +9,7 @@ import java.net.URL;
 
 import org.apache.http.HttpException;
 
-import com.findwise.hydra.DocumentFile;
-import com.findwise.hydra.JsonException;
+import com.findwise.hydra.local.Local;
 import com.findwise.hydra.local.LocalDocument;
 import com.findwise.hydra.local.LocalQuery;
 import com.findwise.hydra.local.RemotePipeline;
@@ -28,7 +27,7 @@ public class InsertFileDocument {
 			LocalDocument ld = rp2.getDocument(new LocalQuery());
 			File f = getFile();
 			FileInputStream fis = new FileInputStream(f);
-			DocumentFile df = new DocumentFile(ld.getID(), f.getName(), fis);
+			DocumentFile<Local> df = new DocumentFile<Local>(ld.getID(), f.getName(), fis);
 			df.setEncoding(new InputStreamReader(df.getStream()).getEncoding());
 			df.setMimetype("application/msword");
 			rp2.saveFile(df);

--- a/examples/src/main/java/com/findwise/hydra/json/JsonPipelineUtil.java
+++ b/examples/src/main/java/com/findwise/hydra/json/JsonPipelineUtil.java
@@ -2,6 +2,8 @@ package com.findwise.hydra.json;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.JsonIOException;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.InputStreamReader;

--- a/examples/src/test/java/com/findwise/hydra/json/JsonPipelineUtilTest.java
+++ b/examples/src/test/java/com/findwise/hydra/json/JsonPipelineUtilTest.java
@@ -18,6 +18,7 @@ public class JsonPipelineUtilTest {
 
     private static final String JSON_FILE = "/sample pipeline.json";
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testFromJson_InputStreamReader() throws FileNotFoundException {
         InputStream in = this.getClass().getResourceAsStream(JSON_FILE);
@@ -42,23 +43,4 @@ public class JsonPipelineUtilTest {
         assertEquals("$1$2$3", regexConfig.get("substitute"));
         System.out.println("* " + cfg.toString());
     }
-
-//    @Test
-//    public void testToJson() {
-//        PipelineConfiguration cfg = new PipelineConfiguration();
-//        cfg.setPipelineName("contacts");
-//        List<Map<String, Object>> stages = new ArrayList<Map<String, Object>>();
-//        Map<String, Object> stage = new HashMap<String, Object>();        
-//        stage.put("stageName", "regexdates");
-//        stage.put("stageClass", "com.findwise.hydra.stage.RegexStage");
-//        stage.put("jarId", "basic");
-//        stage.put("queryOptions", new String[]{"touched(mergeFields,true)"});
-//        Map<String, String> regexConfigs = new HashMap<String, String>();
-//        regexConfigs.put("inField", "releasedatetime");
-//        regexConfigs.put("outField", "releasedatetime");
-//        regexConfigs.put("regex", "(.*)(\\+\\d{2}):(\\d{2})");
-//        regexConfigs.put("substitute", "$1$2$3");
-//        stage.put("regexConfigs", new Object[]{regexConfigs});
-//        cfg.addStage(stage);
-//    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.2.1</version>
+			</plugin>
+			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.8.1</version>
 				<configuration>

--- a/stages/out/elasticsearch-out/src/test/java/com/findwise/hydra/output/elasticsearch/ElasticsearchOutputStageIT.java
+++ b/stages/out/elasticsearch-out/src/test/java/com/findwise/hydra/output/elasticsearch/ElasticsearchOutputStageIT.java
@@ -1,6 +1,6 @@
 package com.findwise.hydra.output.elasticsearch;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.elasticsearch.action.ListenableActionFuture;
 import org.elasticsearch.action.get.GetResponse;

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/DateFormatterStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/DateFormatterStageTest.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author magnus.ebbesson

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/MergeFieldsStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/MergeFieldsStageTest.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.apache.commons.lang.StringUtils;
 import org.junit.Test;

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/PrioritizedCopyStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/PrioritizedCopyStageTest.java
@@ -7,7 +7,7 @@ import com.findwise.hydra.local.LocalDocument;
 
 import java.util.LinkedList;
 import java.util.List;
-import junit.framework.Assert;
+import org.junit.Assert;
 
 public class PrioritizedCopyStageTest {
     @Test

--- a/stages/processing/basic/src/test/java/com/findwise/hydra/stage/SetStaticFieldStageTest.java
+++ b/stages/processing/basic/src/test/java/com/findwise/hydra/stage/SetStaticFieldStageTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import com.findwise.hydra.local.LocalDocument;
 import com.findwise.hydra.stage.SetStaticFieldStage.Policy;

--- a/stages/processing/hydra-groovy-runner/src/test/java/com/findwise/hydra/stage/groovyrunner/GroovyRunnerStageTest.java
+++ b/stages/processing/hydra-groovy-runner/src/test/java/com/findwise/hydra/stage/groovyrunner/GroovyRunnerStageTest.java
@@ -2,7 +2,6 @@ package com.findwise.hydra.stage.groovyrunner;
 
 import java.io.InputStream;
 
-import junit.framework.Assert;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
@@ -17,7 +16,7 @@ public class GroovyRunnerStageTest {
 		GroovyRunnerStage stage = new GroovyRunnerStage();
 		String script = "nothing";
 		stage.setGroovyScript(script);
-		Assert.assertEquals(script, stage.getGroovyScript());
+		assertEquals(script, stage.getGroovyScript());
 	}
 
 	@Test
@@ -30,7 +29,7 @@ public class GroovyRunnerStageTest {
 				+ " public class " + className + " implements GroovyStage{"
 				+ "public void process(LocalDocument doc){}" + "}";
 		GroovyStage stage = runner.loadGroovyStage(script);
-		Assert.assertEquals(className, stage.getClass().getCanonicalName());
+		assertEquals(className, stage.getClass().getCanonicalName());
 	}
 
 	@Test

--- a/stages/processing/web/src/test/java/com/findwise/hydra/stage/webstages/JsoupSelectorTest.java
+++ b/stages/processing/web/src/test/java/com/findwise/hydra/stage/webstages/JsoupSelectorTest.java
@@ -13,7 +13,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.findwise.hydra.local.LocalDocument;
-import junit.framework.Assert;
 
 public class JsoupSelectorTest {
 
@@ -126,9 +125,9 @@ public class JsoupSelectorTest {
 	public void testUnavaiablefield() throws Exception {
 		
 		jsoup.process(new LocalDocument());
-                Assert.assertNull(doc.getContentField("extracted_text"));
-                Assert.assertNull(doc.getContentField("h1"));
-                Assert.assertNull(doc.getContentField("h2"));
+		assertNull(doc.getContentField("extracted_text"));
+		assertNull(doc.getContentField("h1"));
+		assertNull(doc.getContentField("h2"));
 	}
 	
 	@Test
@@ -184,6 +183,5 @@ public class JsoupSelectorTest {
 		assertTrue("Expected " + correct + " got " + result,
 					result.equalsIgnoreCase(correct));
 	}
-		
 }
 

--- a/stages/processing/web/src/test/java/com/findwise/hydra/stage/webstages/RenderHTMLStageTest.java
+++ b/stages/processing/web/src/test/java/com/findwise/hydra/stage/webstages/RenderHTMLStageTest.java
@@ -4,14 +4,13 @@
  */
 package com.findwise.hydra.stage.webstages;
 
-import com.findwise.hydra.stage.webstages.RenderHTMLStage;
 import com.findwise.hydra.local.LocalDocument;
 import com.findwise.hydra.stage.RequiredArgumentMissingException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.LinkedList;
 import java.util.List;
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 


### PR DESCRIPTION
There were a number of compile warnings, especially references to the deprecated `junit.framework.Assert`. I've replaced those with the correct one (`org.junit.Assert`) and fixed a bunch of other warnings.
