### PR TITLE
Refactor of Stage to Core communication

### DIFF
--- a/api/src/main/java/com/findwise/hydra/local/HttpEndpointConstants.java
+++ b/api/src/main/java/com/findwise/hydra/local/HttpEndpointConstants.java
@@ -1,0 +1,20 @@
+package com.findwise.hydra.local;
+
+public class HttpEndpointConstants {
+    public static final String GET_DOCUMENT_URL = "getDocument";
+    public static final String WRITE_DOCUMENT_URL = "writeDocument";
+    public static final String RELEASE_DOCUMENT_URL = "releaseDocument";
+    public static final String PROCESSED_DOCUMENT_URL = "processedDocument";
+    public static final String PENDING_DOCUMENT_URL = "pendingDocument";
+    public static final String DISCARDED_DOCUMENT_URL = "discardedDocument";
+    public static final String GET_PROPERTIES_URL = "getProperties";
+    public static final String FAILED_DOCUMENT_URL = "failedDocument";
+    public static final String FILE_URL = "documentFile";
+    public static final String STAGE_PARAM = "stage";
+    public static final String NORELEASE_PARAM = "norelease";
+    public static final String PARTIAL_PARAM = "partial";
+    public static final String DOCID_PARAM = "docid";
+    public static final String FILENAME_PARAM = "filename";
+    public static final int DEFAULT_PORT = 12001;
+    public static final String DEFAULT_HOST = "localhost";
+}

--- a/api/src/main/java/com/findwise/hydra/local/HttpRemotePipeline.java
+++ b/api/src/main/java/com/findwise/hydra/local/HttpRemotePipeline.java
@@ -1,0 +1,389 @@
+package com.findwise.hydra.local;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.findwise.hydra.DocumentFile;
+import com.findwise.hydra.DocumentID;
+import com.findwise.hydra.JsonException;
+import com.findwise.hydra.SerializationUtils;
+import com.findwise.hydra.stage.AbstractProcessStage;
+import com.findwise.hydra.stage.AbstractProcessStageMapper;
+import com.findwise.hydra.stage.InitFailedException;
+import com.findwise.hydra.stage.RequiredArgumentMissingException;
+import com.findwise.tools.HttpConnection;
+
+public class HttpRemotePipeline implements RemotePipeline {
+	private static final Logger internalLogger = LoggerFactory.getLogger("internal");
+	private static final Logger logger = LoggerFactory.getLogger(HttpRemotePipeline.class);
+
+    private final boolean performanceLogging;
+
+	private final HttpConnection core;
+
+	private final String getUrl;
+	private final String writeUrl;
+	private final String processedUrl;
+	private final String failedUrl;
+	private final String pendingUrl;
+	private final String discardedUrl;
+	private final String propertyUrl;
+	private final String fileUrl;
+
+	private final String stageName;
+
+	/**
+	 * Calls RemotePipeline(String, int, String) with default values for
+	 * hostName (RemotePipeline.DEFAULT_HOST) and port (RemotePipeline.DEFAULT_PORT).
+	 *
+	 * @param stageName
+	 */
+	public HttpRemotePipeline(String stageName) {
+		this(HttpEndpointConstants.DEFAULT_HOST, HttpEndpointConstants.DEFAULT_PORT, stageName, false);
+	}
+
+	public HttpRemotePipeline(String hostName, int port, String stageName) {
+		this(hostName, port, stageName, false);
+	}
+
+	public HttpRemotePipeline(String hostName, int port, String stageName, boolean performanceLogging) {
+		this.stageName = stageName;
+		getUrl = "/" + HttpEndpointConstants.GET_DOCUMENT_URL + "?" + HttpEndpointConstants.STAGE_PARAM + "=" + stageName;
+		writeUrl = "/" + HttpEndpointConstants.WRITE_DOCUMENT_URL + "?" + HttpEndpointConstants.STAGE_PARAM + "=" + stageName;
+		processedUrl = "/" + HttpEndpointConstants.PROCESSED_DOCUMENT_URL + "?" + HttpEndpointConstants.STAGE_PARAM + "=" + stageName;
+		failedUrl = "/" + HttpEndpointConstants.FAILED_DOCUMENT_URL + "?" + HttpEndpointConstants.STAGE_PARAM + "=" + stageName;
+		pendingUrl = "/" + HttpEndpointConstants.PENDING_DOCUMENT_URL + "?" + HttpEndpointConstants.STAGE_PARAM + "=" + stageName;
+		discardedUrl = "/" + HttpEndpointConstants.DISCARDED_DOCUMENT_URL + "?" + HttpEndpointConstants.STAGE_PARAM + "=" + stageName;
+		propertyUrl = "/" + HttpEndpointConstants.GET_PROPERTIES_URL + "?" + HttpEndpointConstants.STAGE_PARAM + "=" + stageName;
+		fileUrl = "/" + HttpEndpointConstants.FILE_URL + "?" + HttpEndpointConstants.STAGE_PARAM + "=" + stageName;
+
+		core = new HttpConnection(hostName, port);
+		this.performanceLogging = performanceLogging;
+	}
+
+	@Override
+    public LocalDocument getDocument(LocalQuery query) throws IOException {
+		HttpResponse response;
+		long start = System.currentTimeMillis();
+		response = core.post(getUrl, query.toJson());
+
+		long startSerialize = System.currentTimeMillis();
+		long startJson = 0L;
+		LocalDocument ld = null;
+		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+			String s = EntityUtils.toString(response.getEntity());
+			startJson = System.currentTimeMillis();
+			ld = buildDocument(s);
+			internalLogger.debug("Received document with ID " + ld.getID());
+		} else if (response.getStatusLine().getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+			internalLogger.debug("No document found matching query");
+			EntityUtils.consume(response.getEntity());
+		} else {
+			logUnexpected(response);
+		}
+		if (isPerformanceLogging()) {
+			long end = System.currentTimeMillis();
+			Object docId = ld != null ? ld.getID() : null;
+			logger.info(String.format("type=performance event=query stage_name=%s doc_id=\"%s\" start=%d fetch=%d entitystring=%d serialize=%d end=%d total=%d", stageName, docId, start, startSerialize - start, startJson - startSerialize, end - startJson, end, end - start));
+		}
+		return ld;
+	}
+
+	private LocalDocument buildDocument(String s) throws IOException {
+		LocalDocument ld;
+		try {
+			ld = new LocalDocument(s);
+		} catch (JsonException e) {
+			// TODO: Why IOException here?
+			throw new IOException(e);
+		}
+		ld.setDocumentFileRepository(this);
+		return ld;
+	}
+
+	private static void logUnexpected(HttpResponse response) throws IOException {
+		internalLogger.error("Node gave an unexpected response: " + response.getStatusLine());
+		internalLogger.error("Message: " + EntityUtils.toString(response.getEntity()));
+	}
+
+	@Override
+    public boolean saveFull(LocalDocument d) throws IOException, JsonException {
+		boolean res = save(d, false);
+		if (res) {
+			d.markSynced();
+		}
+		return res;
+	}
+
+	@Override
+    public boolean save(LocalDocument d) throws IOException, JsonException {
+		boolean res = save(d, true);
+		if (res) {
+			d.markSynced();
+		}
+		return res;
+	}
+
+	private boolean save(LocalDocument d, boolean partialUpdate) throws IOException, JsonException {
+		boolean hasId = d.getID() != null;
+		String s;
+		long start = System.currentTimeMillis();
+		if (partialUpdate) {
+			s = d.modifiedFieldsToJson();
+		} else {
+			s = d.toJson();
+		}
+		long startPost = System.currentTimeMillis();
+		HttpResponse response = core.post(getWriteUrl(partialUpdate), s);
+		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+			if (!hasId) {
+				LocalDocument updated = new LocalDocument(EntityUtils.toString(response.getEntity()));
+				d.putAll(updated);
+			} else {
+				EntityUtils.consume(response.getEntity());
+			}
+			if (isPerformanceLogging()) {
+				long end = System.currentTimeMillis();
+				DocumentID<Local> docId = d.getID();
+				logger.info(String.format("type=performance event=update stage_name=%s doc_id=\"%s\" start=%d serialize=%d post=%d end=%d total=%d", stageName, docId, start, startPost - start, end - startPost, end, end - start));
+			}
+			return true;
+		}
+
+		logUnexpected(response);
+		return false;
+	}
+
+	@Override
+    public boolean markPending(LocalDocument d) throws IOException {
+		HttpResponse response = core.post(pendingUrl, d.contentFieldsToJson(null));
+		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+			EntityUtils.consume(response.getEntity());
+
+			return true;
+		}
+
+		logUnexpected(response);
+
+		return false;
+	}
+
+	@Override
+    public boolean markFailed(LocalDocument d) throws IOException {
+		HttpResponse response = core.post(failedUrl, d.modifiedFieldsToJson());
+		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+			EntityUtils.consume(response.getEntity());
+
+			return true;
+		}
+
+		logUnexpected(response);
+
+		return false;
+	}
+
+	@Override
+    public boolean markFailed(LocalDocument d, Throwable t) throws IOException {
+		d.addError(stageName, t);
+		return markFailed(d);
+	}
+
+	@Override
+    public boolean markProcessed(LocalDocument d) throws IOException {
+		HttpResponse response = core.post(processedUrl, d.modifiedFieldsToJson());
+		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+			EntityUtils.consume(response.getEntity());
+
+			return true;
+		}
+
+		logUnexpected(response);
+
+		return false;
+	}
+
+	@Override
+    public boolean markDiscarded(LocalDocument d) throws IOException {
+		HttpResponse response = core.post(discardedUrl, d.modifiedFieldsToJson());
+		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+			EntityUtils.consume(response.getEntity());
+
+			return true;
+		}
+
+		logUnexpected(response);
+
+		return false;
+	}
+
+	private String getWriteUrl(boolean partialUpdate) {
+		String s = writeUrl;
+		s += "&" + HttpEndpointConstants.NORELEASE_PARAM + "=0";
+		if (partialUpdate) {
+			s += "&" + HttpEndpointConstants.PARTIAL_PARAM + "=1";
+		} else {
+			s += "&" + HttpEndpointConstants.PARTIAL_PARAM + "=0";
+		}
+		return s;
+	}
+
+	@Override
+    public AbstractProcessStage getStageInstance() throws IOException, IllegalAccessException, InitFailedException, InstantiationException, JsonException, RequiredArgumentMissingException, ClassNotFoundException {
+		String jsonString = getStagePropertiesJsonString();
+		return AbstractProcessStageMapper.fromJsonString(jsonString);
+	}
+
+	private String getStagePropertiesJsonString() throws IOException {
+		HttpResponse response = core.get(propertyUrl);
+
+		String jsonString;
+		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+			internalLogger.debug("Successfully retrieved propertyMap");
+			jsonString = EntityUtils.toString(response.getEntity());
+		} else if (response.getStatusLine().getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+			internalLogger.debug("No document found matching query");
+			EntityUtils.consume(response.getEntity());
+			throw new RuntimeException("No stage properties found for " + stageName);
+		} else {
+			logUnexpected(response);
+			throw new RuntimeException("Unexpected error while fetching stage properties for " + stageName);
+		}
+		return jsonString;
+	}
+
+	private String getFileUrl(DocumentFile<Local> df) throws UnsupportedEncodingException {
+		return getFileUrl(df.getFileName(), df.getDocumentId());
+	}
+
+	private String getFileUrl(String fileName, DocumentID<Local> docid) throws UnsupportedEncodingException {
+		return fileUrl + "&" + HttpEndpointConstants.FILENAME_PARAM + "=" + fileName + "&" + HttpEndpointConstants.DOCID_PARAM + "=" + URLEncoder.encode(docid.toJSON(), "UTF-8");
+	}
+
+	public DocumentFile<Local> getFile(String fileName, DocumentID<Local> docid) {
+		try {
+			HttpResponse response = core.get(getFileUrl(fileName, docid));
+
+			if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+				Object o;
+				try {
+					o = SerializationUtils.toObject(EntityUtils.toString(response.getEntity()));
+				} catch (JsonException e) {
+					throw new IOException(e);
+				}
+				if (!(o instanceof Map)) {
+					return null;
+				}
+
+				@SuppressWarnings("unchecked")
+				Map<String, Object> map = (Map<String, Object>) o;
+				Date d = (Date) map.get("uploadDate");
+				String encoding = (String) map.get("encoding");
+				String mimetype = (String) map.get("mimetype");
+				String savedByStage = (String) map.get("savedByStage");
+				InputStream is;
+				if (encoding == null) {
+					is = new ByteArrayInputStream(Base64.decodeBase64(((String) map.get("stream")).getBytes("UTF-8")));
+				} else {
+					is = new ByteArrayInputStream(Base64.decodeBase64(((String) map.get("stream")).getBytes(encoding)));
+				}
+
+				DocumentFile<Local> df = new DocumentFile<Local>(docid, fileName, is, savedByStage, d);
+				df.setEncoding(encoding);
+				df.setMimetype(mimetype);
+
+				return df;
+			} else {
+				logUnexpected(response);
+				return null;
+			}
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public boolean saveFile(DocumentFile<Local> df) {
+		try {
+			HttpResponse response = core.post(getFileUrl(df), SerializationUtils.toJson(df));
+			int code = response.getStatusLine().getStatusCode();
+			if (code == HttpStatus.SC_OK || code == HttpStatus.SC_NO_CONTENT) {
+				EntityUtils.consume(response.getEntity());
+				return true;
+			} else {
+				logUnexpected(response);
+				return false;
+			}
+		} catch(IOException e) {
+			// TODO: Something else here?
+			throw new RuntimeException(e);
+		}
+	}
+
+	public boolean deleteFile(String fileName, DocumentID<Local> docid) {
+		try {
+			HttpResponse response = core.delete(getFileUrl(fileName, docid));
+
+			if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+				EntityUtils.consume(response.getEntity());
+				return true;
+			} else {
+				logUnexpected(response);
+				return false;
+			}
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	public List<String> getFileNames(DocumentID<?> docid) {
+		try {
+			HttpResponse response = core.get(fileUrl + "&" + HttpEndpointConstants.DOCID_PARAM + "=" + URLEncoder.encode(docid.toJSON(), "UTF-8"));
+
+			if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+				try {
+					return (List<String>) SerializationUtils.toObject(EntityUtils.toString(response.getEntity()));
+				} catch (JsonException e) {
+					throw new IOException(e);
+				}
+			} else {
+				logUnexpected(response);
+				return null;
+			}
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public List<DocumentFile<Local>> getFiles(DocumentID<Local> docid) {
+		List<String> fileNames = getFileNames(docid);
+		List<DocumentFile<Local>> files = new ArrayList<DocumentFile<Local>>();
+		for (String fileName : fileNames) {
+			files.add(getFile(fileName, docid));
+		}
+		return files;
+	}
+
+	@Override
+    public String getStageName() {
+		return stageName;
+	}
+
+    @Override
+	public boolean isPerformanceLogging() {
+		return performanceLogging;
+	}
+}

--- a/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
+++ b/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
@@ -1,411 +1,48 @@
 package com.findwise.hydra.local;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.commons.codec.binary.Base64;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.util.EntityUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.findwise.hydra.DocumentFile;
 import com.findwise.hydra.DocumentFileRepository;
-import com.findwise.hydra.DocumentID;
 import com.findwise.hydra.JsonException;
-import com.findwise.hydra.SerializationUtils;
 import com.findwise.hydra.stage.AbstractProcessStage;
-import com.findwise.hydra.stage.AbstractProcessStageMapper;
 import com.findwise.hydra.stage.InitFailedException;
 import com.findwise.hydra.stage.RequiredArgumentMissingException;
-import com.findwise.tools.HttpConnection;
 
-public class RemotePipeline implements DocumentFileRepository {
-	private static final Logger internalLogger = LoggerFactory.getLogger("internal");
-	private static final Logger logger = LoggerFactory.getLogger(RemotePipeline.class);
+import java.io.IOException;
 
-	public static final String GET_DOCUMENT_URL = "getDocument";
-	public static final String WRITE_DOCUMENT_URL = "writeDocument";
-	public static final String RELEASE_DOCUMENT_URL = "releaseDocument";
-	public static final String PROCESSED_DOCUMENT_URL = "processedDocument";
-	public static final String PENDING_DOCUMENT_URL = "pendingDocument";
-	public static final String DISCARDED_DOCUMENT_URL = "discardedDocument";
-	public static final String GET_PROPERTIES_URL = "getProperties";
-	public static final String FAILED_DOCUMENT_URL = "failedDocument";
-	public static final String FILE_URL = "documentFile";
+public interface RemotePipeline extends DocumentFileRepository {
 
-	public static final String STAGE_PARAM = "stage";
-	public static final String NORELEASE_PARAM = "norelease";
-	public static final String PARTIAL_PARAM = "partial";
-	public static final String DOCID_PARAM = "docid";
-	public static final String FILENAME_PARAM = "filename";
+    int DEFAULT_LOG_PORT = 12002;
 
-	public static final int DEFAULT_PORT = 12001;
-	public static final String DEFAULT_HOST = "localhost";
-	public static final int DEFAULT_LOG_PORT = 12002;
+    /**
+     * Non-recurring, use this in all known cases except for in an output node.
+     * <p/>
+     * The fetched document will be tagged with the name of the stage which is
+     * used to execute getDocument.
+     */
+    LocalDocument getDocument(LocalQuery query) throws IOException;
 
-	private final boolean performanceLogging;
+    /**
+     * Writes an entire document to the pipeline. Use is discouraged, try using save(..) whenever possible.
+     */
+    boolean saveFull(LocalDocument d) throws IOException, JsonException;
 
-	private final HttpConnection core;
+    /**
+     * Writes all outstanding updates to the document since it was initialized.
+     */
+    boolean save(LocalDocument d) throws IOException, JsonException;
 
-	private final String getUrl;
-	private final String writeUrl;
-	private final String processedUrl;
-	private final String failedUrl;
-	private final String pendingUrl;
-	private final String discardedUrl;
-	private final String propertyUrl;
-	private final String fileUrl;
+    boolean markPending(LocalDocument d) throws IOException;
 
-	private final String stageName;
+    boolean markFailed(LocalDocument d) throws IOException;
 
-	/**
-	 * Calls RemotePipeline(String, int, String) with default values for
-	 * hostName (RemotePipeline.DEFAULT_HOST) and port (RemotePipeline.DEFAULT_PORT).
-	 *
-	 * @param stageName
-	 */
-	public RemotePipeline(String stageName) {
-		this(DEFAULT_HOST, DEFAULT_PORT, stageName, false);
-	}
+    boolean markFailed(LocalDocument d, Throwable t) throws IOException;
 
-	public RemotePipeline(String hostName, int port, String stageName) {
-		this(hostName, port, stageName, false);
-	}
+    boolean markProcessed(LocalDocument d) throws IOException;
 
-	public RemotePipeline(String hostName, int port, String stageName, boolean performanceLogging) {
-		this.stageName = stageName;
-		getUrl = "/" + GET_DOCUMENT_URL + "?" + STAGE_PARAM + "=" + stageName;
-		writeUrl = "/" + WRITE_DOCUMENT_URL + "?" + STAGE_PARAM + "=" + stageName;
-		processedUrl = "/" + PROCESSED_DOCUMENT_URL + "?" + STAGE_PARAM + "=" + stageName;
-		failedUrl = "/" + FAILED_DOCUMENT_URL + "?" + STAGE_PARAM + "=" + stageName;
-		pendingUrl = "/" + PENDING_DOCUMENT_URL + "?" + STAGE_PARAM + "=" + stageName;
-		discardedUrl = "/" + DISCARDED_DOCUMENT_URL + "?" + STAGE_PARAM + "=" + stageName;
-		propertyUrl = "/" + GET_PROPERTIES_URL + "?" + STAGE_PARAM + "=" + stageName;
-		fileUrl = "/" + FILE_URL + "?" + STAGE_PARAM + "=" + stageName;
+    boolean markDiscarded(LocalDocument d) throws IOException;
 
-		core = new HttpConnection(hostName, port);
-		this.performanceLogging = performanceLogging;
-	}
+    AbstractProcessStage getStageInstance() throws IOException, IllegalAccessException, InitFailedException, InstantiationException, JsonException, RequiredArgumentMissingException, ClassNotFoundException;
 
-	/**
-	 * Non-recurring, use this in all known cases except for in an output node.
-	 * <p/>
-	 * The fetched document will be tagged with the name of the stage which is
-	 * used to execute getDocument.
-	 */
-	public LocalDocument getDocument(LocalQuery query) throws IOException {
-		HttpResponse response;
-		long start = System.currentTimeMillis();
-		response = core.post(getUrl, query.toJson());
+    String getStageName();
 
-		long startSerialize = System.currentTimeMillis();
-		long startJson = 0L;
-		LocalDocument ld = null;
-		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-			String s = EntityUtils.toString(response.getEntity());
-			startJson = System.currentTimeMillis();
-			ld = buildDocument(s);
-			internalLogger.debug("Received document with ID " + ld.getID());
-		} else if (response.getStatusLine().getStatusCode() == HttpStatus.SC_NOT_FOUND) {
-			internalLogger.debug("No document found matching query");
-			EntityUtils.consume(response.getEntity());
-		} else {
-			logUnexpected(response);
-		}
-		if (isPerformanceLogging()) {
-			long end = System.currentTimeMillis();
-			Object docId = ld != null ? ld.getID() : null;
-			logger.info(String.format("type=performance event=query stage_name=%s doc_id=\"%s\" start=%d fetch=%d entitystring=%d serialize=%d end=%d total=%d", stageName, docId, start, startSerialize - start, startJson - startSerialize, end - startJson, end, end - start));
-		}
-		return ld;
-	}
-
-	private LocalDocument buildDocument(String s) throws IOException {
-		LocalDocument ld;
-		try {
-			ld = new LocalDocument(s);
-		} catch (JsonException e) {
-			// TODO: Why IOException here?
-			throw new IOException(e);
-		}
-		ld.setDocumentFileRepository(this);
-		return ld;
-	}
-
-	private static void logUnexpected(HttpResponse response) throws IOException {
-		internalLogger.error("Node gave an unexpected response: " + response.getStatusLine());
-		internalLogger.error("Message: " + EntityUtils.toString(response.getEntity()));
-	}
-
-	/**
-	 * Writes an entire document to the pipeline. Use is discouraged, try using save(..) whenever possible.
-	 */
-	public boolean saveFull(LocalDocument d) throws IOException, JsonException {
-		boolean res = save(d, false);
-		if (res) {
-			d.markSynced();
-		}
-		return res;
-	}
-
-	/**
-	 * Writes all outstanding updates to the document since it was initialized.
-	 */
-	public boolean save(LocalDocument d) throws IOException, JsonException {
-		boolean res = save(d, true);
-		if (res) {
-			d.markSynced();
-		}
-		return res;
-	}
-
-	private boolean save(LocalDocument d, boolean partialUpdate) throws IOException, JsonException {
-		boolean hasId = d.getID() != null;
-		String s;
-		long start = System.currentTimeMillis();
-		if (partialUpdate) {
-			s = d.modifiedFieldsToJson();
-		} else {
-			s = d.toJson();
-		}
-		long startPost = System.currentTimeMillis();
-		HttpResponse response = core.post(getWriteUrl(partialUpdate), s);
-		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-			if (!hasId) {
-				LocalDocument updated = new LocalDocument(EntityUtils.toString(response.getEntity()));
-				d.putAll(updated);
-			} else {
-				EntityUtils.consume(response.getEntity());
-			}
-			if (isPerformanceLogging()) {
-				long end = System.currentTimeMillis();
-				DocumentID<Local> docId = d.getID();
-				logger.info(String.format("type=performance event=update stage_name=%s doc_id=\"%s\" start=%d serialize=%d post=%d end=%d total=%d", stageName, docId, start, startPost - start, end - startPost, end, end - start));
-			}
-			return true;
-		}
-
-		logUnexpected(response);
-		return false;
-	}
-
-	public boolean markPending(LocalDocument d) throws IOException {
-		HttpResponse response = core.post(pendingUrl, d.contentFieldsToJson(null));
-		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-			EntityUtils.consume(response.getEntity());
-
-			return true;
-		}
-
-		logUnexpected(response);
-
-		return false;
-	}
-
-	public boolean markFailed(LocalDocument d) throws IOException {
-		HttpResponse response = core.post(failedUrl, d.modifiedFieldsToJson());
-		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-			EntityUtils.consume(response.getEntity());
-
-			return true;
-		}
-
-		logUnexpected(response);
-
-		return false;
-	}
-
-	public boolean markFailed(LocalDocument d, Throwable t) throws IOException {
-		d.addError(stageName, t);
-		return markFailed(d);
-	}
-
-	public boolean markProcessed(LocalDocument d) throws IOException {
-		HttpResponse response = core.post(processedUrl, d.modifiedFieldsToJson());
-		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-			EntityUtils.consume(response.getEntity());
-
-			return true;
-		}
-
-		logUnexpected(response);
-
-		return false;
-	}
-
-	public boolean markDiscarded(LocalDocument d) throws IOException {
-		HttpResponse response = core.post(discardedUrl, d.modifiedFieldsToJson());
-		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-			EntityUtils.consume(response.getEntity());
-
-			return true;
-		}
-
-		logUnexpected(response);
-
-		return false;
-	}
-
-	private String getWriteUrl(boolean partialUpdate) {
-		String s = writeUrl;
-		s += "&" + NORELEASE_PARAM + "=0";
-		if (partialUpdate) {
-			s += "&" + PARTIAL_PARAM + "=1";
-		} else {
-			s += "&" + PARTIAL_PARAM + "=0";
-		}
-		return s;
-	}
-
-	public AbstractProcessStage getStageInstance() throws IOException, IllegalAccessException, InitFailedException, InstantiationException, JsonException, RequiredArgumentMissingException, ClassNotFoundException {
-		String jsonString = getStagePropertiesJsonString();
-		return AbstractProcessStageMapper.fromJsonString(jsonString);
-	}
-
-	private String getStagePropertiesJsonString() throws IOException {
-		HttpResponse response = core.get(propertyUrl);
-
-		String jsonString;
-		if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-			internalLogger.debug("Successfully retrieved propertyMap");
-			jsonString = EntityUtils.toString(response.getEntity());
-		} else if (response.getStatusLine().getStatusCode() == HttpStatus.SC_NOT_FOUND) {
-			internalLogger.debug("No document found matching query");
-			EntityUtils.consume(response.getEntity());
-			throw new RuntimeException("No stage properties found for " + stageName);
-		} else {
-			logUnexpected(response);
-			throw new RuntimeException("Unexpected error while fetching stage properties for " + stageName);
-		}
-		return jsonString;
-	}
-
-	private String getFileUrl(DocumentFile<Local> df) throws UnsupportedEncodingException {
-		return getFileUrl(df.getFileName(), df.getDocumentId());
-	}
-
-	private String getFileUrl(String fileName, DocumentID<Local> docid) throws UnsupportedEncodingException {
-		return fileUrl + "&" + RemotePipeline.FILENAME_PARAM + "=" + fileName + "&" + RemotePipeline.DOCID_PARAM + "=" + URLEncoder.encode(docid.toJSON(), "UTF-8");
-	}
-
-	public DocumentFile<Local> getFile(String fileName, DocumentID<Local> docid) {
-		try {
-			HttpResponse response = core.get(getFileUrl(fileName, docid));
-
-			if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-				Object o;
-				try {
-					o = SerializationUtils.toObject(EntityUtils.toString(response.getEntity()));
-				} catch (JsonException e) {
-					throw new IOException(e);
-				}
-				if (!(o instanceof Map)) {
-					return null;
-				}
-
-				@SuppressWarnings("unchecked")
-				Map<String, Object> map = (Map<String, Object>) o;
-				Date d = (Date) map.get("uploadDate");
-				String encoding = (String) map.get("encoding");
-				String mimetype = (String) map.get("mimetype");
-				String savedByStage = (String) map.get("savedByStage");
-				InputStream is;
-				if (encoding == null) {
-					is = new ByteArrayInputStream(Base64.decodeBase64(((String) map.get("stream")).getBytes("UTF-8")));
-				} else {
-					is = new ByteArrayInputStream(Base64.decodeBase64(((String) map.get("stream")).getBytes(encoding)));
-				}
-
-				DocumentFile<Local> df = new DocumentFile<Local>(docid, fileName, is, savedByStage, d);
-				df.setEncoding(encoding);
-				df.setMimetype(mimetype);
-
-				return df;
-			} else {
-				logUnexpected(response);
-				return null;
-			}
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	public boolean saveFile(DocumentFile<Local> df) {
-		try {
-			HttpResponse response = core.post(getFileUrl(df), SerializationUtils.toJson(df));
-			int code = response.getStatusLine().getStatusCode();
-			if (code == HttpStatus.SC_OK || code == HttpStatus.SC_NO_CONTENT) {
-				EntityUtils.consume(response.getEntity());
-				return true;
-			} else {
-				logUnexpected(response);
-				return false;
-			}
-		} catch(IOException e) {
-			// TODO: Something else here?
-			throw new RuntimeException(e);
-		}
-	}
-
-	public boolean deleteFile(String fileName, DocumentID<Local> docid) {
-		try {
-			HttpResponse response = core.delete(getFileUrl(fileName, docid));
-
-			if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-				EntityUtils.consume(response.getEntity());
-				return true;
-			} else {
-				logUnexpected(response);
-				return false;
-			}
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	@SuppressWarnings("unchecked")
-	public List<String> getFileNames(DocumentID<?> docid) {
-		try {
-			HttpResponse response = core.get(fileUrl + "&" + RemotePipeline.DOCID_PARAM + "=" + URLEncoder.encode(docid.toJSON(), "UTF-8"));
-
-			if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-				try {
-					return (List<String>) SerializationUtils.toObject(EntityUtils.toString(response.getEntity()));
-				} catch (JsonException e) {
-					throw new IOException(e);
-				}
-			} else {
-				logUnexpected(response);
-				return null;
-			}
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	public List<DocumentFile<Local>> getFiles(DocumentID<Local> docid) {
-		List<String> fileNames = getFileNames(docid);
-		List<DocumentFile<Local>> files = new ArrayList<DocumentFile<Local>>();
-		for (String fileName : fileNames) {
-			files.add(getFile(fileName, docid));
-		}
-		return files;
-	}
-
-	public String getStageName() {
-		return stageName;
-	}
-
-	public boolean isPerformanceLogging() {
-		return performanceLogging;
-	}
+    boolean isPerformanceLogging();
 }

--- a/api/src/main/java/com/findwise/hydra/stage/StageCommandLineArguments.java
+++ b/api/src/main/java/com/findwise/hydra/stage/StageCommandLineArguments.java
@@ -1,5 +1,6 @@
 package com.findwise.hydra.stage;
 
+import com.findwise.hydra.local.HttpEndpointConstants;
 import com.findwise.hydra.local.RemotePipeline;
 
 public class StageCommandLineArguments {
@@ -34,8 +35,8 @@ public class StageCommandLineArguments {
 		}
 
 		String stageName = args[STAGE_NAME_PARAM];
-		String host = (args.length>PIPELINE_HOST_PARAM) ? args[PIPELINE_HOST_PARAM] : RemotePipeline.DEFAULT_HOST;
-		int port = (args.length>PIPELINE_PORT_PARAM) ? Integer.parseInt(args[PIPELINE_PORT_PARAM]) : RemotePipeline.DEFAULT_PORT;
+		String host = (args.length>PIPELINE_HOST_PARAM) ? args[PIPELINE_HOST_PARAM] : HttpEndpointConstants.DEFAULT_HOST;
+		int port = (args.length>PIPELINE_PORT_PARAM) ? Integer.parseInt(args[PIPELINE_PORT_PARAM]) : HttpEndpointConstants.DEFAULT_PORT;
 		boolean usePerformanceLogging = (args.length>PERFORMANCE_LOG_PARAM) ? Boolean.parseBoolean(args[PERFORMANCE_LOG_PARAM]) : false;
 		int logPort = (args.length>LOG_PORT_PARAM) ? Integer.parseInt(args[LOG_PORT_PARAM]) : RemotePipeline.DEFAULT_LOG_PORT;
 		AbstractProcessStage stageOverrideProperties = (args.length>OVERRIDE_PROPERTIES_PARAM) ? AbstractProcessStageMapper.fromJsonString(args[OVERRIDE_PROPERTIES_PARAM]) : null;

--- a/api/src/main/java/com/findwise/hydra/stage/StageServiceFactory.java
+++ b/api/src/main/java/com/findwise/hydra/stage/StageServiceFactory.java
@@ -1,18 +1,16 @@
 package com.findwise.hydra.stage;
 
 import com.findwise.hydra.JsonException;
+import com.findwise.hydra.local.HttpRemotePipeline;
 import com.findwise.hydra.local.RemotePipeline;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
 public class StageServiceFactory {
 	public static List<StageService> createStageServices(String stageName, String hostName, int port, boolean usePerformanceLogging, AbstractProcessStage overrideStage) throws IOException, InitFailedException, RequiredArgumentMissingException, ClassNotFoundException, InstantiationException, JsonException, IllegalAccessException {
-		RemotePipeline remotePipeline = new RemotePipeline(hostName, port, stageName, usePerformanceLogging);
+		RemotePipeline remotePipeline = new HttpRemotePipeline(hostName, port, stageName, usePerformanceLogging);
 		AbstractProcessStage stage = (overrideStage != null) ? overrideStage : remotePipeline.getStageInstance();
 		ProcessStageRunner stageRunner = new ProcessStageRunner(stageName, stage, remotePipeline);
 		List<StageService> stageServices = new ArrayList<StageService>();

--- a/api/src/test/java/com/findwise/hydra/local/HttpRemotePipelineTest.java
+++ b/api/src/test/java/com/findwise/hydra/local/HttpRemotePipelineTest.java
@@ -29,9 +29,9 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class RemotePipelineTest {
+public class HttpRemotePipelineTest {
 
-	RemotePipeline rp;
+	HttpRemotePipeline rp;
 
 	LocalDocument doc;
 
@@ -44,16 +44,16 @@ public class RemotePipelineTest {
 
 	@Before
 	public void setUp() {
-		rp = new RemotePipeline(mockHost, mockPort, stageName, false);
+		rp = new HttpRemotePipeline(mockHost, mockPort, stageName, false);
 		doc = new LocalDocument();
 		doc.setID(new LocalDocumentID("testdoc"));
 	}
 
 	@Test
 	public void testGetFileNames() throws IOException {
-		String fileUrl = "/" + RemotePipeline.FILE_URL
-				+ "?" + RemotePipeline.STAGE_PARAM + "=" + stageName
-				+ "&" + RemotePipeline.DOCID_PARAM + "=" + URLEncoder.encode(doc.getID().toJSON(), "UTF-8");
+		String fileUrl = "/" + HttpEndpointConstants.FILE_URL
+				+ "?" + HttpEndpointConstants.STAGE_PARAM + "=" + stageName
+				+ "&" + HttpEndpointConstants.DOCID_PARAM + "=" + URLEncoder.encode(doc.getID().toJSON(), "UTF-8");
 
 		stubFor(get(urlEqualTo(fileUrl)).willReturn(aResponse().withBody("[\"file1\", \"file2\"]")));
 
@@ -87,9 +87,9 @@ public class RemotePipelineTest {
 		testFiles.put("file1", "file1 contents".getBytes(encoding));
 		testFiles.put("file2", "contents of file2".getBytes(encoding));
 
-		String fileNamesUrl = "/" + RemotePipeline.FILE_URL
-				+ "?" + RemotePipeline.STAGE_PARAM + "=" + stageName
-				+ "&" + RemotePipeline.DOCID_PARAM + "=" + URLEncoder.encode(doc.getID().toJSON(), "UTF-8");
+		String fileNamesUrl = "/" + HttpEndpointConstants.FILE_URL
+				+ "?" + HttpEndpointConstants.STAGE_PARAM + "=" + stageName
+				+ "&" + HttpEndpointConstants.DOCID_PARAM + "=" + URLEncoder.encode(doc.getID().toJSON(), "UTF-8");
 
 		stubFor(get(urlEqualTo(fileNamesUrl)).willReturn(aResponse().withBody("[\"file2\", \"file1\"]")));
 
@@ -115,10 +115,10 @@ public class RemotePipelineTest {
 	}
 
 	private void stubFile(String fileName, LocalDocumentID docId, byte[] content, Date date, String encoding, String mimetype) throws UnsupportedEncodingException {
-		String fileUrl = "/" + RemotePipeline.FILE_URL
-				+ "?" + RemotePipeline.STAGE_PARAM + "=" + stageName
-				+ "&" + RemotePipeline.FILENAME_PARAM + "=" + fileName
-				+ "&" + RemotePipeline.DOCID_PARAM + "=" + URLEncoder.encode(docId.toJSON(), "UTF-8");
+		String fileUrl = "/" + HttpEndpointConstants.FILE_URL
+				+ "?" + HttpEndpointConstants.STAGE_PARAM + "=" + stageName
+				+ "&" + HttpEndpointConstants.FILENAME_PARAM + "=" + fileName
+				+ "&" + HttpEndpointConstants.DOCID_PARAM + "=" + URLEncoder.encode(docId.toJSON(), "UTF-8");
 
 		Map<String, Object> fileMap = new HashMap<String, Object>();
 		fileMap.put("uploadDate", date);

--- a/api/src/test/java/com/findwise/hydra/stage/ProcessStageRunnerTest.java
+++ b/api/src/test/java/com/findwise/hydra/stage/ProcessStageRunnerTest.java
@@ -2,8 +2,8 @@ package com.findwise.hydra.stage;
 
 import ch.qos.logback.classic.Level;
 import com.findwise.hydra.Logging;
+import com.findwise.hydra.local.HttpRemotePipeline;
 import com.findwise.hydra.local.LocalDocument;
-import com.findwise.hydra.local.LocalDocumentID;
 import com.findwise.hydra.local.RemotePipeline;
 import org.junit.Before;
 import org.junit.Rule;
@@ -15,9 +15,7 @@ import java.util.concurrent.TimeoutException;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -32,7 +30,7 @@ public class ProcessStageRunnerTest {
 	@Before
 	public void setUp() throws Exception {
 		Logging.setGlobalLoggingLevel(Level.OFF);
-		rp = mock(RemotePipeline.class);
+		rp = mock(HttpRemotePipeline.class);
 	}
 
 	public ProcessStageRunner buildStageRunner(AbstractProcessStage stage) {

--- a/core/src/main/java/com/findwise/hydra/CoreMapConfiguration.java
+++ b/core/src/main/java/com/findwise/hydra/CoreMapConfiguration.java
@@ -1,6 +1,6 @@
 package com.findwise.hydra;
 
-import com.findwise.hydra.local.RemotePipeline;
+import com.findwise.hydra.local.HttpEndpointConstants;
 import com.findwise.hydra.mongodb.MongoConfiguration;
 
 public class CoreMapConfiguration implements CoreConfiguration, Configuration {
@@ -44,7 +44,7 @@ public class CoreMapConfiguration implements CoreConfiguration, Configuration {
 
 	public int getRestPort() {
 		return Integer.parseInt(getParameter(COMMUNICATION_PORT_PARAM, ""
-				+ RemotePipeline.DEFAULT_PORT));
+				+ HttpEndpointConstants.DEFAULT_PORT));
 	}
 
 	public String getDatabaseUser() {

--- a/core/src/main/java/com/findwise/hydra/FileConfiguration.java
+++ b/core/src/main/java/com/findwise/hydra/FileConfiguration.java
@@ -1,12 +1,11 @@
 package com.findwise.hydra;
 
+import com.findwise.hydra.local.HttpEndpointConstants;
 import com.findwise.hydra.mongodb.MongoConfiguration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.findwise.hydra.local.RemotePipeline;
 
 public class FileConfiguration implements CoreConfiguration, Configuration {
 	public static final String DEFAULT_PROPERTIES_FILE = "resource.properties";
@@ -50,7 +49,7 @@ public class FileConfiguration implements CoreConfiguration, Configuration {
 
 	@Override
 	public int getRestPort() {
-		return conf.getInt(COMMUNICATION_PORT_PARAM, RemotePipeline.DEFAULT_PORT);
+		return conf.getInt(COMMUNICATION_PORT_PARAM, HttpEndpointConstants.DEFAULT_PORT);
 	}
 
 	@Override

--- a/core/src/main/java/com/findwise/hydra/net/FileHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/FileHandler.java
@@ -32,209 +32,208 @@ import com.findwise.hydra.local.RemotePipeline;
 
 public class FileHandler<T extends DatabaseType> implements ResponsibleHandler {
 
-	private static Logger logger = LoggerFactory.getLogger(FileHandler.class);
-	
-	private CachingDocumentNIO<T> io;
-	
-	public FileHandler(CachingDocumentNIO<T> io) {
-		this.io = io;
-	}
-	
-	@Override
-	public void handle(HttpRequest request, HttpResponse response, HttpContext context)
-			throws HttpException, IOException {
-		if(RESTTools.isPost(request)) {
-			handleSaveFile(request, response);
-		} else if (RESTTools.isGet(request)) {
-			if(RESTTools.getParam(request, RemotePipeline.FILENAME_PARAM)!=null) {
-				handleGetFile(request, response);
-			} else {
-				handleGetFilenames(request, response);
-			}
-		} else if (RESTTools.isDelete(request)) {
-			handleDeleteFile(request, response);
-		}
-	}
+    private static Logger logger = LoggerFactory.getLogger(FileHandler.class);
 
-	@Override
-	public boolean supports(HttpRequest request) {
-		return (RESTTools.isGet(request) || RESTTools.isPost(request) || RESTTools.isDelete(request)) && RESTTools.getBaseUrl(request).equals(RemotePipeline.FILE_URL);
-	}
+    private CachingDocumentNIO<T> io;
 
-	@Override
-	public String[] getSupportedUrls() {
-		return new String[] { RemotePipeline.FILE_URL };
-	}
-	
-	private void handleSaveFile(HttpRequest request, HttpResponse response) {
-		try {
-			DocumentFile<T> df = getDocumentFile(request);
-			
-			if (df == null) {
-				HttpResponseWriter.printBadRequestContent(response);
-			}
-			
-			DatabaseDocument<T> md = io.getDocumentById(df.getDocumentId());
-			if (md == null) {
-				HttpResponseWriter.printNoDocument(response);
-				return;
-			}
-			
-			io.write(df);
-			
-			HttpResponseWriter.printOk(response);
-		} catch (Exception e) {
-			logger.error("An error occurred during file save", e);
-			HttpResponseWriter.printUnhandledException(response, e);
-		}
-	}
-	
-	private void handleGetFile(HttpRequest request, HttpResponse response) throws IOException {
+    public FileHandler(CachingDocumentNIO<T> io) {
+        this.io = io;
+    }
+
+    @Override
+    public void handle(HttpRequest request, HttpResponse response, HttpContext context)
+            throws HttpException, IOException {
+        if(RESTTools.isPost(request)) {
+            handleSaveFile(request, response);
+        } else if (RESTTools.isGet(request)) {
+            if(RESTTools.getParam(request, RemotePipeline.FILENAME_PARAM)!=null) {
+                handleGetFile(request, response);
+            } else {
+                handleGetFilenames(request, response);
+            }
+        } else if (RESTTools.isDelete(request)) {
+            handleDeleteFile(request, response);
+        }
+    }
+
+    @Override
+    public boolean supports(HttpRequest request) {
+        return (RESTTools.isGet(request) || RESTTools.isPost(request) || RESTTools.isDelete(request)) && RESTTools.getBaseUrl(request).equals(RemotePipeline.FILE_URL);
+    }
+
+    @Override
+    public String[] getSupportedUrls() {
+        return new String[] { RemotePipeline.FILE_URL };
+    }
+
+    private void handleSaveFile(HttpRequest request, HttpResponse response) {
+        try {
+            DocumentFile<T> df = getDocumentFile(request);
+
+            if (df == null) {
+                HttpResponseWriter.printBadRequestContent(response);
+            }
+
+            DatabaseDocument<T> md = io.getDocumentById(df.getDocumentId());
+            if (md == null) {
+                HttpResponseWriter.printNoDocument(response);
+                return;
+            }
+
+            io.write(df);
+
+            HttpResponseWriter.printOk(response);
+        } catch (Exception e) {
+            logger.error("An error occurred during file save", e);
+            HttpResponseWriter.printUnhandledException(response, e);
+        }
+    }
+
+    private void handleGetFile(HttpRequest request, HttpResponse response) throws IOException {
         Triple triple = getTriple(request, response);
         if(triple==null) {
-        	return;
+            return;
         }
-        
+
         DatabaseDocument<T> md = io.getDocumentById(triple.docid);
         if(md==null) {
-        	HttpResponseWriter.printNoDocument(response);
-        	return;
+            HttpResponseWriter.printNoDocument(response);
+            return;
         }
-        
+
         DocumentFile<T> df = io.getDocumentFile(md, triple.fileName);
-        
+
         if(df==null) {
-        	HttpResponseWriter.printFileNotFound(response, triple.fileName);
-        	return;
+            HttpResponseWriter.printFileNotFound(response, triple.fileName);
+            return;
         }
-        
+
         HttpResponseWriter.printJson(response, df);
-	}
-	
-	private void handleGetFilenames(HttpRequest request, HttpResponse response) throws IOException {
-		Tuple tuple = getTuple(request, response);
-		
-		if(tuple == null) {
-			return;
-		}
-		
+    }
+
+    private void handleGetFilenames(HttpRequest request, HttpResponse response) throws IOException {
+        Tuple tuple = getTuple(request, response);
+
+        if(tuple == null) {
+            return;
+        }
+
         DatabaseDocument<T> md = io.getDocumentById(tuple.docid);
         if(md==null) {
-        	HttpResponseWriter.printNoDocument(response);
-        	return;
+            HttpResponseWriter.printNoDocument(response);
+            return;
         }
-		
+
         HttpResponseWriter.printJson(response, io.getDocumentFileNames(md));
-	}
-	
-	@SuppressWarnings("unchecked")
-	private DocumentFile<T> getDocumentFile(HttpRequest request) throws ParseException, IOException, JsonException {
+    }
+
+    @SuppressWarnings("unchecked")
+    private DocumentFile<T> getDocumentFile(HttpRequest request) throws ParseException, IOException, JsonException {
         HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request).getEntity();
         String requestContent = EntityUtils.toString(requestEntity, "UTF-8");
 
-		Object o = SerializationUtils.fromJson(requestContent);
-		
-		if(!(o instanceof Map)) {
-			return null;
-		}
-		
-		Map<String, Object> map = (Map<String, Object>) o;
-		DocumentID<T> id = io.toDocumentId(map.get("documentId"));
-		String fileName = (String) map.get("fileName");
-		Date d = (Date) map.get("uploadDate");
-		String encoding = (String) map.get("encoding");
-		String mimetype = (String) map.get("mimetype");
-		String savedByStage = (String) map.get("savedByStage");
-		
-		InputStream is;
-		if(encoding == null) {
-			is = new ByteArrayInputStream(Base64.decodeBase64(((String)map.get("stream")).getBytes("UTF-8")));
-		} else {
-			is = new ByteArrayInputStream(Base64.decodeBase64(((String)map.get("stream")).getBytes(encoding)));
-		}
-		
-		DocumentFile<T> df = new DocumentFile<T>(id, fileName, is, savedByStage, d);
-		df.setEncoding(encoding);
-		df.setMimetype(mimetype);
-		
-		return df;
-	}
-	
-	private void handleDeleteFile(HttpRequest request, HttpResponse response) throws IOException {
-		Triple triple = getTriple(request, response);
-		
-		if(triple == null) {
-			return;
-		}
-		
+        Object o = SerializationUtils.fromJson(requestContent);
+
+        if(!(o instanceof Map)) {
+            return null;
+        }
+
+        Map<String, Object> map = (Map<String, Object>) o;
+        DocumentID<T> id = io.toDocumentId(map.get("documentId"));
+        String fileName = (String) map.get("fileName");
+        Date d = (Date) map.get("uploadDate");
+        String encoding = (String) map.get("encoding");
+        String mimetype = (String) map.get("mimetype");
+        String savedByStage = (String) map.get("savedByStage");
+
+        InputStream is;
+        if(encoding == null) {
+            is = new ByteArrayInputStream(Base64.decodeBase64(((String)map.get("stream")).getBytes("UTF-8")));
+        } else {
+            is = new ByteArrayInputStream(Base64.decodeBase64(((String)map.get("stream")).getBytes(encoding)));
+        }
+
+        DocumentFile<T> df = new DocumentFile<T>(id, fileName, is, savedByStage, d);
+        df.setEncoding(encoding);
+        df.setMimetype(mimetype);
+
+        return df;
+    }
+
+    private void handleDeleteFile(HttpRequest request, HttpResponse response) throws IOException {
+        Triple triple = getTriple(request, response);
+
+        if(triple == null) {
+            return;
+        }
+
         DatabaseDocument<T> md = io.getDocumentById(triple.docid);
         if(md==null) {
-        	HttpResponseWriter.printNoDocument(response);
-        	return;
+            HttpResponseWriter.printNoDocument(response);
+            return;
         }
-        
-       if(io.deleteDocumentFile(md, triple.fileName)) {
-    	   HttpResponseWriter.printFileDeleteOk(response, triple.fileName, md.getID());
-    	   return;
-       } 
-       HttpResponseWriter.printFileNotFound(response, triple.fileName);
-	}
-	
-	private Tuple getTuple(HttpRequest request, HttpResponse response) {
-		Tuple tuple = new Tuple();
-		tuple.stage = RESTTools.getParam(request, RemotePipeline.STAGE_PARAM);
+
+        if(io.deleteDocumentFile(md, triple.fileName)) {
+            HttpResponseWriter.printFileDeleteOk(response, triple.fileName, md.getID());
+            return;
+        }
+        HttpResponseWriter.printFileNotFound(response, triple.fileName);
+    }
+
+    private Tuple getTuple(HttpRequest request, HttpResponse response) {
+        Tuple tuple = new Tuple();
+        tuple.stage = RESTTools.getParam(request, RemotePipeline.STAGE_PARAM);
         if(tuple.stage==null) {
-        	HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
-        	return null;
+            HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
+            return null;
         }
 
-		String rawparam = RESTTools.getParam(request, RemotePipeline.DOCID_PARAM);
-		if(rawparam==null) {
-        	HttpResponseWriter.printMissingParameter(response, RemotePipeline.DOCID_PARAM);
-        	return null;
+        String rawparam = RESTTools.getParam(request, RemotePipeline.DOCID_PARAM);
+        if(rawparam==null) {
+            HttpResponseWriter.printMissingParameter(response, RemotePipeline.DOCID_PARAM);
+            return null;
         }
-		try {
-			tuple.docid = io.toDocumentIdFromJson(URLDecoder.decode(rawparam, "UTF-8"));
-		} catch (UnsupportedEncodingException e) {
-			
-		}
-		if(tuple.docid==null) {
-        	HttpResponseWriter.printUnhandledException(response, new SerializationException("Unable to deserialize the parameter "+RemotePipeline.DOCID_PARAM));
-        	return null;
+        try {
+            tuple.docid = io.toDocumentIdFromJson(URLDecoder.decode(rawparam, "UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+
         }
-        
+        if(tuple.docid==null) {
+            HttpResponseWriter.printUnhandledException(response, new SerializationException("Unable to deserialize the parameter "+RemotePipeline.DOCID_PARAM));
+            return null;
+        }
+
         return tuple;
-	}
-	
-	private Triple getTriple(HttpRequest request, HttpResponse response) {
-		Triple triple = new Triple();
+    }
 
-		Tuple tuple = getTuple(request, response);
-		if(tuple==null) {
-			return null;
-		}
-		
-		triple.docid = tuple.docid;
-		triple.stage = tuple.stage;
-        
+    private Triple getTriple(HttpRequest request, HttpResponse response) {
+        Triple triple = new Triple();
+
+        Tuple tuple = getTuple(request, response);
+        if(tuple==null) {
+            return null;
+        }
+
+        triple.docid = tuple.docid;
+        triple.stage = tuple.stage;
+
         triple.fileName = RESTTools.getParam(request, RemotePipeline.FILENAME_PARAM);
         if(triple.fileName==null) {
-        	HttpResponseWriter.printMissingParameter(response, RemotePipeline.FILENAME_PARAM);
-        	return null;
+            HttpResponseWriter.printMissingParameter(response, RemotePipeline.FILENAME_PARAM);
+            return null;
         }
-        
+
         return triple;
-	}
-	
-	private class Tuple {
-		String stage;
-		DocumentID<T> docid;
-	}
-	
-	private class Triple {
-		@SuppressWarnings("unused")
-		String stage;
-		DocumentID<T> docid;
-		String fileName;
-	}
+    }
+
+    private class Tuple {
+        String stage;
+        DocumentID<T> docid;
+    }
+
+    private class Triple {
+        String stage;
+        DocumentID<T> docid;
+        String fileName;
+    }
 }

--- a/core/src/main/java/com/findwise/hydra/net/FileHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/FileHandler.java
@@ -8,6 +8,7 @@ import java.net.URLDecoder;
 import java.util.Date;
 import java.util.Map;
 
+import com.findwise.hydra.local.HttpEndpointConstants;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.SerializationException;
 import org.apache.http.HttpEntity;
@@ -28,7 +29,6 @@ import com.findwise.hydra.DocumentFile;
 import com.findwise.hydra.DocumentID;
 import com.findwise.hydra.JsonException;
 import com.findwise.hydra.SerializationUtils;
-import com.findwise.hydra.local.RemotePipeline;
 
 public class FileHandler<T extends DatabaseType> implements ResponsibleHandler {
 
@@ -46,7 +46,7 @@ public class FileHandler<T extends DatabaseType> implements ResponsibleHandler {
         if(RESTTools.isPost(request)) {
             handleSaveFile(request, response);
         } else if (RESTTools.isGet(request)) {
-            if(RESTTools.getParam(request, RemotePipeline.FILENAME_PARAM)!=null) {
+            if(RESTTools.getParam(request, HttpEndpointConstants.FILENAME_PARAM)!=null) {
                 handleGetFile(request, response);
             } else {
                 handleGetFilenames(request, response);
@@ -58,12 +58,12 @@ public class FileHandler<T extends DatabaseType> implements ResponsibleHandler {
 
     @Override
     public boolean supports(HttpRequest request) {
-        return (RESTTools.isGet(request) || RESTTools.isPost(request) || RESTTools.isDelete(request)) && RESTTools.getBaseUrl(request).equals(RemotePipeline.FILE_URL);
+        return (RESTTools.isGet(request) || RESTTools.isPost(request) || RESTTools.isDelete(request)) && RESTTools.getBaseUrl(request).equals(HttpEndpointConstants.FILE_URL);
     }
 
     @Override
     public String[] getSupportedUrls() {
-        return new String[] { RemotePipeline.FILE_URL };
+        return new String[] { HttpEndpointConstants.FILE_URL };
     }
 
     private void handleSaveFile(HttpRequest request, HttpResponse response) {
@@ -182,15 +182,15 @@ public class FileHandler<T extends DatabaseType> implements ResponsibleHandler {
 
     private Tuple getTuple(HttpRequest request, HttpResponse response) {
         Tuple tuple = new Tuple();
-        tuple.stage = RESTTools.getParam(request, RemotePipeline.STAGE_PARAM);
+        tuple.stage = RESTTools.getParam(request, HttpEndpointConstants.STAGE_PARAM);
         if(tuple.stage==null) {
-            HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
+            HttpResponseWriter.printMissingParameter(response, HttpEndpointConstants.STAGE_PARAM);
             return null;
         }
 
-        String rawparam = RESTTools.getParam(request, RemotePipeline.DOCID_PARAM);
+        String rawparam = RESTTools.getParam(request, HttpEndpointConstants.DOCID_PARAM);
         if(rawparam==null) {
-            HttpResponseWriter.printMissingParameter(response, RemotePipeline.DOCID_PARAM);
+            HttpResponseWriter.printMissingParameter(response, HttpEndpointConstants.DOCID_PARAM);
             return null;
         }
         try {
@@ -199,7 +199,7 @@ public class FileHandler<T extends DatabaseType> implements ResponsibleHandler {
 
         }
         if(tuple.docid==null) {
-            HttpResponseWriter.printUnhandledException(response, new SerializationException("Unable to deserialize the parameter "+RemotePipeline.DOCID_PARAM));
+            HttpResponseWriter.printUnhandledException(response, new SerializationException("Unable to deserialize the parameter "+ HttpEndpointConstants.DOCID_PARAM));
             return null;
         }
 
@@ -217,9 +217,9 @@ public class FileHandler<T extends DatabaseType> implements ResponsibleHandler {
         triple.docid = tuple.docid;
         triple.stage = tuple.stage;
 
-        triple.fileName = RESTTools.getParam(request, RemotePipeline.FILENAME_PARAM);
+        triple.fileName = RESTTools.getParam(request, HttpEndpointConstants.FILENAME_PARAM);
         if(triple.fileName==null) {
-            HttpResponseWriter.printMissingParameter(response, RemotePipeline.FILENAME_PARAM);
+            HttpResponseWriter.printMissingParameter(response, HttpEndpointConstants.FILENAME_PARAM);
             return null;
         }
 

--- a/core/src/main/java/com/findwise/hydra/net/HttpRESTHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/HttpRESTHandler.java
@@ -22,175 +22,175 @@ import com.findwise.hydra.NoopCache;
 import com.findwise.hydra.PipelineReader;
 
 public class HttpRESTHandler<T extends DatabaseType> implements
-		ResponsibleHandler {
-	private Logger logger = LoggerFactory.getLogger(HttpRESTHandler.class);
+        ResponsibleHandler {
+    private Logger logger = LoggerFactory.getLogger(HttpRESTHandler.class);
 
-	private CachingDocumentNIO<T> documentIO;
-	private PipelineReader pipelineReader;
+    private CachingDocumentNIO<T> documentIO;
+    private PipelineReader pipelineReader;
 
-	private boolean performanceLogging = false;
+    private boolean performanceLogging = false;
 
-	private String restId;
+    private String restId;
 
-	private List<String> allowedHosts;
+    private List<String> allowedHosts;
 
-	private List<InetAddress> resolvedHosts;
+    private List<InetAddress> resolvedHosts;
 
-	private ResponsibleHandler[] handlers;
+    private ResponsibleHandler[] handlers;
 
-	private PingHandler pingHandler;
+    private PingHandler pingHandler;
 
-	private PingHandler getPingHandler() {
-		if (pingHandler == null) {
-			pingHandler = new PingHandler(restId);
-		}
-		return pingHandler;
-	}
-	
-	public HttpRESTHandler(DatabaseConnector<T> dbc) {
-		this(new CachingDocumentNIO<T>(dbc, new NoopCache<T>()), dbc
-				.getPipelineReader(), null, false);
-	}
+    private PingHandler getPingHandler() {
+        if (pingHandler == null) {
+            pingHandler = new PingHandler(restId);
+        }
+        return pingHandler;
+    }
 
-	public HttpRESTHandler(CachingDocumentNIO<T> documentIO,
-			PipelineReader pipelineReader, List<String> allowedHosts,
-			boolean isPerformanceLogging) {
-		this.documentIO = documentIO;
-		this.pipelineReader = pipelineReader;
-		this.setAllowedHosts(allowedHosts);
-		this.performanceLogging = isPerformanceLogging;
-	}
+    public HttpRESTHandler(DatabaseConnector<T> dbc) {
+        this(new CachingDocumentNIO<T>(dbc, new NoopCache<T>()), dbc
+                .getPipelineReader(), null, false);
+    }
 
-	private void createHandlers() {
-		handlers = new ResponsibleHandler[] { new FileHandler<T>(documentIO),
-				new PropertiesHandler<T>(pipelineReader),
-				new MarkHandler<T>(documentIO, performanceLogging),
-				new QueryHandler<T>(documentIO, performanceLogging),
-				new ReleaseHandler<T>(documentIO),
-				new WriteHandler<T>(documentIO, performanceLogging) };
-	}
+    public HttpRESTHandler(CachingDocumentNIO<T> documentIO,
+                           PipelineReader pipelineReader, List<String> allowedHosts,
+                           boolean isPerformanceLogging) {
+        this.documentIO = documentIO;
+        this.pipelineReader = pipelineReader;
+        this.setAllowedHosts(allowedHosts);
+        this.performanceLogging = isPerformanceLogging;
+    }
 
-	private ResponsibleHandler[] getHandlers() {
-		if (handlers == null) {
-			createHandlers();
-		}
-		return handlers;
-	}
+    private void createHandlers() {
+        handlers = new ResponsibleHandler[] { new FileHandler<T>(documentIO),
+                new PropertiesHandler<T>(pipelineReader),
+                new MarkHandler<T>(documentIO, performanceLogging),
+                new QueryHandler<T>(documentIO, performanceLogging),
+                new ReleaseHandler<T>(documentIO),
+                new WriteHandler<T>(documentIO, performanceLogging) };
+    }
 
-	public void setRestId(String restId) {
-		getPingHandler().setServerId(restId);
-	}
+    private ResponsibleHandler[] getHandlers() {
+        if (handlers == null) {
+            createHandlers();
+        }
+        return handlers;
+    }
 
-	public boolean dispatch(HttpRequest request, HttpResponse response,
-			HttpContext context, ResponsibleHandler... handlers)
-			throws HttpException, IOException {
-		for (ResponsibleHandler handler : handlers) {
-			if (handler.supports(request)) {
-				handler.handle(request, response, context);
-				return true;
-			}
-		}
-		return false;
-	}
+    public void setRestId(String restId) {
+        getPingHandler().setServerId(restId);
+    }
 
-	@Override
-	public void handle(final HttpRequest request, final HttpResponse response,
-			final HttpContext context) {
-		if (!accessAllowed(context)) {
-			HttpResponseWriter.printAccessDenied(response);
-			return;
-		}
-		try {
-			logger.trace("Parsing incoming request");
+    public boolean dispatch(HttpRequest request, HttpResponse response,
+                            HttpContext context, ResponsibleHandler... handlers)
+            throws HttpException, IOException {
+        for (ResponsibleHandler handler : handlers) {
+            if (handler.supports(request)) {
+                handler.handle(request, response, context);
+                return true;
+            }
+        }
+        return false;
+    }
 
-			if (dispatch(request, response, context, getPingHandler())) {
-				return;
-			}
+    @Override
+    public void handle(final HttpRequest request, final HttpResponse response,
+                       final HttpContext context) {
+        if (!accessAllowed(context)) {
+            HttpResponseWriter.printAccessDenied(response);
+            return;
+        }
+        try {
+            logger.trace("Parsing incoming request");
 
-			if (dispatch(request, response, context, getHandlers())) {
-				return;
-			}
+            if (dispatch(request, response, context, getPingHandler())) {
+                return;
+            }
 
-			HttpResponseWriter.printUnsupportedRequest(response);
-		} catch (Exception e) {
-			logger.error("Unhandled exception occurred", e);
-			HttpResponseWriter.printUnhandledException(response, e);
-			System.exit(1);
-		}
-	}
+            if (dispatch(request, response, context, getHandlers())) {
+                return;
+            }
 
-	public boolean accessAllowed(HttpContext context) {
-		if (allowedHosts == null) {
-			return true;
-		}
-		try {
-			HttpInetConnection connection = (HttpInetConnection) context
-					.getAttribute(ExecutionContext.HTTP_CONNECTION);
-			InetAddress ia = connection.getRemoteAddress();
+            HttpResponseWriter.printUnsupportedRequest(response);
+        } catch (Exception e) {
+            logger.error("Unhandled exception occurred", e);
+            HttpResponseWriter.printUnhandledException(response, e);
+            System.exit(1);
+        }
+    }
 
-			if(resolvedHosts.contains(ia)) {
-				return true;
-			} else {
-				logger.error("Caller adress ("+ia+") not in the list of allowed hosts ("+allowedHosts+"). Refusing the connection.");
-				return false;
-			}
-		} catch (Exception e) {
-			logger.error("Caught an exception while trying to determine remote address. Refusing the connection.");
-		}
-		return false;
-	}
+    public boolean accessAllowed(HttpContext context) {
+        if (allowedHosts == null) {
+            return true;
+        }
+        try {
+            HttpInetConnection connection = (HttpInetConnection) context
+                    .getAttribute(ExecutionContext.HTTP_CONNECTION);
+            InetAddress ia = connection.getRemoteAddress();
 
-	@Override
-	public boolean supports(HttpRequest request) {
-		if (getPingHandler().supports(request)) {
-			return true;
-		}
-		for (ResponsibleHandler handler : handlers) {
-			if (handler.supports(request)) {
-				return true;
-			}
-		}
-		return false;
-	}
+            if(resolvedHosts.contains(ia)) {
+                return true;
+            } else {
+                logger.error("Caller adress ("+ia+") not in the list of allowed hosts ("+allowedHosts+"). Refusing the connection.");
+                return false;
+            }
+        } catch (Exception e) {
+            logger.error("Caught an exception while trying to determine remote address. Refusing the connection.");
+        }
+        return false;
+    }
 
-	@Override
-	public String[] getSupportedUrls() {
-		List<String> urls = new ArrayList<String>();
-		addArrayToList(getPingHandler().getSupportedUrls(), urls);
-		for (ResponsibleHandler handler : getHandlers()) {
-			addArrayToList(handler.getSupportedUrls(), urls);
-		}
-		return urls.toArray(new String[urls.size()]);
-	}
+    @Override
+    public boolean supports(HttpRequest request) {
+        if (getPingHandler().supports(request)) {
+            return true;
+        }
+        for (ResponsibleHandler handler : handlers) {
+            if (handler.supports(request)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	private static <T> void addArrayToList(T[] array, List<T> list) {
-		for (T t : array) {
-			list.add(t);
-		}
-	}
+    @Override
+    public String[] getSupportedUrls() {
+        List<String> urls = new ArrayList<String>();
+        addArrayToList(getPingHandler().getSupportedUrls(), urls);
+        for (ResponsibleHandler handler : getHandlers()) {
+            addArrayToList(handler.getSupportedUrls(), urls);
+        }
+        return urls.toArray(new String[urls.size()]);
+    }
 
-	public void setAllowedHosts(List<String> allowedHosts) {
-		this.allowedHosts = allowedHosts;
-		resolveAllowedHosts();
-	}
+    private static <T> void addArrayToList(T[] array, List<T> list) {
+        for (T t : array) {
+            list.add(t);
+        }
+    }
 
-	private void resolveAllowedHosts() {
-		if( allowedHosts == null) {
-			resolvedHosts = null;
-		} else {
-			resolvedHosts = new ArrayList<InetAddress>();
-			for(String allowedHost: allowedHosts) {
-				try {
-					resolvedHosts.add(InetAddress.getByName(allowedHost));
-				} catch (UnknownHostException e) {
+    public void setAllowedHosts(List<String> allowedHosts) {
+        this.allowedHosts = allowedHosts;
+        resolveAllowedHosts();
+    }
+
+    private void resolveAllowedHosts() {
+        if( allowedHosts == null) {
+            resolvedHosts = null;
+        } else {
+            resolvedHosts = new ArrayList<InetAddress>();
+            for(String allowedHost: allowedHosts) {
+                try {
+                    resolvedHosts.add(InetAddress.getByName(allowedHost));
+                } catch (UnknownHostException e) {
 					/* Fail early if configuration is wrong */
-					throw new RuntimeException("Could not resolve host: " + allowedHost, e);
-				}
-			}
-		}
-	}
+                    throw new RuntimeException("Could not resolve host: " + allowedHost, e);
+                }
+            }
+        }
+    }
 
-	public List<String> getAllowedHosts() {
-		return allowedHosts;
-	}
+    public List<String> getAllowedHosts() {
+        return allowedHosts;
+    }
 }

--- a/core/src/main/java/com/findwise/hydra/net/HttpResponseWriter.java
+++ b/core/src/main/java/com/findwise/hydra/net/HttpResponseWriter.java
@@ -13,152 +13,152 @@ import com.findwise.hydra.SerializationUtils;
 
 /**
  * This class provides methods for writing output to a HttpResponse.
- * 
+ *
  * @author joel.westberg
  */
 public final class HttpResponseWriter {
-	private static Logger logger = LoggerFactory.getLogger(HttpResponseWriter.class);
+    private static Logger logger = LoggerFactory.getLogger(HttpResponseWriter.class);
 
-	private HttpResponseWriter() {} // Should not be possible to instantiate
-	
-	public static final ContentType CONTENT_TYPE = ContentType.create("application/json", "UTF-8");
+    private HttpResponseWriter() {} // Should not be possible to instantiate
 
-	private static void setStringEntity(HttpResponse response, String content) {
-		response.setEntity(new NStringEntity(content, CONTENT_TYPE));
-	}
-	
-	protected static void printDocument(HttpResponse response, Document<?> d, String stage) {
-		logger.debug("Printing document with ID " + d.getID() + " to stage " + stage);
-		response.setStatusCode(HttpStatus.SC_OK);
-		setStringEntity(response, d.toJson());
-	}
+    public static final ContentType CONTENT_TYPE = ContentType.create("application/json", "UTF-8");
 
-	protected static void printDocumentReleased(HttpResponse response) {
-		logger.debug("Printing release successful");
-		response.setStatusCode(HttpStatus.SC_OK);
-		setStringEntity(response, "Document successfully released");
-	}
+    private static void setStringEntity(HttpResponse response, String content) {
+        response.setEntity(new NStringEntity(content, CONTENT_TYPE));
+    }
 
-	protected static void printNoDocument(HttpResponse response) {
-		logger.trace("Printing no document found");
-		response.setStatusCode(HttpStatus.SC_NOT_FOUND);
-		setStringEntity(response, "No document found matching your query");
-	}
-	
-	protected static void printUpdateFailed(HttpResponse response, Object id) {
-		logger.debug("Printing updateFailed for id:"+id);
-		response.setStatusCode(HttpStatus.SC_NOT_FOUND);
-		setStringEntity(response, "Update of your document failed. Sent ID { _id : '"+id+"' } probably doesn't exist.");
-	}
+    protected static void printDocument(HttpResponse response, Document<?> d, String stage) {
+        logger.debug("Printing document with ID " + d.getID() + " to stage " + stage);
+        response.setStatusCode(HttpStatus.SC_OK);
+        setStringEntity(response, d.toJson());
+    }
 
-	protected static void printDeadNode(HttpResponse response) {
-		logger.debug("Printing node is dead");
-		response.setStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-		setStringEntity(response, "Node appears to be dead");
-	}
+    protected static void printDocumentReleased(HttpResponse response) {
+        logger.debug("Printing release successful");
+        response.setStatusCode(HttpStatus.SC_OK);
+        setStringEntity(response, "Document successfully released");
+    }
 
-	protected static void printNotPost(HttpResponse response) {
-		logger.debug("Received bad request (not post)");
-		response.setStatusCode(HttpStatus.SC_BAD_REQUEST);
-		setStringEntity(response, "Use POST to talk to the Node");
-	}
+    protected static void printNoDocument(HttpResponse response) {
+        logger.trace("Printing no document found");
+        response.setStatusCode(HttpStatus.SC_NOT_FOUND);
+        setStringEntity(response, "No document found matching your query");
+    }
 
-	protected static void printJsonException(HttpResponse response, JsonException e) {
-		logger.error("Received bad JSON");
-		response.setStatusCode(HttpStatus.SC_BAD_REQUEST);
-		setStringEntity(response, "Unable to parse query: " + e.getMessage());
-	}
+    protected static void printUpdateFailed(HttpResponse response, Object id) {
+        logger.debug("Printing updateFailed for id:"+id);
+        response.setStatusCode(HttpStatus.SC_NOT_FOUND);
+        setStringEntity(response, "Update of your document failed. Sent ID { _id : '"+id+"' } probably doesn't exist.");
+    }
 
-	protected static void printUnsupportedRequest(HttpResponse response) {
-		logger.error("Request not understood");
-		response.setStatusCode(HttpStatus.SC_BAD_REQUEST);
-		setStringEntity(response, "Unimplemented action");
-	}
+    protected static void printDeadNode(HttpResponse response) {
+        logger.debug("Printing node is dead");
+        response.setStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        setStringEntity(response, "Node appears to be dead");
+    }
 
-	protected static void printMissingID(HttpResponse response) {
-		logger.error("Submitted document was missing the required ID field");
-		response.setStatusCode(HttpStatus.SC_BAD_REQUEST);
-		setStringEntity(response, "Submitted document was missing the required ID field");
-	}
+    protected static void printNotPost(HttpResponse response) {
+        logger.debug("Received bad request (not post)");
+        response.setStatusCode(HttpStatus.SC_BAD_REQUEST);
+        setStringEntity(response, "Use POST to talk to the Node");
+    }
 
-	protected static void printMissingParameter(HttpResponse response, String param) {
-		logger.error(param + " parameter is missing from request");
-		response.setStatusCode(HttpStatus.SC_BAD_REQUEST);
-		setStringEntity(response, "Parameter '" + param + "' is missing from request URI");
-	}
-	
-	protected static void printOk(HttpResponse response) {
-		response.setStatusCode(HttpStatus.SC_NO_CONTENT);
-	}
+    protected static void printJsonException(HttpResponse response, JsonException e) {
+        logger.error("Received bad JSON");
+        response.setStatusCode(HttpStatus.SC_BAD_REQUEST);
+        setStringEntity(response, "Unable to parse query: " + e.getMessage());
+    }
 
-	protected static void printSaveOk(HttpResponse response, Object id) {
-		logger.debug("Successfully saved Document with ID: " + id);
-		response.setStatusCode(HttpStatus.SC_OK);
-		setStringEntity(response, "Document " + id + " successfully saved");
-	}
-	
-	protected static void printSaveFailed(HttpResponse response, Object id) {
-		response.setStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-		setStringEntity(response, "Unable to update document with id:"+id);
-	}
-	
-	protected static void printFileDeleteOk(HttpResponse response, String filename, Object id) {
-		logger.debug("Successfully deleted file with filename: "+filename+" from document " + id);
-		response.setStatusCode(HttpStatus.SC_OK);
-		setStringEntity(response, "File " + id + " successfully deleted");
-	}
+    protected static void printUnsupportedRequest(HttpResponse response) {
+        logger.error("Request not understood");
+        response.setStatusCode(HttpStatus.SC_BAD_REQUEST);
+        setStringEntity(response, "Unimplemented action");
+    }
 
-	protected static void printInsertOk(HttpResponse response, Document<?> d) {
-		logger.debug("Successfully inserted a document with ID: " + d.getID());
-		response.setStatusCode(HttpStatus.SC_OK);
-		setStringEntity(response, d.contentFieldsToJson(null));
-	}
+    protected static void printMissingID(HttpResponse response) {
+        logger.error("Submitted document was missing the required ID field");
+        response.setStatusCode(HttpStatus.SC_BAD_REQUEST);
+        setStringEntity(response, "Submitted document was missing the required ID field");
+    }
 
-	protected static void printInsertFailed(HttpResponse response) {
-		logger.error("Failed to insert the document");
-		response.setStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-		setStringEntity(response, "An error occurred while inserting the document");
-	}
+    protected static void printMissingParameter(HttpResponse response, String param) {
+        logger.error(param + " parameter is missing from request");
+        response.setStatusCode(HttpStatus.SC_BAD_REQUEST);
+        setStringEntity(response, "Parameter '" + param + "' is missing from request URI");
+    }
 
-	protected static void printReleaseFailed(HttpResponse response) {
-		logger.error("Failed to release the document");
-		response.setStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-		setStringEntity(response, "An error occurred while releasing the document");
-	}
+    protected static void printOk(HttpResponse response) {
+        response.setStatusCode(HttpStatus.SC_NO_CONTENT);
+    }
 
-	protected static void printUnhandledException(HttpResponse response, Exception e) {
-		logger.error("Printing Unhandled Exception");
-		response.setStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-		setStringEntity(response, "An internal server error occurred with the message " + e.getMessage());
-	}
-	
-	protected static void printBadRequestContent(HttpResponse response) {
-		logger.error("Printing Bad Request Content");
-		response.setStatusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
-		setStringEntity(response, "Bad Request content. Content not understood.");
-	}
-	
-	protected static void printJson(HttpResponse response, Object o) {
-		logger.debug("Printing a JSON response.");
-		response.setStatusCode(HttpStatus.SC_OK);
-		setStringEntity(response, SerializationUtils.toJson(o));
-	}
+    protected static void printSaveOk(HttpResponse response, Object id) {
+        logger.debug("Successfully saved Document with ID: " + id);
+        response.setStatusCode(HttpStatus.SC_OK);
+        setStringEntity(response, "Document " + id + " successfully saved");
+    }
 
-	protected static void printID(HttpResponse response, String uuid) {
-		logger.info("Got ID ping!");
-		response.setStatusCode(HttpStatus.SC_OK);
-		setStringEntity(response, uuid);
-	}
+    protected static void printSaveFailed(HttpResponse response, Object id) {
+        response.setStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        setStringEntity(response, "Unable to update document with id:"+id);
+    }
 
-	protected static void printAccessDenied(HttpResponse response) {
-		logger.warn("Denying access");
-		response.setStatusCode(HttpStatus.SC_FORBIDDEN);
-		setStringEntity(response, "Access forbidden");
-	}
+    protected static void printFileDeleteOk(HttpResponse response, String filename, Object id) {
+        logger.debug("Successfully deleted file with filename: "+filename+" from document " + id);
+        response.setStatusCode(HttpStatus.SC_OK);
+        setStringEntity(response, "File " + id + " successfully deleted");
+    }
 
-	protected static void printFileNotFound(HttpResponse response, String fileName) {
-		logger.debug("Printing no file found");
-		response.setStatusCode(HttpStatus.SC_NOT_FOUND);
-		setStringEntity(response, "No file found by the name "+fileName+" for this document");
-	}
+    protected static void printInsertOk(HttpResponse response, Document<?> d) {
+        logger.debug("Successfully inserted a document with ID: " + d.getID());
+        response.setStatusCode(HttpStatus.SC_OK);
+        setStringEntity(response, d.contentFieldsToJson(null));
+    }
+
+    protected static void printInsertFailed(HttpResponse response) {
+        logger.error("Failed to insert the document");
+        response.setStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        setStringEntity(response, "An error occurred while inserting the document");
+    }
+
+    protected static void printReleaseFailed(HttpResponse response) {
+        logger.error("Failed to release the document");
+        response.setStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        setStringEntity(response, "An error occurred while releasing the document");
+    }
+
+    protected static void printUnhandledException(HttpResponse response, Exception e) {
+        logger.error("Printing Unhandled Exception");
+        response.setStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        setStringEntity(response, "An internal server error occurred with the message " + e.getMessage());
+    }
+
+    protected static void printBadRequestContent(HttpResponse response) {
+        logger.error("Printing Bad Request Content");
+        response.setStatusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+        setStringEntity(response, "Bad Request content. Content not understood.");
+    }
+
+    protected static void printJson(HttpResponse response, Object o) {
+        logger.debug("Printing a JSON response.");
+        response.setStatusCode(HttpStatus.SC_OK);
+        setStringEntity(response, SerializationUtils.toJson(o));
+    }
+
+    protected static void printID(HttpResponse response, String uuid) {
+        logger.info("Got ID ping!");
+        response.setStatusCode(HttpStatus.SC_OK);
+        setStringEntity(response, uuid);
+    }
+
+    protected static void printAccessDenied(HttpResponse response) {
+        logger.warn("Denying access");
+        response.setStatusCode(HttpStatus.SC_FORBIDDEN);
+        setStringEntity(response, "Access forbidden");
+    }
+
+    protected static void printFileNotFound(HttpResponse response, String fileName) {
+        logger.debug("Printing no file found");
+        response.setStatusCode(HttpStatus.SC_NOT_FOUND);
+        setStringEntity(response, "No file found by the name "+fileName+" for this document");
+    }
 }

--- a/core/src/main/java/com/findwise/hydra/net/MarkHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/MarkHandler.java
@@ -21,113 +21,113 @@ import com.findwise.hydra.local.LocalDocument;
 import com.findwise.hydra.local.RemotePipeline;
 
 public class MarkHandler<T extends DatabaseType> implements ResponsibleHandler {
-	private enum Mark {
-		PENDING, PROCESSED, DISCARDED, FAILED
-	};
+    private enum Mark {
+        PENDING, PROCESSED, DISCARDED, FAILED
+    };
 
-	private static Logger logger = LoggerFactory.getLogger(MarkHandler.class);
+    private static Logger logger = LoggerFactory.getLogger(MarkHandler.class);
 
-	private CachingDocumentNIO<T> io;
-	private boolean performanceLogging = false;
-	
-	public MarkHandler(CachingDocumentNIO<T> io, boolean performanceLogging) {
-		this.io = io;
-		this.performanceLogging = performanceLogging;
-	}
+    private CachingDocumentNIO<T> io;
+    private boolean performanceLogging = false;
 
-	@Override
-	public void handle(HttpRequest request, HttpResponse response,
-			HttpContext context) throws HttpException, IOException {
-		long start = System.currentTimeMillis();
-		HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request)
-				.getEntity();
-		String requestContent = EntityUtils.toString(requestEntity);
-		long tostring = System.currentTimeMillis();
-		String stage = RESTTools.getParam(request, RemotePipeline.STAGE_PARAM);
-		if (stage == null) {
-			HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
-			return;
-		}
+    public MarkHandler(CachingDocumentNIO<T> io, boolean performanceLogging) {
+        this.io = io;
+        this.performanceLogging = performanceLogging;
+    }
 
-		DatabaseDocument<T> md;
-		try {
-			md = io.convert(new LocalDocument(requestContent));
-		} catch (JsonException e) {
-			HttpResponseWriter.printJsonException(response, e);
-			return;
-		} catch (ConversionException e) {
-			logger.error("Caught Exception when trying to convert "+requestContent, e);
-			HttpResponseWriter.printBadRequestContent(response);
-			return;
-		}
-		long convert = System.currentTimeMillis();
-		
-		DatabaseDocument<T> dbdoc = io.getDocumentById(md.getID());
-		long query = System.currentTimeMillis();
-		if(dbdoc==null) {
-			HttpResponseWriter.printNoDocument(response);
-			return;
-		}
-		
-		dbdoc.putAll(md);
+    @Override
+    public void handle(HttpRequest request, HttpResponse response,
+                       HttpContext context) throws HttpException, IOException {
+        long start = System.currentTimeMillis();
+        HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request)
+                .getEntity();
+        String requestContent = EntityUtils.toString(requestEntity);
+        long tostring = System.currentTimeMillis();
+        String stage = RESTTools.getParam(request, RemotePipeline.STAGE_PARAM);
+        if (stage == null) {
+            HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
+            return;
+        }
 
-		if (!mark(dbdoc, stage, getMark(request))) {
-			HttpResponseWriter.printNoDocument(response);
-		} else {
-			HttpResponseWriter.printSaveOk(response, md.getID());
-		}
-		if(performanceLogging) {
-			long end = System.currentTimeMillis();
-			logger.info(String.format("type=performance event=processed stage_name=%s doc_id=%s start=%d end=%d total=%d entitystring=%d parse=%d query=%d serialize=%d", stage, md.getID(), start, end, end-start, tostring-start, convert-tostring, query-convert, end-query));
-		}
-	}
-	
-	private Mark getMark(HttpRequest request) {
-		String uri = RESTTools.getBaseUrl(request);
-		if (uri.equals(RemotePipeline.PROCESSED_DOCUMENT_URL)) {
-			return Mark.PROCESSED;
-		} else if (uri.equals(RemotePipeline.PENDING_DOCUMENT_URL)) {
-			return Mark.PENDING;
-		} else if (uri.equals(RemotePipeline.DISCARDED_DOCUMENT_URL)) {
-			return Mark.DISCARDED;
-		} else if (uri.equals(RemotePipeline.FAILED_DOCUMENT_URL)) {
-			return Mark.FAILED;
-		}
-		return null;
-	}
+        DatabaseDocument<T> md;
+        try {
+            md = io.convert(new LocalDocument(requestContent));
+        } catch (JsonException e) {
+            HttpResponseWriter.printJsonException(response, e);
+            return;
+        } catch (ConversionException e) {
+            logger.error("Caught Exception when trying to convert "+requestContent, e);
+            HttpResponseWriter.printBadRequestContent(response);
+            return;
+        }
+        long convert = System.currentTimeMillis();
 
-	private boolean mark(DatabaseDocument<T> md, String stage, Mark mark) throws IOException {
-		logger.trace("handleMark(..., ..., " + mark.toString() + ")");
+        DatabaseDocument<T> dbdoc = io.getDocumentById(md.getID());
+        long query = System.currentTimeMillis();
+        if(dbdoc==null) {
+            HttpResponseWriter.printNoDocument(response);
+            return;
+        }
 
-		switch (mark) {
-		case PENDING: {
-			return io.markPending(md, stage);
-			
-		}
-		case PROCESSED: {
-			return io.markProcessed(md, stage);
-		}
-		case FAILED: {
-			return io.markFailed(md, stage);
-		}
-		case DISCARDED: {
-			return io.markDiscarded(md, stage);
-		}
-		}
-		return false;
-	}
+        dbdoc.putAll(md);
 
-	@Override
-	public boolean supports(HttpRequest request) {
-		return RESTTools.isPost(request) && getMark(request)!=null;
-	}
+        if (!mark(dbdoc, stage, getMark(request))) {
+            HttpResponseWriter.printNoDocument(response);
+        } else {
+            HttpResponseWriter.printSaveOk(response, md.getID());
+        }
+        if(performanceLogging) {
+            long end = System.currentTimeMillis();
+            logger.info(String.format("type=performance event=processed stage_name=%s doc_id=%s start=%d end=%d total=%d entitystring=%d parse=%d query=%d serialize=%d", stage, md.getID(), start, end, end-start, tostring-start, convert-tostring, query-convert, end-query));
+        }
+    }
 
-	@Override
-	public String[] getSupportedUrls() {
-		return new String[] { RemotePipeline.DISCARDED_DOCUMENT_URL,
-				RemotePipeline.FAILED_DOCUMENT_URL,
-				RemotePipeline.PROCESSED_DOCUMENT_URL,
-				RemotePipeline.PENDING_DOCUMENT_URL };
-	}
+    private Mark getMark(HttpRequest request) {
+        String uri = RESTTools.getBaseUrl(request);
+        if (uri.equals(RemotePipeline.PROCESSED_DOCUMENT_URL)) {
+            return Mark.PROCESSED;
+        } else if (uri.equals(RemotePipeline.PENDING_DOCUMENT_URL)) {
+            return Mark.PENDING;
+        } else if (uri.equals(RemotePipeline.DISCARDED_DOCUMENT_URL)) {
+            return Mark.DISCARDED;
+        } else if (uri.equals(RemotePipeline.FAILED_DOCUMENT_URL)) {
+            return Mark.FAILED;
+        }
+        return null;
+    }
+
+    private boolean mark(DatabaseDocument<T> md, String stage, Mark mark) throws IOException {
+        logger.trace("handleMark(..., ..., " + mark.toString() + ")");
+
+        switch (mark) {
+            case PENDING: {
+                return io.markPending(md, stage);
+
+            }
+            case PROCESSED: {
+                return io.markProcessed(md, stage);
+            }
+            case FAILED: {
+                return io.markFailed(md, stage);
+            }
+            case DISCARDED: {
+                return io.markDiscarded(md, stage);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean supports(HttpRequest request) {
+        return RESTTools.isPost(request) && getMark(request)!=null;
+    }
+
+    @Override
+    public String[] getSupportedUrls() {
+        return new String[] { RemotePipeline.DISCARDED_DOCUMENT_URL,
+                RemotePipeline.FAILED_DOCUMENT_URL,
+                RemotePipeline.PROCESSED_DOCUMENT_URL,
+                RemotePipeline.PENDING_DOCUMENT_URL };
+    }
 
 }

--- a/core/src/main/java/com/findwise/hydra/net/MarkHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/MarkHandler.java
@@ -2,6 +2,7 @@ package com.findwise.hydra.net;
 
 import java.io.IOException;
 
+import com.findwise.hydra.local.HttpEndpointConstants;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpException;
@@ -18,7 +19,6 @@ import com.findwise.hydra.DatabaseDocument;
 import com.findwise.hydra.DatabaseType;
 import com.findwise.hydra.JsonException;
 import com.findwise.hydra.local.LocalDocument;
-import com.findwise.hydra.local.RemotePipeline;
 
 public class MarkHandler<T extends DatabaseType> implements ResponsibleHandler {
     private enum Mark {
@@ -43,9 +43,9 @@ public class MarkHandler<T extends DatabaseType> implements ResponsibleHandler {
                 .getEntity();
         String requestContent = EntityUtils.toString(requestEntity);
         long tostring = System.currentTimeMillis();
-        String stage = RESTTools.getParam(request, RemotePipeline.STAGE_PARAM);
+        String stage = RESTTools.getParam(request, HttpEndpointConstants.STAGE_PARAM);
         if (stage == null) {
-            HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
+            HttpResponseWriter.printMissingParameter(response, HttpEndpointConstants.STAGE_PARAM);
             return;
         }
 
@@ -84,13 +84,13 @@ public class MarkHandler<T extends DatabaseType> implements ResponsibleHandler {
 
     private Mark getMark(HttpRequest request) {
         String uri = RESTTools.getBaseUrl(request);
-        if (uri.equals(RemotePipeline.PROCESSED_DOCUMENT_URL)) {
+        if (uri.equals(HttpEndpointConstants.PROCESSED_DOCUMENT_URL)) {
             return Mark.PROCESSED;
-        } else if (uri.equals(RemotePipeline.PENDING_DOCUMENT_URL)) {
+        } else if (uri.equals(HttpEndpointConstants.PENDING_DOCUMENT_URL)) {
             return Mark.PENDING;
-        } else if (uri.equals(RemotePipeline.DISCARDED_DOCUMENT_URL)) {
+        } else if (uri.equals(HttpEndpointConstants.DISCARDED_DOCUMENT_URL)) {
             return Mark.DISCARDED;
-        } else if (uri.equals(RemotePipeline.FAILED_DOCUMENT_URL)) {
+        } else if (uri.equals(HttpEndpointConstants.FAILED_DOCUMENT_URL)) {
             return Mark.FAILED;
         }
         return null;
@@ -124,10 +124,10 @@ public class MarkHandler<T extends DatabaseType> implements ResponsibleHandler {
 
     @Override
     public String[] getSupportedUrls() {
-        return new String[] { RemotePipeline.DISCARDED_DOCUMENT_URL,
-                RemotePipeline.FAILED_DOCUMENT_URL,
-                RemotePipeline.PROCESSED_DOCUMENT_URL,
-                RemotePipeline.PENDING_DOCUMENT_URL };
+        return new String[] { HttpEndpointConstants.DISCARDED_DOCUMENT_URL,
+                HttpEndpointConstants.FAILED_DOCUMENT_URL,
+                HttpEndpointConstants.PROCESSED_DOCUMENT_URL,
+                HttpEndpointConstants.PENDING_DOCUMENT_URL };
     }
 
 }

--- a/core/src/main/java/com/findwise/hydra/net/PingHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/PingHandler.java
@@ -8,36 +8,36 @@ import org.apache.http.HttpResponse;
 import org.apache.http.protocol.HttpContext;
 
 public class PingHandler implements ResponsibleHandler {
-	private String serverId;
-	
-	private String pingUrl = "";
-	
-	public PingHandler(String serverId) {
-		this.serverId = serverId;
-	}
-	
-	@Override
-	public void handle(HttpRequest request, HttpResponse response, HttpContext context)
-			throws HttpException, IOException {
-		if (RESTTools.isGet(request)) {
-			String uri = RESTTools.getStrippedUri(request);
-			if (uri.equals(pingUrl)) {
-				HttpResponseWriter.printID(response, serverId);
-			}
-		}
-	}
+    private String serverId;
 
-	@Override
-	public boolean supports(HttpRequest request) {
-		return RESTTools.isGet(request) && pingUrl.equals(RESTTools.getStrippedUri(request));
-	}
+    private String pingUrl = "";
 
-	@Override
-	public String[] getSupportedUrls() {
-		return new String[] { pingUrl };
-	}
+    public PingHandler(String serverId) {
+        this.serverId = serverId;
+    }
 
-	public void setServerId(String serverId) {
-		this.serverId = serverId;
-	}
+    @Override
+    public void handle(HttpRequest request, HttpResponse response, HttpContext context)
+            throws HttpException, IOException {
+        if (RESTTools.isGet(request)) {
+            String uri = RESTTools.getStrippedUri(request);
+            if (uri.equals(pingUrl)) {
+                HttpResponseWriter.printID(response, serverId);
+            }
+        }
+    }
+
+    @Override
+    public boolean supports(HttpRequest request) {
+        return RESTTools.isGet(request) && pingUrl.equals(RESTTools.getStrippedUri(request));
+    }
+
+    @Override
+    public String[] getSupportedUrls() {
+        return new String[] { pingUrl };
+    }
+
+    public void setServerId(String serverId) {
+        this.serverId = serverId;
+    }
 }

--- a/core/src/main/java/com/findwise/hydra/net/PropertiesHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/PropertiesHandler.java
@@ -20,76 +20,76 @@ import com.findwise.hydra.local.RemotePipeline;
 import com.findwise.hydra.stage.GroupStarter;
 
 public class PropertiesHandler<T extends DatabaseType> implements ResponsibleHandler {
-	Logger logger = LoggerFactory.getLogger(PropertiesHandler.class);
-	
-	private PipelineReader reader;
-	
-	public PropertiesHandler(PipelineReader reader) {
-		this.reader = reader;
-	}
-	
-	@Override
-	public void handle(HttpRequest request, HttpResponse response, HttpContext context)
-			throws HttpException, IOException {
-		if(RESTTools.getBaseUrl(request).equals(RemotePipeline.GET_PROPERTIES_URL)) {
-			getPropetries(request, response, context);
-		} else if(RESTTools.getBaseUrl(request).equals(GroupStarter.GET_STAGES_URL)) {
-			getStages(request, response, context);
-		} else {
-			logger.error("Unsupported request to PropertiesHandler. Request URL was: "+RESTTools.getUri(request));
-		}
-	}
+    Logger logger = LoggerFactory.getLogger(PropertiesHandler.class);
 
-	private void getStages(HttpRequest request, HttpResponse response,
-			HttpContext context) {
-		logger.trace("handleGetStages()");
-		String group = RESTTools.getParam(request, GroupStarter.GROUP_PARAM);
-		
-		Pipeline p = reader.getPipeline();
-		if(!p.hasGroup(group)) {
-			p = reader.getDebugPipeline();
-		}
-		if(p.hasGroup(group)) {
-			HttpResponseWriter.printJson(response, p.getGroup(group).getStageNames());
-			return;	
-		}
-		
-		response.setStatusCode(HttpStatus.SC_NOT_FOUND);
-		response.setEntity(new NStringEntity("", HttpResponseWriter.CONTENT_TYPE));
-	}
+    private PipelineReader reader;
 
-	private void getPropetries(HttpRequest request, HttpResponse response,
-			HttpContext context) {
-		logger.trace("handleGetProperties()");
-		
+    public PropertiesHandler(PipelineReader reader) {
+        this.reader = reader;
+    }
+
+    @Override
+    public void handle(HttpRequest request, HttpResponse response, HttpContext context)
+            throws HttpException, IOException {
+        if(RESTTools.getBaseUrl(request).equals(RemotePipeline.GET_PROPERTIES_URL)) {
+            getPropetries(request, response, context);
+        } else if(RESTTools.getBaseUrl(request).equals(GroupStarter.GET_STAGES_URL)) {
+            getStages(request, response, context);
+        } else {
+            logger.error("Unsupported request to PropertiesHandler. Request URL was: "+RESTTools.getUri(request));
+        }
+    }
+
+    private void getStages(HttpRequest request, HttpResponse response,
+                           HttpContext context) {
+        logger.trace("handleGetStages()");
+        String group = RESTTools.getParam(request, GroupStarter.GROUP_PARAM);
+
+        Pipeline p = reader.getPipeline();
+        if(!p.hasGroup(group)) {
+            p = reader.getDebugPipeline();
+        }
+        if(p.hasGroup(group)) {
+            HttpResponseWriter.printJson(response, p.getGroup(group).getStageNames());
+            return;
+        }
+
+        response.setStatusCode(HttpStatus.SC_NOT_FOUND);
+        response.setEntity(new NStringEntity("", HttpResponseWriter.CONTENT_TYPE));
+    }
+
+    private void getPropetries(HttpRequest request, HttpResponse response,
+                               HttpContext context) {
+        logger.trace("handleGetProperties()");
+
         String stage = RESTTools.getStage(request);
         logger.debug("Received getProperties()-request for stage: "+stage);
-        
+
         if(stage==null) {
-        	HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
-        	return;
+            HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
+            return;
         }
-        
+
         Map<String, Object> map = new HashMap<String, Object>();
-        
+
         if(reader.getPipeline().hasStage(stage)) {
-        	map = reader.getPipeline().getStage(stage).getProperties();
+            map = reader.getPipeline().getStage(stage).getProperties();
         }
         else if(reader.getDebugPipeline().hasStage(stage)){
-        	map = reader.getDebugPipeline().getStage(stage).getProperties();
-        } 
-        
+            map = reader.getDebugPipeline().getStage(stage).getProperties();
+        }
+
         HttpResponseWriter.printJson(response, map);
-	}
+    }
 
-	@Override
-	public boolean supports(HttpRequest request) {
-		return RESTTools.isGet(request) && (RESTTools.getBaseUrl(request).equals(RemotePipeline.GET_PROPERTIES_URL) || RESTTools.getBaseUrl(request).equals(GroupStarter.GET_STAGES_URL));
-	}
+    @Override
+    public boolean supports(HttpRequest request) {
+        return RESTTools.isGet(request) && (RESTTools.getBaseUrl(request).equals(RemotePipeline.GET_PROPERTIES_URL) || RESTTools.getBaseUrl(request).equals(GroupStarter.GET_STAGES_URL));
+    }
 
-	@Override
-	public String[] getSupportedUrls() {
-		return new String[] {RemotePipeline.GET_PROPERTIES_URL, GroupStarter.GET_STAGES_URL};
-	}
+    @Override
+    public String[] getSupportedUrls() {
+        return new String[] {RemotePipeline.GET_PROPERTIES_URL, GroupStarter.GET_STAGES_URL};
+    }
 
 }

--- a/core/src/main/java/com/findwise/hydra/net/PropertiesHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/PropertiesHandler.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.findwise.hydra.local.HttpEndpointConstants;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
@@ -16,7 +17,6 @@ import org.slf4j.LoggerFactory;
 import com.findwise.hydra.DatabaseType;
 import com.findwise.hydra.Pipeline;
 import com.findwise.hydra.PipelineReader;
-import com.findwise.hydra.local.RemotePipeline;
 import com.findwise.hydra.stage.GroupStarter;
 
 public class PropertiesHandler<T extends DatabaseType> implements ResponsibleHandler {
@@ -31,7 +31,7 @@ public class PropertiesHandler<T extends DatabaseType> implements ResponsibleHan
     @Override
     public void handle(HttpRequest request, HttpResponse response, HttpContext context)
             throws HttpException, IOException {
-        if(RESTTools.getBaseUrl(request).equals(RemotePipeline.GET_PROPERTIES_URL)) {
+        if(RESTTools.getBaseUrl(request).equals(HttpEndpointConstants.GET_PROPERTIES_URL)) {
             getPropetries(request, response, context);
         } else if(RESTTools.getBaseUrl(request).equals(GroupStarter.GET_STAGES_URL)) {
             getStages(request, response, context);
@@ -66,7 +66,7 @@ public class PropertiesHandler<T extends DatabaseType> implements ResponsibleHan
         logger.debug("Received getProperties()-request for stage: "+stage);
 
         if(stage==null) {
-            HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
+            HttpResponseWriter.printMissingParameter(response, HttpEndpointConstants.STAGE_PARAM);
             return;
         }
 
@@ -84,12 +84,12 @@ public class PropertiesHandler<T extends DatabaseType> implements ResponsibleHan
 
     @Override
     public boolean supports(HttpRequest request) {
-        return RESTTools.isGet(request) && (RESTTools.getBaseUrl(request).equals(RemotePipeline.GET_PROPERTIES_URL) || RESTTools.getBaseUrl(request).equals(GroupStarter.GET_STAGES_URL));
+        return RESTTools.isGet(request) && (RESTTools.getBaseUrl(request).equals(HttpEndpointConstants.GET_PROPERTIES_URL) || RESTTools.getBaseUrl(request).equals(GroupStarter.GET_STAGES_URL));
     }
 
     @Override
     public String[] getSupportedUrls() {
-        return new String[] {RemotePipeline.GET_PROPERTIES_URL, GroupStarter.GET_STAGES_URL};
+        return new String[] {HttpEndpointConstants.GET_PROPERTIES_URL, GroupStarter.GET_STAGES_URL};
     }
 
 }

--- a/core/src/main/java/com/findwise/hydra/net/QueryHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/QueryHandler.java
@@ -2,6 +2,7 @@ package com.findwise.hydra.net;
 
 import java.io.IOException;
 
+import com.findwise.hydra.local.HttpEndpointConstants;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpException;
@@ -19,7 +20,6 @@ import com.findwise.hydra.Document;
 import com.findwise.hydra.JsonException;
 import com.findwise.hydra.StageManager;
 import com.findwise.hydra.local.LocalQuery;
-import com.findwise.hydra.local.RemotePipeline;
 import com.findwise.hydra.net.RESTTools.Method;
 
 public class QueryHandler<T extends DatabaseType> implements ResponsibleHandler {
@@ -42,11 +42,11 @@ public class QueryHandler<T extends DatabaseType> implements ResponsibleHandler 
         HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request).getEntity();
         String requestContent = EntityUtils.toString(requestEntity);
         long tostring = System.currentTimeMillis();
-        String stage = RESTTools.getParam(request, RemotePipeline.STAGE_PARAM);
+        String stage = RESTTools.getParam(request, HttpEndpointConstants.STAGE_PARAM);
 
         if (stage == null) {
             HttpResponseWriter.printMissingParameter(response,
-                    RemotePipeline.STAGE_PARAM);
+                    HttpEndpointConstants.STAGE_PARAM);
             return;
         }
 
@@ -88,13 +88,13 @@ public class QueryHandler<T extends DatabaseType> implements ResponsibleHandler 
     @Override
     public boolean supports(HttpRequest request) {
         return RESTTools.getMethod(request) == Method.POST
-                && RemotePipeline.GET_DOCUMENT_URL.equals(RESTTools
+                && HttpEndpointConstants.GET_DOCUMENT_URL.equals(RESTTools
                 .getBaseUrl(request));
     }
 
     @Override
     public String[] getSupportedUrls() {
-        return new String[] { RemotePipeline.GET_DOCUMENT_URL };
+        return new String[] { HttpEndpointConstants.GET_DOCUMENT_URL };
     }
 
     private void reportQuery(String stage) {

--- a/core/src/main/java/com/findwise/hydra/net/QueryHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/QueryHandler.java
@@ -23,86 +23,86 @@ import com.findwise.hydra.local.RemotePipeline;
 import com.findwise.hydra.net.RESTTools.Method;
 
 public class QueryHandler<T extends DatabaseType> implements ResponsibleHandler {
-	
-	private CachingDocumentNIO<T> io;
-	private boolean performanceLogging = false;
 
-	private static Logger logger = LoggerFactory.getLogger(QueryHandler.class);
+    private CachingDocumentNIO<T> io;
+    private boolean performanceLogging = false;
 
-	public QueryHandler(CachingDocumentNIO<T> dbc, boolean performanceLogging) {
-		this.io = dbc;
-		this.performanceLogging = performanceLogging;
-	}
+    private static Logger logger = LoggerFactory.getLogger(QueryHandler.class);
 
-	@Override
-	public void handle(HttpRequest request, HttpResponse response,
-			HttpContext arg2) throws HttpException, IOException {
-		long start = System.currentTimeMillis();
-		logger.trace("handleGetDocument()");
-		HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request).getEntity();
-		String requestContent = EntityUtils.toString(requestEntity);
-		long tostring = System.currentTimeMillis();
-		String stage = RESTTools.getParam(request, RemotePipeline.STAGE_PARAM);
-		
-		if (stage == null) {
-			HttpResponseWriter.printMissingParameter(response,
-					RemotePipeline.STAGE_PARAM);
-			return;
-		}
+    public QueryHandler(CachingDocumentNIO<T> dbc, boolean performanceLogging) {
+        this.io = dbc;
+        this.performanceLogging = performanceLogging;
+    }
 
-		DatabaseQuery<T> dbq;
-		try {
-			dbq = requestToQuery(requestContent);
-		} catch (JsonException e) {
-			HttpResponseWriter.printJsonException(response, e);
-			return;
-		}
-		
-		long parse = System.currentTimeMillis();
-		
-		reportQuery(stage);		
-		
+    @Override
+    public void handle(HttpRequest request, HttpResponse response,
+                       HttpContext arg2) throws HttpException, IOException {
+        long start = System.currentTimeMillis();
+        logger.trace("handleGetDocument()");
+        HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request).getEntity();
+        String requestContent = EntityUtils.toString(requestEntity);
+        long tostring = System.currentTimeMillis();
+        String stage = RESTTools.getParam(request, RemotePipeline.STAGE_PARAM);
 
-		Document<T> d = io.getAndTag(dbq, stage);
-		
-		long query = System.currentTimeMillis();
-		
-		if (d != null) {
-			HttpResponseWriter.printDocument(response, d, stage);
-		} else {
-			HttpResponseWriter.printNoDocument(response);
-		}
+        if (stage == null) {
+            HttpResponseWriter.printMissingParameter(response,
+                    RemotePipeline.STAGE_PARAM);
+            return;
+        }
 
-		if(performanceLogging) {
-			long serialize = System.currentTimeMillis();
-			Object id = d != null ? d.getID() : null;
-			logger.info(String.format("type=performance event=query stage_name=%s doc_id=\"%s\" start=%d end=%d total=%d entitystring=%d parse=%d query=%d serialize=%d", stage, id, start, serialize, serialize-start, tostring-start, parse-tostring, query-parse, serialize-query));
-		}
-	}
+        DatabaseQuery<T> dbq;
+        try {
+            dbq = requestToQuery(requestContent);
+        } catch (JsonException e) {
+            HttpResponseWriter.printJsonException(response, e);
+            return;
+        }
 
-	private DatabaseQuery<T> requestToQuery(String requestContent)
-			throws JsonException {
-		return io.convert(new LocalQuery(requestContent));
-	}
+        long parse = System.currentTimeMillis();
 
-	@Override
-	public boolean supports(HttpRequest request) {
-		return RESTTools.getMethod(request) == Method.POST
-				&& RemotePipeline.GET_DOCUMENT_URL.equals(RESTTools
-						.getBaseUrl(request));
-	}
+        reportQuery(stage);
 
-	@Override
-	public String[] getSupportedUrls() {
-		return new String[] { RemotePipeline.GET_DOCUMENT_URL };
-	}
-	
-	private void reportQuery(String stage) {
-		StageManager sm = StageManager.getStageManager();
-		
-		if(sm.hasRunnerForStage(stage)) {
-			sm.getRunnerForStage(stage).setHasQueried();
-		}
-	}
+
+        Document<T> d = io.getAndTag(dbq, stage);
+
+        long query = System.currentTimeMillis();
+
+        if (d != null) {
+            HttpResponseWriter.printDocument(response, d, stage);
+        } else {
+            HttpResponseWriter.printNoDocument(response);
+        }
+
+        if(performanceLogging) {
+            long serialize = System.currentTimeMillis();
+            Object id = d != null ? d.getID() : null;
+            logger.info(String.format("type=performance event=query stage_name=%s doc_id=\"%s\" start=%d end=%d total=%d entitystring=%d parse=%d query=%d serialize=%d", stage, id, start, serialize, serialize-start, tostring-start, parse-tostring, query-parse, serialize-query));
+        }
+    }
+
+    private DatabaseQuery<T> requestToQuery(String requestContent)
+            throws JsonException {
+        return io.convert(new LocalQuery(requestContent));
+    }
+
+    @Override
+    public boolean supports(HttpRequest request) {
+        return RESTTools.getMethod(request) == Method.POST
+                && RemotePipeline.GET_DOCUMENT_URL.equals(RESTTools
+                .getBaseUrl(request));
+    }
+
+    @Override
+    public String[] getSupportedUrls() {
+        return new String[] { RemotePipeline.GET_DOCUMENT_URL };
+    }
+
+    private void reportQuery(String stage) {
+        StageManager sm = StageManager.getStageManager();
+
+        if(sm.hasRunnerForStage(stage)) {
+            sm.getRunnerForStage(stage).setHasQueried();
+        }
+    }
 
 }

--- a/core/src/main/java/com/findwise/hydra/net/RESTServer.java
+++ b/core/src/main/java/com/findwise/hydra/net/RESTServer.java
@@ -37,169 +37,169 @@ import com.findwise.tools.HttpConnection;
 
 /**
  * Sets up a REST service on the specified port, or 12001 by default.
- * 
+ *
  * @author joel.westberg
  */
 public class RESTServer extends Thread {
-	private int port;
-	private static Logger logger = LoggerFactory.getLogger(RESTServer.class);
+    private int port;
+    private static Logger logger = LoggerFactory.getLogger(RESTServer.class);
 
-	private Exception error;
-	
-	private DefaultListeningIOReactor ioReactor;
+    private Exception error;
 
-	private static final int BUFFER_SIZE = 8 * 1024; // Consider increasing this
-														// for performance?
+    private DefaultListeningIOReactor ioReactor;
 
-	private boolean shutdownCalled = false;
-	private boolean executing = false;
-	
-	private HttpRESTHandler<?> requestHandler;
-	
-	private String id;
+    private static final int BUFFER_SIZE = 8 * 1024; // Consider increasing this
+    // for performance?
 
-	@SuppressWarnings("rawtypes")
-	public RESTServer(int port, HttpRESTHandler requestHandler) {
-		this.requestHandler = requestHandler;
-		id = UUID.randomUUID().toString();
-		requestHandler.setRestId(id);
-		this.port = port;
-		executing = false;
-		setDaemon(true);
-	}
-	
-	@SuppressWarnings("rawtypes")
-	public RESTServer(CoreConfiguration conf, HttpRESTHandler requestHandler) {
-		this(conf.getRestPort(), requestHandler);
-	}
-	
-	public boolean isExecuting() {
-		return executing;
-	}
-	
-	public boolean hasError() {
-		return error!=null;
-	}
-	
-	public Exception getError() {
-		return error;
-	}
-	
-	public int getPort() {
-		return port;
-	}
-	
-	/**
-	 * Starts the server, confirming that the the startup process went correctly before returning. 
-	 * 
-	 * @return false if server could not be started (on that port), true otherwise.
-	 */
-	public boolean blockingStart() {
-		start();
-		try {
-			return isWorking(System.currentTimeMillis(), 2000);
-		}
-		catch (InterruptedException e) {
-			error = e;
-			Thread.currentThread().interrupt();
-			return false;
-		}
-	}
-	
-	public boolean isWorking(long startTime, long timeout) throws InterruptedException {
-		if(hasError()) {
-			return false;
-		}
-		if(System.currentTimeMillis()-timeout > startTime) {
-			return false;
-		}
-		if (isExecuting()) {
-			HttpConnection conn = new HttpConnection("localhost", port);
-			try {
-				HttpResponse response = conn.get("/");
-				String result = EntityUtils.toString(response.getEntity());
-				if(response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-					return result.equals(id);
-				}
-			}
-			catch (IOException e) {
-				logger.error("An IOException occurred during ping operation", e);
-			}
-		}
-		Thread.sleep(50);
-		return isWorking(startTime, timeout);
-	}
-	
-	@Override
-	public void run() {
-		try {
-			HttpParams params = new SyncBasicHttpParams();
-			params.setIntParameter(CoreConnectionPNames.SOCKET_BUFFER_SIZE, BUFFER_SIZE)
-					.setBooleanParameter(CoreConnectionPNames.STALE_CONNECTION_CHECK, false)
-					.setBooleanParameter(CoreConnectionPNames.TCP_NODELAY, true)
-					.setParameter(CoreProtocolPNames.ORIGIN_SERVER, "Hydra Core (Apache HttpComponents 4.2.1/1.1)");
+    private boolean shutdownCalled = false;
+    private boolean executing = false;
 
-			HttpProcessor httpproc = new ImmutableHttpProcessor(new HttpResponseInterceptor[] { 
-							new ResponseDate(),
-							new ResponseServer(), 
-							new ResponseContent(),
-							new ResponseConnControl() 
-						});
+    private HttpRESTHandler<?> requestHandler;
 
-			HttpAsyncRequestHandlerRegistry registry = new HttpAsyncRequestHandlerRegistry();
-			registry.register("*", new BasicAsyncRequestHandler(requestHandler));
-			
-			HttpAsyncService handler = new HttpAsyncService(httpproc, new DefaultConnectionReuseStrategy(), registry, params) {
-	            @Override
-	            public void connected(final NHttpServerConnection conn) {
-	            	logger.debug("Connection open: " + conn);
-	                super.connected(conn);
-	            }
+    private String id;
 
-	            @Override
-	            public void closed(final NHttpServerConnection conn) {
-	            	logger.debug("Connection closed: " + conn);
-	                super.closed(conn);
-	            }
-			};
+    @SuppressWarnings("rawtypes")
+    public RESTServer(int port, HttpRESTHandler requestHandler) {
+        this.requestHandler = requestHandler;
+        id = UUID.randomUUID().toString();
+        requestHandler.setRestId(id);
+        this.port = port;
+        executing = false;
+        setDaemon(true);
+    }
 
-	        NHttpConnectionFactory<DefaultNHttpServerConnection> connFactory = new DefaultNHttpServerConnectionFactory(params);
-			
+    @SuppressWarnings("rawtypes")
+    public RESTServer(CoreConfiguration conf, HttpRESTHandler requestHandler) {
+        this(conf.getRestPort(), requestHandler);
+    }
 
-	        IOEventDispatch ioEventDispatch = new DefaultHttpServerIODispatch(handler, connFactory);
+    public boolean isExecuting() {
+        return executing;
+    }
 
-			ioReactor = new DefaultListeningIOReactor();
+    public boolean hasError() {
+        return error!=null;
+    }
 
-			ioReactor.listen(new InetSocketAddress(port));
-			executing = true;
-			ioReactor.execute(ioEventDispatch);
-			if(!shutdownCalled) {
-				logger.error("Exiting ioReactor exec loop");
-			}
-			else {
-				logger.debug("Exiting ioReactor exec loop");
-			}
-			executing = false;
-		}
-		catch (IOException e) {
-			logger.error("I/O error in RESTServer: " + e.getMessage());
-			error = e;
-		}
-	}
+    public Exception getError() {
+        return error;
+    }
 
-	public void shutdown() throws IOException {
-		logger.info("Caught shutdown command to RESTServer");
-		shutdownCalled = true;
-		ioReactor.shutdown();
-	}
-	
-	public static RESTServer getNewStartedRESTServer(int port, HttpRESTHandler<?> restHandler) {
-		RESTServer rest = new RESTServer(port, restHandler);
-		
-		if(!rest.blockingStart()) {
-			return getNewStartedRESTServer((int)(Math.random()*64000)+1024, restHandler);
-		}
-		
-		return rest;
-	}
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * Starts the server, confirming that the the startup process went correctly before returning.
+     *
+     * @return false if server could not be started (on that port), true otherwise.
+     */
+    public boolean blockingStart() {
+        start();
+        try {
+            return isWorking(System.currentTimeMillis(), 2000);
+        }
+        catch (InterruptedException e) {
+            error = e;
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    public boolean isWorking(long startTime, long timeout) throws InterruptedException {
+        if(hasError()) {
+            return false;
+        }
+        if(System.currentTimeMillis()-timeout > startTime) {
+            return false;
+        }
+        if (isExecuting()) {
+            HttpConnection conn = new HttpConnection("localhost", port);
+            try {
+                HttpResponse response = conn.get("/");
+                String result = EntityUtils.toString(response.getEntity());
+                if(response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+                    return result.equals(id);
+                }
+            }
+            catch (IOException e) {
+                logger.error("An IOException occurred during ping operation", e);
+            }
+        }
+        Thread.sleep(50);
+        return isWorking(startTime, timeout);
+    }
+
+    @Override
+    public void run() {
+        try {
+            HttpParams params = new SyncBasicHttpParams();
+            params.setIntParameter(CoreConnectionPNames.SOCKET_BUFFER_SIZE, BUFFER_SIZE)
+                    .setBooleanParameter(CoreConnectionPNames.STALE_CONNECTION_CHECK, false)
+                    .setBooleanParameter(CoreConnectionPNames.TCP_NODELAY, true)
+                    .setParameter(CoreProtocolPNames.ORIGIN_SERVER, "Hydra Core (Apache HttpComponents 4.2.1/1.1)");
+
+            HttpProcessor httpproc = new ImmutableHttpProcessor(new HttpResponseInterceptor[] {
+                    new ResponseDate(),
+                    new ResponseServer(),
+                    new ResponseContent(),
+                    new ResponseConnControl()
+            });
+
+            HttpAsyncRequestHandlerRegistry registry = new HttpAsyncRequestHandlerRegistry();
+            registry.register("*", new BasicAsyncRequestHandler(requestHandler));
+
+            HttpAsyncService handler = new HttpAsyncService(httpproc, new DefaultConnectionReuseStrategy(), registry, params) {
+                @Override
+                public void connected(final NHttpServerConnection conn) {
+                    logger.debug("Connection open: " + conn);
+                    super.connected(conn);
+                }
+
+                @Override
+                public void closed(final NHttpServerConnection conn) {
+                    logger.debug("Connection closed: " + conn);
+                    super.closed(conn);
+                }
+            };
+
+            NHttpConnectionFactory<DefaultNHttpServerConnection> connFactory = new DefaultNHttpServerConnectionFactory(params);
+
+
+            IOEventDispatch ioEventDispatch = new DefaultHttpServerIODispatch(handler, connFactory);
+
+            ioReactor = new DefaultListeningIOReactor();
+
+            ioReactor.listen(new InetSocketAddress(port));
+            executing = true;
+            ioReactor.execute(ioEventDispatch);
+            if(!shutdownCalled) {
+                logger.error("Exiting ioReactor exec loop");
+            }
+            else {
+                logger.debug("Exiting ioReactor exec loop");
+            }
+            executing = false;
+        }
+        catch (IOException e) {
+            logger.error("I/O error in RESTServer: " + e.getMessage());
+            error = e;
+        }
+    }
+
+    public void shutdown() throws IOException {
+        logger.info("Caught shutdown command to RESTServer");
+        shutdownCalled = true;
+        ioReactor.shutdown();
+    }
+
+    public static RESTServer getNewStartedRESTServer(int port, HttpRESTHandler<?> restHandler) {
+        RESTServer rest = new RESTServer(port, restHandler);
+
+        if(!rest.blockingStart()) {
+            return getNewStartedRESTServer((int)(Math.random()*64000)+1024, restHandler);
+        }
+
+        return rest;
+    }
 }

--- a/core/src/main/java/com/findwise/hydra/net/RESTTools.java
+++ b/core/src/main/java/com/findwise/hydra/net/RESTTools.java
@@ -4,9 +4,8 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.findwise.hydra.local.HttpEndpointConstants;
 import org.apache.http.HttpRequest;
-
-import com.findwise.hydra.local.RemotePipeline;
 
 public final class RESTTools {
 	public enum Method { GET, PUT, POST, DELETE, HEAD, TRACE, CONNECT, PATCH, OPTIONS };
@@ -44,7 +43,7 @@ public final class RESTTools {
 	}
 	
 	public static String getStage(HttpRequest request) {
-		return getParam(request, RemotePipeline.STAGE_PARAM);
+		return getParam(request, HttpEndpointConstants.STAGE_PARAM);
 	}
 	
 	public static boolean isPost(HttpRequest request) {

--- a/core/src/main/java/com/findwise/hydra/net/ReleaseHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/ReleaseHandler.java
@@ -23,61 +23,61 @@ import com.findwise.hydra.net.RESTTools.Method;
 
 public class ReleaseHandler<T extends DatabaseType> implements ResponsibleHandler {
 
-	private CachingDocumentNIO<T> io;
+    private CachingDocumentNIO<T> io;
 
-	private static Logger logger = LoggerFactory
-			.getLogger(ReleaseHandler.class);
+    private static Logger logger = LoggerFactory
+            .getLogger(ReleaseHandler.class);
 
-	public ReleaseHandler(CachingDocumentNIO<T> dbc) {
-		this.io = dbc;
-	}
+    public ReleaseHandler(CachingDocumentNIO<T> dbc) {
+        this.io = dbc;
+    }
 
-	@Override
-	public void handle(HttpRequest request, HttpResponse response,
-			HttpContext arg2) throws HttpException, IOException {
-		logger.trace("handleReleaseDocument()");
-		HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request)
-				.getEntity();
-		String requestContent = EntityUtils.toString(requestEntity);
-		String stage = RESTTools.getParam(request, RemotePipeline.STAGE_PARAM);
+    @Override
+    public void handle(HttpRequest request, HttpResponse response,
+                       HttpContext arg2) throws HttpException, IOException {
+        logger.trace("handleReleaseDocument()");
+        HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request)
+                .getEntity();
+        String requestContent = EntityUtils.toString(requestEntity);
+        String stage = RESTTools.getParam(request, RemotePipeline.STAGE_PARAM);
 
-		if (stage == null) {
-			HttpResponseWriter.printMissingParameter(response,
-					RemotePipeline.STAGE_PARAM);
-			return;
-		}
+        if (stage == null) {
+            HttpResponseWriter.printMissingParameter(response,
+                    RemotePipeline.STAGE_PARAM);
+            return;
+        }
 
-		try {
-			boolean x = release(io.convert(new LocalDocument(requestContent)), stage);
-			if (!x) {
-				HttpResponseWriter.printNoDocument(response);
-			}
-		} catch (JsonException e) {
-			HttpResponseWriter.printJsonException(response, e);
-			return;
-		} catch (ConversionException e) {
-			HttpResponseWriter.printUnhandledException(response, e);
-			return;
-		}
+        try {
+            boolean x = release(io.convert(new LocalDocument(requestContent)), stage);
+            if (!x) {
+                HttpResponseWriter.printNoDocument(response);
+            }
+        } catch (JsonException e) {
+            HttpResponseWriter.printJsonException(response, e);
+            return;
+        } catch (ConversionException e) {
+            HttpResponseWriter.printUnhandledException(response, e);
+            return;
+        }
 
-		HttpResponseWriter.printDocumentReleased(response);
+        HttpResponseWriter.printDocumentReleased(response);
 
-	}
+    }
 
-	private boolean release(Document<T> md, String stage) {
-		return io.markTouched(md.getID(), stage);
-	}
+    private boolean release(Document<T> md, String stage) {
+        return io.markTouched(md.getID(), stage);
+    }
 
-	@Override
-	public boolean supports(HttpRequest request) {
-		return RESTTools.getMethod(request) == Method.POST
-				&& RemotePipeline.RELEASE_DOCUMENT_URL.equals(RESTTools
-						.getBaseUrl(request));
-	}
+    @Override
+    public boolean supports(HttpRequest request) {
+        return RESTTools.getMethod(request) == Method.POST
+                && RemotePipeline.RELEASE_DOCUMENT_URL.equals(RESTTools
+                .getBaseUrl(request));
+    }
 
-	@Override
-	public String[] getSupportedUrls() {
-		return new String[] { RemotePipeline.RELEASE_DOCUMENT_URL };
-	}
+    @Override
+    public String[] getSupportedUrls() {
+        return new String[] { RemotePipeline.RELEASE_DOCUMENT_URL };
+    }
 
 }

--- a/core/src/main/java/com/findwise/hydra/net/ReleaseHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/ReleaseHandler.java
@@ -2,6 +2,7 @@ package com.findwise.hydra.net;
 
 import java.io.IOException;
 
+import com.findwise.hydra.local.HttpEndpointConstants;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpException;
@@ -18,7 +19,6 @@ import com.findwise.hydra.DatabaseType;
 import com.findwise.hydra.Document;
 import com.findwise.hydra.JsonException;
 import com.findwise.hydra.local.LocalDocument;
-import com.findwise.hydra.local.RemotePipeline;
 import com.findwise.hydra.net.RESTTools.Method;
 
 public class ReleaseHandler<T extends DatabaseType> implements ResponsibleHandler {
@@ -39,11 +39,11 @@ public class ReleaseHandler<T extends DatabaseType> implements ResponsibleHandle
         HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request)
                 .getEntity();
         String requestContent = EntityUtils.toString(requestEntity);
-        String stage = RESTTools.getParam(request, RemotePipeline.STAGE_PARAM);
+        String stage = RESTTools.getParam(request, HttpEndpointConstants.STAGE_PARAM);
 
         if (stage == null) {
             HttpResponseWriter.printMissingParameter(response,
-                    RemotePipeline.STAGE_PARAM);
+                    HttpEndpointConstants.STAGE_PARAM);
             return;
         }
 
@@ -71,13 +71,13 @@ public class ReleaseHandler<T extends DatabaseType> implements ResponsibleHandle
     @Override
     public boolean supports(HttpRequest request) {
         return RESTTools.getMethod(request) == Method.POST
-                && RemotePipeline.RELEASE_DOCUMENT_URL.equals(RESTTools
+                && HttpEndpointConstants.RELEASE_DOCUMENT_URL.equals(RESTTools
                 .getBaseUrl(request));
     }
 
     @Override
     public String[] getSupportedUrls() {
-        return new String[] { RemotePipeline.RELEASE_DOCUMENT_URL };
+        return new String[] { HttpEndpointConstants.RELEASE_DOCUMENT_URL };
     }
 
 }

--- a/core/src/main/java/com/findwise/hydra/net/ResponsibleHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/ResponsibleHandler.java
@@ -10,19 +10,19 @@ import org.apache.http.protocol.HttpRequestHandler;
 
 public interface ResponsibleHandler extends HttpRequestHandler {
 
-	/**
-	 * Implementing classes should guarantee expected behavior if and only if
-	 * supports(request) returns true.
-	 */
-	@Override
-	public void handle(HttpRequest request, HttpResponse response,
-			HttpContext context) throws HttpException, IOException;
+    /**
+     * Implementing classes should guarantee expected behavior if and only if
+     * supports(request) returns true.
+     */
+    @Override
+    public void handle(HttpRequest request, HttpResponse response,
+                       HttpContext context) throws HttpException, IOException;
 
-	/**
-	 * Indicates that this handler can serve the given request by a later call
-	 * to handle(...)
-	 */
-	public boolean supports(HttpRequest request);
+    /**
+     * Indicates that this handler can serve the given request by a later call
+     * to handle(...)
+     */
+    public boolean supports(HttpRequest request);
 
-	public String[] getSupportedUrls();
+    public String[] getSupportedUrls();
 }

--- a/core/src/main/java/com/findwise/hydra/net/WriteHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/WriteHandler.java
@@ -3,6 +3,7 @@ package com.findwise.hydra.net;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
+import com.findwise.hydra.local.HttpEndpointConstants;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpException;
@@ -20,7 +21,6 @@ import com.findwise.hydra.DatabaseType;
 import com.findwise.hydra.Document;
 import com.findwise.hydra.JsonException;
 import com.findwise.hydra.local.LocalDocument;
-import com.findwise.hydra.local.RemotePipeline;
 import com.findwise.hydra.net.RESTTools.Method;
 
 public class WriteHandler<T extends DatabaseType> implements ResponsibleHandler {
@@ -44,21 +44,21 @@ public class WriteHandler<T extends DatabaseType> implements ResponsibleHandler 
         String requestContent = EntityUtils.toString(requestEntity);
         long tostring = System.currentTimeMillis();
 
-        String stage = RESTTools.getParam(request, RemotePipeline.STAGE_PARAM);
+        String stage = RESTTools.getParam(request, HttpEndpointConstants.STAGE_PARAM);
         if(stage==null) {
-            HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
+            HttpResponseWriter.printMissingParameter(response, HttpEndpointConstants.STAGE_PARAM);
             return;
         }
 
-        String partial = RESTTools.getParam(request, RemotePipeline.PARTIAL_PARAM);
+        String partial = RESTTools.getParam(request, HttpEndpointConstants.PARTIAL_PARAM);
         if(partial==null) {
-            HttpResponseWriter.printMissingParameter(response, RemotePipeline.PARTIAL_PARAM);
+            HttpResponseWriter.printMissingParameter(response, HttpEndpointConstants.PARTIAL_PARAM);
             return;
         }
 
-        String norelease = RESTTools.getParam(request, RemotePipeline.NORELEASE_PARAM);
+        String norelease = RESTTools.getParam(request, HttpEndpointConstants.NORELEASE_PARAM);
         if(norelease==null) {
-            HttpResponseWriter.printMissingParameter(response, RemotePipeline.NORELEASE_PARAM);
+            HttpResponseWriter.printMissingParameter(response, HttpEndpointConstants.NORELEASE_PARAM);
             return;
         }
 
@@ -159,13 +159,13 @@ public class WriteHandler<T extends DatabaseType> implements ResponsibleHandler 
     @Override
     public boolean supports(HttpRequest request) {
         return RESTTools.getMethod(request) == Method.POST
-                && RemotePipeline.WRITE_DOCUMENT_URL.equals(RESTTools
+                && HttpEndpointConstants.WRITE_DOCUMENT_URL.equals(RESTTools
                 .getBaseUrl(request));
     }
 
     @Override
     public String[] getSupportedUrls() {
-        return new String[] { RemotePipeline.WRITE_DOCUMENT_URL };
+        return new String[] { HttpEndpointConstants.WRITE_DOCUMENT_URL };
     }
 
 }

--- a/core/src/main/java/com/findwise/hydra/net/WriteHandler.java
+++ b/core/src/main/java/com/findwise/hydra/net/WriteHandler.java
@@ -25,147 +25,147 @@ import com.findwise.hydra.net.RESTTools.Method;
 
 public class WriteHandler<T extends DatabaseType> implements ResponsibleHandler {
 
-	private CachingDocumentNIO<T> io;
-	private boolean performanceLogging;
-	
-	private static Logger logger = LoggerFactory.getLogger(WriteHandler.class);
+    private CachingDocumentNIO<T> io;
+    private boolean performanceLogging;
 
-	public WriteHandler(CachingDocumentNIO<T> dbc, boolean performanceLogging) {
-		this.io = dbc;
-		this.performanceLogging = performanceLogging;
-	}
-	
-	@Override
-	public void handle(HttpRequest request, HttpResponse response, HttpContext arg2)
-			throws HttpException, IOException {
-		logger.trace("handleWriteDocument()");
+    private static Logger logger = LoggerFactory.getLogger(WriteHandler.class);
+
+    public WriteHandler(CachingDocumentNIO<T> dbc, boolean performanceLogging) {
+        this.io = dbc;
+        this.performanceLogging = performanceLogging;
+    }
+
+    @Override
+    public void handle(HttpRequest request, HttpResponse response, HttpContext arg2)
+            throws HttpException, IOException {
+        logger.trace("handleWriteDocument()");
         long start = System.currentTimeMillis();
-		HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request).getEntity();
+        HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request).getEntity();
         String requestContent = EntityUtils.toString(requestEntity);
         long tostring = System.currentTimeMillis();
-        
+
         String stage = RESTTools.getParam(request, RemotePipeline.STAGE_PARAM);
         if(stage==null) {
-        	HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
-        	return;
+            HttpResponseWriter.printMissingParameter(response, RemotePipeline.STAGE_PARAM);
+            return;
         }
-        
+
         String partial = RESTTools.getParam(request, RemotePipeline.PARTIAL_PARAM);
         if(partial==null) {
-        	HttpResponseWriter.printMissingParameter(response, RemotePipeline.PARTIAL_PARAM);
-        	return;
+            HttpResponseWriter.printMissingParameter(response, RemotePipeline.PARTIAL_PARAM);
+            return;
         }
-        
+
         String norelease = RESTTools.getParam(request, RemotePipeline.NORELEASE_PARAM);
         if(norelease==null) {
-        	HttpResponseWriter.printMissingParameter(response, RemotePipeline.NORELEASE_PARAM);
-        	return;
+            HttpResponseWriter.printMissingParameter(response, RemotePipeline.NORELEASE_PARAM);
+            return;
         }
-        
+
         DatabaseDocument<T> md;
         try {
-        	md = io.convert(new LocalDocument(requestContent));
+            md = io.convert(new LocalDocument(requestContent));
         }
         catch(JsonException e) {
-        	HttpResponseWriter.printJsonException(response, e);
-        	return;
+            HttpResponseWriter.printJsonException(response, e);
+            return;
         } catch (ConversionException e) {
-			logger.error("Caught Exception when trying to convert "+requestContent, e);
-			HttpResponseWriter.printBadRequestContent(response);
-			return;
-		}
-        
+            logger.error("Caught Exception when trying to convert "+requestContent, e);
+            HttpResponseWriter.printBadRequestContent(response);
+            return;
+        }
+
         long convert = System.currentTimeMillis();
-        
+
         String type;
         boolean saveRes;
         if(partial.equals("1")) {
-        	saveRes = handlePartialWrite(md, response);
-        	type="update";
+            saveRes = handlePartialWrite(md, response);
+            type="update";
         }
         else {
-        	if(md.getID()!=null) {
-        		saveRes = handleFullUpdate(md, response);
-        	}
-        	else {
-        		saveRes = handleInsert(md, response);
-        	}
-        	type="insert";
+            if(md.getID()!=null) {
+                saveRes = handleFullUpdate(md, response);
+            }
+            else {
+                saveRes = handleInsert(md, response);
+            }
+            type="insert";
         }
         long write = System.currentTimeMillis();
 
-		if (saveRes && norelease.equals("0")) {
-			boolean result = release(md, stage);
-			if (!result) {
-				HttpResponseWriter.printReleaseFailed(response);
-				return;
-			}
-		}
-		if(performanceLogging) {
-			long end = System.currentTimeMillis();
-			logger.info(String.format("type=performance event=%s stage_name=%s doc_id=\"%s\" start=%d end=%d total=%d entitystring=%d parse=%d query=%d serialize=%d", type, stage, md.getID(), start, end, end-start, tostring-start, convert-tostring, write-convert, end-write));	
-		}
-	}
-	
-	private boolean release(Document<T> md, String stage) {
-		return io.markTouched(md.getID(), stage);
-	}
-	
-	private boolean handlePartialWrite(DatabaseDocument<T> md, HttpResponse response) throws UnsupportedEncodingException{
-		logger.trace("handlePartialWrite()");
-		if(md.getID()==null) {
-			HttpResponseWriter.printMissingID(response);
-			return false;
-		}
-		logger.debug("Handling a partial write for document "+md.getID());
-		DatabaseDocument<T> inDB = io.getDocumentById(md.getID());
-		if(inDB==null) {
-			HttpResponseWriter.printNoDocument(response);
-			return false;
-		}
-		inDB.putAll(md);
+        if (saveRes && norelease.equals("0")) {
+            boolean result = release(md, stage);
+            if (!result) {
+                HttpResponseWriter.printReleaseFailed(response);
+                return;
+            }
+        }
+        if(performanceLogging) {
+            long end = System.currentTimeMillis();
+            logger.info(String.format("type=performance event=%s stage_name=%s doc_id=\"%s\" start=%d end=%d total=%d entitystring=%d parse=%d query=%d serialize=%d", type, stage, md.getID(), start, end, end-start, tostring-start, convert-tostring, write-convert, end-write));
+        }
+    }
+
+    private boolean release(Document<T> md, String stage) {
+        return io.markTouched(md.getID(), stage);
+    }
+
+    private boolean handlePartialWrite(DatabaseDocument<T> md, HttpResponse response) throws UnsupportedEncodingException{
+        logger.trace("handlePartialWrite()");
+        if(md.getID()==null) {
+            HttpResponseWriter.printMissingID(response);
+            return false;
+        }
+        logger.debug("Handling a partial write for document "+md.getID());
+        DatabaseDocument<T> inDB = io.getDocumentById(md.getID());
+        if(inDB==null) {
+            HttpResponseWriter.printNoDocument(response);
+            return false;
+        }
+        inDB.putAll(md);
 
 
-		if(io.update(inDB)){
-			HttpResponseWriter.printSaveOk(response, md.getID());
-			return true;
-		} 
-		else {
-			HttpResponseWriter.printSaveFailed(response, md.getID());
-			return false;
-		}
-	}
-	
-	private boolean handleFullUpdate(DatabaseDocument<T> md, HttpResponse response) {
-		logger.trace("handleFullUpdate()");
-		if(io.update(md)) {
-			HttpResponseWriter.printSaveOk(response, md.getID());
-			return true;
-		}
-		HttpResponseWriter.printSaveFailed(response, md.getID());
-		return false;
-	}
-	
-	private boolean handleInsert(DatabaseDocument<T> md, HttpResponse response) {
-		if(io.insert(md)) {
-			HttpResponseWriter.printInsertOk(response, md);
-			return true;
-		}
-		else {
-			HttpResponseWriter.printInsertFailed(response);
-			return false;
-		}
-	}
-	@Override
-	public boolean supports(HttpRequest request) {
-		return RESTTools.getMethod(request) == Method.POST
-				&& RemotePipeline.WRITE_DOCUMENT_URL.equals(RESTTools
-						.getBaseUrl(request));
-	}
+        if(io.update(inDB)){
+            HttpResponseWriter.printSaveOk(response, md.getID());
+            return true;
+        }
+        else {
+            HttpResponseWriter.printSaveFailed(response, md.getID());
+            return false;
+        }
+    }
 
-	@Override
-	public String[] getSupportedUrls() {
-		return new String[] { RemotePipeline.WRITE_DOCUMENT_URL };
-	}
+    private boolean handleFullUpdate(DatabaseDocument<T> md, HttpResponse response) {
+        logger.trace("handleFullUpdate()");
+        if(io.update(md)) {
+            HttpResponseWriter.printSaveOk(response, md.getID());
+            return true;
+        }
+        HttpResponseWriter.printSaveFailed(response, md.getID());
+        return false;
+    }
+
+    private boolean handleInsert(DatabaseDocument<T> md, HttpResponse response) {
+        if(io.insert(md)) {
+            HttpResponseWriter.printInsertOk(response, md);
+            return true;
+        }
+        else {
+            HttpResponseWriter.printInsertFailed(response);
+            return false;
+        }
+    }
+    @Override
+    public boolean supports(HttpRequest request) {
+        return RESTTools.getMethod(request) == Method.POST
+                && RemotePipeline.WRITE_DOCUMENT_URL.equals(RESTTools
+                .getBaseUrl(request));
+    }
+
+    @Override
+    public String[] getSupportedUrls() {
+        return new String[] { RemotePipeline.WRITE_DOCUMENT_URL };
+    }
 
 }

--- a/core/src/test/java/com/findwise/hydra/local/RemotePipelineIT.java
+++ b/core/src/test/java/com/findwise/hydra/local/RemotePipelineIT.java
@@ -95,7 +95,7 @@ public class RemotePipelineIT {
 	
 	@Test
 	public void testPersistedAction() {
-		RemotePipeline rp = new RemotePipeline("127.0.0.1", server.getPort(), "stage1");
+		RemotePipeline rp = new HttpRemotePipeline("127.0.0.1", server.getPort(), "stage1");
 		try {
 			LocalDocument ld = rp.getDocument(new LocalQuery());
 			if(ld.getAction()!=test.getAction()) {
@@ -111,7 +111,7 @@ public class RemotePipelineIT {
 
 	@Test
 	public void testRemotePipeline() {
-		RemotePipeline rp = new RemotePipeline("127.0.0.1", server.getPort(), "stage1");
+		RemotePipeline rp = new HttpRemotePipeline("127.0.0.1", server.getPort(), "stage1");
 		try {
 			rp.getDocument(new LocalQuery());
 		}
@@ -129,7 +129,7 @@ public class RemotePipelineIT {
 
 	@Test
 	public void testGetDocument() throws Exception {
-		RemotePipeline rp1 = new RemotePipeline("127.0.0.1", server.getPort(), "stage1");
+		RemotePipeline rp1 = new HttpRemotePipeline("127.0.0.1", server.getPort(), "stage1");
 		LocalDocument d = rp1.getDocument(new LocalQuery());
 		if(d==null) {
 			fail("getDocument returned null");
@@ -143,7 +143,7 @@ public class RemotePipelineIT {
 			fail("Got document, but was expecting null. Both documents in DB should have been tagged by stage1 already. This was "+d3.getID()+", previous were "+d.getID()+" and "+d2.getID());
 		}
 		
-		RemotePipeline rp2 = new RemotePipeline("127.0.0.1", server.getPort(), "stage2");
+		RemotePipeline rp2 = new HttpRemotePipeline("127.0.0.1", server.getPort(), "stage2");
 		LocalQuery lq = new LocalQuery();
 		lq.requireContentFieldNotExists("name");
 		
@@ -155,7 +155,7 @@ public class RemotePipelineIT {
 
 	@Test
 	public void testSave() throws Exception {
-		RemotePipeline rp1 = new RemotePipeline("127.0.0.1", server.getPort(), "stage1");
+		RemotePipeline rp1 = new HttpRemotePipeline("127.0.0.1", server.getPort(), "stage1");
 		LocalDocument d1 = rp1.getDocument(new LocalQuery());
 		LocalDocument d2 = rp1.getDocument(new LocalQuery());
 		d1.putContentField("x", "y");
@@ -164,7 +164,7 @@ public class RemotePipelineIT {
 		d2.putContentField("x2", "z");
 		rp1.save(d2);
 
-		RemotePipeline rp2 = new RemotePipeline("127.0.0.1", server.getPort(), "stage2");
+		RemotePipeline rp2 = new HttpRemotePipeline("127.0.0.1", server.getPort(), "stage2");
 		LocalQuery query = new LocalQuery();
 		query.requireContentFieldExists("x");
 		LocalDocument x = rp2.getDocument(query);
@@ -184,7 +184,7 @@ public class RemotePipelineIT {
 	
 	@Test
 	public void testSaveWithoutId() throws Exception {
-		RemotePipeline rp2 = new RemotePipeline("127.0.0.1", server.getPort(), "stage2");
+		RemotePipeline rp2 = new HttpRemotePipeline("127.0.0.1", server.getPort(), "stage2");
 		
 		LocalDocument d = new LocalDocument();
 		d.putContentField("aField", "aValue");
@@ -196,7 +196,7 @@ public class RemotePipelineIT {
 	
 	@Test
 	public void testSaveIncorrectId() throws Exception {
-		RemotePipeline rp1 = new RemotePipeline("127.0.0.1", server.getPort(), "stage1");
+		RemotePipeline rp1 = new HttpRemotePipeline("127.0.0.1", server.getPort(), "stage1");
 		boolean res = rp1.save(new LocalDocument("{_id : 123}"));
 		if(res) {
 			fail("Save returned false even though it should fail -- that ID doesn't exist.");
@@ -212,9 +212,9 @@ public class RemotePipelineIT {
 	@Test
 	public void testSaveFull() throws Exception {
 		//Primary use case: Write an entirely new document to the database
-		RemotePipeline rp1 = new RemotePipeline("127.0.0.1", server.getPort(), "inputNode");
-		RemotePipeline rp2 = new RemotePipeline("127.0.0.1", server.getPort(), "stage");
-		RemotePipeline rp3 = new RemotePipeline("127.0.0.1", server.getPort(), "stage2");
+		RemotePipeline rp1 = new HttpRemotePipeline("127.0.0.1", server.getPort(), "inputNode");
+		RemotePipeline rp2 = new HttpRemotePipeline("127.0.0.1", server.getPort(), "stage");
+		RemotePipeline rp3 = new HttpRemotePipeline("127.0.0.1", server.getPort(), "stage2");
 		LocalDocument ld = new LocalDocument();
 		ld.putContentField("fieldName", "unique!");
 		ld.putContentField("status", "new");
@@ -269,8 +269,8 @@ public class RemotePipelineIT {
 	
 	@Test
 	public void testMarkProcessed() throws Exception {
-		RemotePipeline rp1 = new RemotePipeline("127.0.0.1", server.getPort(), "stage1");
-		RemotePipeline rp2 = new RemotePipeline("127.0.0.1", server.getPort(), "outputNode");
+		RemotePipeline rp1 = new HttpRemotePipeline("127.0.0.1", server.getPort(), "stage1");
+		RemotePipeline rp2 = new HttpRemotePipeline("127.0.0.1", server.getPort(), "outputNode");
 
 		LocalDocument d = rp2.getDocument(new LocalQuery());
 		if(!rp2.markProcessed(d)) {
@@ -287,8 +287,8 @@ public class RemotePipelineIT {
 	
 	@Test
 	public void testMarkPending() throws Exception {
-		RemotePipeline rp1 = new RemotePipeline("127.0.0.1", server.getPort(), "stage1");
-		RemotePipeline rp2 = new RemotePipeline("127.0.0.1", server.getPort(), "outputNode");
+		RemotePipeline rp1 = new HttpRemotePipeline("127.0.0.1", server.getPort(), "stage1");
+		RemotePipeline rp2 = new HttpRemotePipeline("127.0.0.1", server.getPort(), "outputNode");
 
 		LocalDocument d = rp2.getDocument(new LocalQuery());
 		if(!rp2.markPending(d)) {
@@ -305,8 +305,8 @@ public class RemotePipelineIT {
 	
 	@Test
 	public void testMarkDiscarded() throws Exception {
-		RemotePipeline rp = new RemotePipeline("127.0.0.1", server.getPort(), "testStage");
-		RemotePipeline rpOut = new RemotePipeline("127.0.0.1", server.getPort(), "outStage");
+		RemotePipeline rp = new HttpRemotePipeline("127.0.0.1", server.getPort(), "testStage");
+		RemotePipeline rpOut = new HttpRemotePipeline("127.0.0.1", server.getPort(), "outStage");
 		
 		LocalQuery lq = new LocalQuery();
 		LocalDocument testDoc = rp.getDocument(lq);
@@ -328,7 +328,7 @@ public class RemotePipelineIT {
 	
 	@Test
 	public void testMarkFailed() throws Exception {
-		RemotePipeline rp = new RemotePipeline("127.0.0.1", server.getPort(), "testStage");
+		RemotePipeline rp = new HttpRemotePipeline("127.0.0.1", server.getPort(), "testStage");
 		
 		LocalQuery lq = new LocalQuery();
 		LocalDocument testDoc = rp.getDocument(lq);
@@ -367,7 +367,7 @@ public class RemotePipelineIT {
 		MongoDocument testDoc = new MongoDocument();
 		dbc.getDocumentWriter().insert(testDoc);
 		
-		RemotePipeline rp = new RemotePipeline("localhost", server.getPort(), "stage");
+		RemotePipeline rp = new HttpRemotePipeline("localhost", server.getPort(), "stage");
 		
 		String content = "xäöåx";
 
@@ -401,7 +401,7 @@ public class RemotePipelineIT {
 		MongoDocument testDoc = new MongoDocument();
 		testDoc.putContentField("field", "value");
 		dbc.getDocumentWriter().insert(testDoc);
-		RemotePipeline rp = new RemotePipeline("localhost", server.getPort(), "stage");
+		RemotePipeline rp = new HttpRemotePipeline("localhost", server.getPort(), "stage");
 		
 		LocalDocument ld = rp.getDocument(new LocalQuery());
 		assertTrue(ld.hasContentField("field"));
@@ -409,7 +409,7 @@ public class RemotePipelineIT {
 		
 		rp.save(ld);
 		
-		rp = new RemotePipeline("localhost", server.getPort(), "stage2");
+		rp = new HttpRemotePipeline("localhost", server.getPort(), "stage2");
 		ld = rp.getDocument(new LocalQuery());
 		assertFalse(ld.hasContentField("field"));
 	}

--- a/core/src/test/java/com/findwise/hydra/net/FileHandlerTest.java
+++ b/core/src/test/java/com/findwise/hydra/net/FileHandlerTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.fail;
 import java.io.InputStream;
 import java.util.List;
 
+import com.findwise.hydra.local.HttpRemotePipeline;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,7 +38,7 @@ public class FileHandlerTest {
 		MemoryDocument testDoc = new MemoryDocument();
 		mc.getDocumentWriter().insert(testDoc);
 		
-		RemotePipeline rp = new RemotePipeline("localhost", server.getPort(), "stage");
+		RemotePipeline rp = new HttpRemotePipeline("localhost", server.getPort(), "stage");
 		
 		String content = "adsafgoaiuhgahgo\ndasdas";
 		String fileName = "test.txt";
@@ -63,7 +64,7 @@ public class FileHandlerTest {
 	
 	@Test
 	public void testFileList() throws Exception {		
-		RemotePipeline rp = new RemotePipeline("localhost", server.getPort(), "stage");
+		RemotePipeline rp = new HttpRemotePipeline("localhost", server.getPort(), "stage");
 		if(rp.getFileNames(new LocalDocumentID(""))!=null) {
 			fail("Got filenames for non-existant document");
 		}
@@ -102,7 +103,7 @@ public class FileHandlerTest {
 	
 	@Test
 	public void testGetFile() throws Exception {		
-		RemotePipeline rp = new RemotePipeline("localhost", server.getPort(), "stage");
+		RemotePipeline rp = new HttpRemotePipeline("localhost", server.getPort(), "stage");
 		if(rp.getFile("id", new LocalDocumentID("file"))!=null) {
 			fail("Got non-null for non-existant document and non-existant file");
 		}
@@ -143,7 +144,7 @@ public class FileHandlerTest {
 	
 	@Test
 	public void testDeleteFile() throws Exception {		
-		RemotePipeline rp = new RemotePipeline("localhost", server.getPort(), "stage");
+		RemotePipeline rp = new HttpRemotePipeline("localhost", server.getPort(), "stage");
 		if(rp.deleteFile("name", new LocalDocumentID("id"))) {
 			fail("Got positive response for non-existant document and non-existant file");
 		}

--- a/core/src/test/java/com/findwise/hydra/net/HttpRESTHandlerTest.java
+++ b/core/src/test/java/com/findwise/hydra/net/HttpRESTHandlerTest.java
@@ -9,10 +9,10 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Random;
 
+import com.findwise.hydra.local.HttpRemotePipeline;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.findwise.hydra.local.RemotePipeline;
 import com.findwise.hydra.memorydb.MemoryConnector;
 import com.findwise.hydra.memorydb.MemoryType;
 
@@ -33,7 +33,7 @@ public class HttpRESTHandlerTest {
 	public void testSupportsAllUrls() throws
 			IllegalArgumentException,
 			IllegalAccessException {
-		Field[] fields = RemotePipeline.class.getFields();
+		Field[] fields = HttpRemotePipeline.class.getFields();
 		for (Field f : fields) {
 			int mod = f.getModifiers();
 			if (Modifier.isFinal(mod) && f.getName().endsWith("_URL")) {

--- a/core/src/test/java/com/findwise/hydra/net/MarkHandlerTest.java
+++ b/core/src/test/java/com/findwise/hydra/net/MarkHandlerTest.java
@@ -1,5 +1,6 @@
 package com.findwise.hydra.net;
 
+import com.findwise.hydra.local.HttpRemotePipeline;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,7 +28,7 @@ public class MarkHandlerTest {
 	
 	@Test
 	public void testMarkPersistance() throws Exception {
-		RemotePipeline rp = new RemotePipeline("localhost", server.getPort(), "x");
+		RemotePipeline rp = new HttpRemotePipeline("localhost", server.getPort(), "x");
 		
 		LocalDocument doc = new LocalDocument();
 

--- a/core/src/test/java/com/findwise/hydra/net/WriteHandlerTest.java
+++ b/core/src/test/java/com/findwise/hydra/net/WriteHandlerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.findwise.hydra.local.HttpRemotePipeline;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,7 +51,7 @@ public class WriteHandlerTest {
 		
 		when(dbdoc.getID()).thenReturn(null);
 		
-		RemotePipeline rp = new RemotePipeline("localhost", server.getPort(), "stage");
+		RemotePipeline rp = new HttpRemotePipeline("localhost", server.getPort(), "stage");
 		LocalDocument ld = new LocalDocument();
 		
 		boolean result = rp.saveFull(ld);
@@ -75,7 +76,7 @@ public class WriteHandlerTest {
 		when(dbdoc.getID()).thenReturn(id);
 		when(reader.getDocumentById(id)).thenReturn(dbdoc);
 		
-		RemotePipeline rp = new RemotePipeline("localhost", server.getPort(), "stage");
+		RemotePipeline rp = new HttpRemotePipeline("localhost", server.getPort(), "stage");
 		LocalDocument ld = new LocalDocument();
 		
 		boolean result = rp.saveFull(ld);

--- a/examples/src/main/java/com/findwise/hydra/FlowCheck.java
+++ b/examples/src/main/java/com/findwise/hydra/FlowCheck.java
@@ -2,9 +2,9 @@ package com.findwise.hydra;
 
 import java.io.IOException;
 
+import com.findwise.hydra.local.HttpRemotePipeline;
 import org.apache.http.HttpException;
 
-import com.findwise.hydra.JsonException;
 import com.findwise.hydra.local.RemotePipeline;
 
 public class FlowCheck {
@@ -18,7 +18,7 @@ public class FlowCheck {
 	
 	public void postDocuments(int numberToPost) throws JsonException, IOException, HttpException {
 
-		RemotePipeline rp = new RemotePipeline("insertStage");
+		RemotePipeline rp = new HttpRemotePipeline("insertStage");
 		for(int i=0; i<numberToPost; i++) {
 			rp.saveFull(LocalDocumentFactory.getRandomStringDocument("in", "id", "x", "y", "z", "a", "b", "c", "d", "e", "f"));
 		}

--- a/examples/src/main/java/com/findwise/hydra/InsertFileDocument.java
+++ b/examples/src/main/java/com/findwise/hydra/InsertFileDocument.java
@@ -7,6 +7,7 @@ import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.net.URL;
 
+import com.findwise.hydra.local.HttpRemotePipeline;
 import org.apache.http.HttpException;
 
 import com.findwise.hydra.local.Local;
@@ -20,10 +21,10 @@ public class InsertFileDocument {
 	}
 	
 	public void postDocuments(int numberToPost) throws JsonException, IOException, HttpException, URISyntaxException {
-		RemotePipeline rp = new RemotePipeline("insertStage");
+		RemotePipeline rp = new HttpRemotePipeline("insertStage");
 		for(int i=0; i<numberToPost; i++) {
 			rp.saveFull(LocalDocumentFactory.getRandomStringDocument("in", "id"));
-			RemotePipeline rp2 = new RemotePipeline("fileAdder");
+			RemotePipeline rp2 = new HttpRemotePipeline("fileAdder");
 			LocalDocument ld = rp2.getDocument(new LocalQuery());
 			File f = getFile();
 			FileInputStream fis = new FileInputStream(f);

--- a/examples/src/main/java/com/findwise/hydra/StdinInput.java
+++ b/examples/src/main/java/com/findwise/hydra/StdinInput.java
@@ -1,5 +1,6 @@
 package com.findwise.hydra;
 
+import com.findwise.hydra.local.HttpRemotePipeline;
 import org.apache.commons.lang.StringUtils;
 
 import com.findwise.hydra.local.LocalDocument;
@@ -15,7 +16,7 @@ public class StdinInput {
 	 * @param args
 	 */
 	public static void main(String[] args) {
-		RemotePipeline rp1 = new RemotePipeline("127.0.0.1", 12001, "StdinInputNode");
+		RemotePipeline rp1 = new HttpRemotePipeline("127.0.0.1", 12001, "StdinInputNode");
 		LocalDocument ld = new LocalDocument();
 		
 		for (String tuple : StringUtils.join(args, " ").split(";")) {


### PR DESCRIPTION
This is a preparation for allowing different implementations of the Stage to Core transport (i.e. `RemotePipeline` and the `com.findwise.hydra.net` package).

I'm not sure if it is best to merge the extraction of the interface and the reformatting right away, or if this should be a work in progress PR.

My idea is that with the `RemotePipeline` interface, alternative implementations of the transport are possible from the stage side. It is more complicated on the Core side, but perhaps other implementations don't have to conform with how the REST/HTTP impl works. It's a bit hard to extract interfaces or do other abstractions with the `RESTServer` and the rest of the `com.findwise.hydra.net` classes.
