### PR TITLE
Restructure readme and add stage libs to distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ examples/src/main/resources/*.jar
 .springBeans
 distribution/bin/
 distribution/tools/
+distribution/lib/
 nbactions.xml
 nb-configuration.xml
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Current snapshot: [![Build Status](https://secure.travis-ci.org/Findwise/Hydra.p
 
 This readme uses Google Analytics for basic visit statistics thanks to ga-beacon: [![Analytics](https://ga-beacon.appspot.com/UA-45204268-3/Hydra/readme)](https://github.com/igrigorik/ga-beacon)
 
-What you'll need
-----------------
+Getting started
+---------------
+
+Hydra uses a central database for distributing documents and configuration between nodes. Currently, the only supported database is MongoDB.
 
 * [MongoDB](http://www.mongodb.org/downloads) 
-
-You'll need a database as the central node for Hydra. Currently, the only supported database is MongoDB. Simply install and start MongoDB.
 
 To get output from Hydra, the following systems are supported:
 
@@ -25,117 +25,15 @@ To get output from Hydra, the following systems are supported:
 Check [stages/out](https://github.com/Findwise/Hydra/tree/master/stages/out) to see the implemented outputs.
 You can easily write your own output, as well!
 
-Starting Hydra
---------------
+### Setting up a pipeline
 
-You have two alternatives, either build Hydra yourself to get the very latest features, or download the latest released (and stable).
-### Getting and starting core
-#### Download Hydra
+To set up a pipeline, we want to add *stage libraries* containing stages, *stage configuration* to instruct Hydra how the stages should be run, and a *document* to process. Let's get started!
 
-You can find the latest released build on [the download page](http://findwise.github.io/Hydra/#downloads). The main executable is called Hydra Core.
-See the section "Setting up a pipeline" in this readme for how to get started.
+Download MongoDB (see [Getting started](#getting-started))
 
-#### Building Hydra 
+Start the MongoDB deamon (mongod), in your `mongodb/bin` folder.
 
-If you want to get involved in development of the framework, or simply want to try out the latest new features, you will need to build it yourself. Building Hydra, however, is very simple. 
-
-There are a few pre-requisites: Hydra is built with Maven, and as such you will need to install and set up [maven](http://maven.apache.org). You will also need to have a MongoDB instance running for some of the integration tests to pass.
-
-1. Clone the repository.
-2. In the root directory, run `mvn clean install`
-3. To start, run `java -jar hydra-core.jar` from inside the `distribution/bin` directory
-
-Using Hydra
------------
-
-Once you have a running pipeline system, you can now start adding some some stages to it. For the most basic pipeline, you'll want to load at least two stage libraries into Hydra: `basic-stages` and `solr-out` (if you are connecting Hydra to send documents to Solr).
-
-You'll find the projects to build these two (using Maven) in `stages/processing/basic` and `stages/output/solr`.
-
-There are a few different methods for setting up pipelines in Hydra:
-
-* Script your pipeline setup with the `database-impl/mongodb` package
-* Set up the Admin Service webapp and configure the pipeline using its REST interface (see the readme file in the `admin-service` package)
-* Use the `CmdlineInserter`-class that you can find in the `tools` project under the Hydra root
-
-Using the CmdlineInserter, if you run `mvn clean install` on that project, you will get a runnable jar that you can use (`java -jar hydra-inserter.jar`) Below, we'll assume that's the method you are using. 
-
-### Inserting a library into Hydra
-When inserting the library, you will need to provide the name of the jar and an ID that uniquely identifies this library. Should you give an ID that already exists, the old library will be overwritten and *any pipeline stages being run from it will be restarted.*
-
-Run the CmdlineInserter class (or the jar) with the following arguments:
-	`-a -p pipeline -l -i {my-library-id} {my-jar-with-dependencies.jar}` 
-
-### Configuring a stage in Hydra
-
-Now that you have a library inserted, you can add your stage by referencing the library id. 
-
-#### The configuration
-In order to configure a stage, you'll need to know what stage it is you want to configure. A configuration for a SetStaticField-stage might look like this:
-
-```
-
-	{
-		stageClass: "com.findwise.hydra.stage.SetStaticFieldStage",
-		query: {"touched" : {"extractTitles" : true}, "exists" : {"source" : true} },
-		fieldValueMap: {"source": ["value1", "value2"] }
-	}
-
-```
-
-* __stageClass__: *Required*. Must be the full name of the stage class to be configured. 
-* __query__: A serialized version of the query, that all documents this stage receives must match. In this example, all documents received by this stage will have already been processed by a stage called _extractTitles_ and they all have a field called _source_. See below for more information about the query syntax.
-* __fieldValueMap__: A parameter expected by this stage. Parameters can be a number of different types and are used for stage-specific configuration. This parameter is a map from field names to objects (JSON arrays are converted to lists).
-
-Save the configuration in a file somewhere on disk, e.g. {mystage.properties}, for ease of use. 
-
-The possible configuration parameteras for each stage can be found using the `admin-service` web application. Try the `/libraries` endpoint to see all the stages of all your inserted libraries and their configurable parameters.
-
-##### Query syntax
-The `query` in the configuration is used to decide what documents the stage should make changes to. A document is picked up by the stage only if it matched *all* clauses in the query. The available options are:
-
-* { "touched" : { "stageId" : true/false } } - Matches if a documents has (or has not if value is `false`) been processed by the stage with id `stageId`
-* { "exists" : { "fieldName" : true/false } } - Matches if the document has (or has not if value is `false`) a field called `fieldName`
-* { "equals" : { "fieldName" : fieldValue} } - Matches if the document has a field called `fieldName` with the value `fieldValue` (where `fieldValue` may be any object)
-* { "notEquals" : { "fieldName" : fieldValue} } - Matches whenever equlas is not matching
-* { "action" : "ADD"/"UPDATE"/"DELETE" } - Matches if the action of the document is set to `ADD`, `UPDATE` or `DELETE`
-
-#### Inserting the configuration
-
-Run the CmdlineInserter class (or the jar) with the following arguments:
-	`-a -p pipeline -s -i {my-library-id} -n {my-stage-name} {mystage.properties}` 
-	
-That's it. You now have a pipeline configured with a SetStaticField-stage. If your Hydra Core was running while you configured this, you'll notice that it picked up the change and launched the stage with the properties you provided. Any subsequent changes to the configuration will also make Hydra Core restart the stage.
-
-Next, you'll probably want to add an output stage, and then start pushing some documents in!
-
-#### Inserting documents
-
-There are a couple of way to import your documents into Hydra. The easiest way would be to post a document to the hydra admin-service (see documentation in the `admin-service` package). Adding documents this way is however not recommended in a production environment. Instead, create your own input connector using the `hydra-mongodb` package in `database-impl`. 
-
-Basically, an input connector pushes data directly to mongodb by creating an instance of `MongoDocumentIO` and calling its insert method:
-
-```
-
-	...
-	MongoDocumentIO io = new MongoDocumentIO(db, concern, documentsToKeep, oldDocsMaxSizeMB, updater, documentFs);
-	io.prepare();
-
-	MongoDocument document = new MongoDocument(jsonDocument);
-	io.insert(document);
-	...
-
-```
-
-A `StdinInput`connector can be found in the `stages/debugging` package, and can be used as a reference implementation.
-
-## Setting up a pipeline
-
-To set up a pipeline, we want to add *stage libraries* containing stages, *stage configuration* to instruct Hydra how the stages should be run, and a *document* to process.
-
-Start the mongo deamon (mongod), in your `mongodb/bin` folder.
-
-Get hold of the following jars, either by building Hydra or downloading from https://github.com/Findwise/Hydra/releases
+Get hold of the following jars, either by building Hydra or downloading from the [Releases page on Github](https://github.com/Findwise/Hydra/releases).
 
 * Hydra Core: `hydra-core.jar`
 * Hydra Inserter (CmdLineInserter): `hydra-inserter.jar`
@@ -201,8 +99,92 @@ Everything is now up and running. To add a document for processing, just type
 
 Hydra will print out the processed document, that should contain a title as well as the imported text. Try modifying the configuration, inserting it again, then insert a new document and see what happens!
 
+Using Hydra
+------------------
 
-## Debugging
+Once you have a running pipeline system, you can now start adding some some stages to it. For the most basic pipeline, you'll want to load at least two stage libraries into Hydra: `basic-stages` and `solr-out` (if you are connecting Hydra to send documents to Solr).
+
+You'll find the projects to build these two (using Maven) in `stages/processing/basic` and `stages/output/solr`.
+
+There are a few different methods for setting up pipelines in Hydra:
+
+* Script your pipeline setup with the `database-impl/mongodb` package
+* Set up the Admin Service webapp and configure the pipeline using its REST interface (see the readme file in the `admin-service` package)
+* Use the `CmdlineInserter`-class that you can find in the `tools` project under the Hydra root
+
+Using the CmdlineInserter, if you run `mvn clean install` on that project, you will get a runnable jar that you can use (`java -jar hydra-inserter.jar`) Below, we'll assume that's the method you are using. 
+
+### Inserting a library into Hydra
+
+When inserting the library, you will need to provide the name of the jar and an ID that uniquely identifies this library. Should you give an ID that already exists, the old library will be overwritten and *any pipeline stages being run from it will be restarted.*
+
+Run the CmdlineInserter class (or the jar) with the following arguments:
+	`-a -p pipeline -l -i {my-library-id} {my-jar-with-dependencies.jar}` 
+
+### Configuring a stage in Hydra
+
+Now that you have a library inserted, you can add your stage by referencing the library id. 
+
+#### The configuration
+
+In order to configure a stage, you'll need to know what stage it is you want to configure. A configuration for a SetStaticField-stage might look like this:
+
+```
+
+	{
+		stageClass: "com.findwise.hydra.stage.SetStaticFieldStage",
+		query: {"touched" : {"extractTitles" : true}, "exists" : {"source" : true} },
+		fieldValueMap: {"source": ["value1", "value2"] }
+	}
+
+```
+
+* __stageClass__: *Required*. Must be the full name of the stage class to be configured. 
+* __query__: A serialized version of the query, that all documents this stage receives must match. In this example, all documents received by this stage will have already been processed by a stage called _extractTitles_ and they all have a field called _source_. See below for more information about the query syntax.
+* __fieldValueMap__: A parameter expected by this stage. Parameters can be a number of different types and are used for stage-specific configuration. This parameter is a map from field names to objects (JSON arrays are converted to lists).
+
+Save the configuration in a file somewhere on disk, e.g. `mystage.properties`, for ease of use. 
+
+The possible configuration parameteras for each stage can be found using the `admin-service` web application. Try the `/libraries` endpoint to see all the stages of all your inserted libraries and their configurable parameters.
+
+##### Query syntax
+The `query` in the configuration is used to decide what documents the stage should make changes to. A document is picked up by the stage only if it matched *all* clauses in the query. The available options are:
+
+* `{ "touched" : { "stageId" : true/false } }` - Matches if a documents has (or has not if value is `false`) been processed by the stage with id `stageId`
+* `{ "exists" : { "fieldName" : true/false } }` - Matches if the document has (or has not if value is `false`) a field called `fieldName`
+* `{ "equals" : { "fieldName" : fieldValue} }` - Matches if the document has a field called `fieldName` with the value `fieldValue` (where `fieldValue` may be any object)
+* `{ "notEquals" : { "fieldName" : fieldValue} }` - Matches whenever equlas is not matching
+* `{ "action" : "ADD"/"UPDATE"/"DELETE" }` - Matches if the action of the document is set to `ADD`, `UPDATE` or `DELETE`
+
+#### Inserting the configuration
+
+Run the CmdlineInserter class (or the jar) with the following arguments:
+	`-a -p pipeline -s -i {my-library-id} -n {my-stage-name} {mystage.properties}` 
+	
+That's it. You now have a pipeline configured with a SetStaticField-stage. If your Hydra Core was running while you configured this, you'll notice that it picked up the change and launched the stage with the properties you provided. Any subsequent changes to the configuration will also make Hydra Core restart the stage.
+
+Next, you'll probably want to add an output stage, and then start pushing some documents in!
+
+#### Inserting documents
+
+There are a couple of way to import your documents into Hydra. The easiest way would be to post a document to the hydra admin-service (see documentation in the `admin-service` package). Adding documents this way is however not recommended in a production environment. Instead, create your own input connector using the `hydra-mongodb` package in `database-impl`. 
+
+Basically, an input connector pushes data directly to mongodb by creating an instance of `MongoDocumentIO` and calling its insert method:
+
+```
+	...
+	MongoDocumentIO io = new MongoDocumentIO(db, concern, documentsToKeep, oldDocsMaxSizeMB, updater, documentFs);
+	io.prepare();
+
+	MongoDocument document = new MongoDocument(jsonDocument);
+	io.insert(document);
+	...
+
+```
+
+A `StdinInput`connector can be found in the `stages/debugging` package, and can be used as a reference implementation.
+
+### Debugging
 
 You can run your stages from the command line (or you IDE) if you need to debug them. 
 
@@ -214,7 +196,7 @@ i.e.
 ```
 
 
-## Scaling and Distribution
+### Scaling and Distribution
 
 You can easily start a stage with several threads on your machine. This can for example be done when you have one stage that is the bottleneck of your processing. Set the `numberOfThreads` parameter to the stage configuration and push the configuration to hydra and it will restart the stage with more threads.
 
@@ -235,3 +217,14 @@ If you need to distribute Hydra, to make it run on several servers, the only thi
 Configuring the mongodb location is done in the `resource.properties` file, that is located in the `distribution/bin` folder.
 
 If you are running heavy processing in your stages, the cache may time out forcing a new call to mongodb. To prevent this from happening, increase the cache timeout in `resource.properties`. 
+
+### Building and contributing to Hydra 
+
+If you want to get involved in development of the framework, or simply want to try out the latest new features, you will need to build it yourself. Building Hydra, however, is very simple. 
+
+There are a few pre-requisites: Hydra is built with Maven, and as such you will need to install and set up [maven](http://maven.apache.org). You will also need to have a MongoDB instance running for some of the integration tests to pass.
+
+1. Clone the repository
+2. Start MongoDB
+2. In the root directory, run `mvn clean install`
+3. You will find all built stage libraries and binaries in the `distribution/` directory

--- a/admin-service/pom.xml
+++ b/admin-service/pom.xml
@@ -16,6 +16,24 @@
 	<build>
 		<finalName>hydra</finalName>
 		<plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>compile</phase>
+                        <configuration>
+                            <tasks>
+                                <copy file="src/main/resources/admin-service.properties" tofile="target/admin-service.properties" />
+                            </tasks>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 			<plugin>
 				<groupId>org.mortbay.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>

--- a/admin-service/pom.xml
+++ b/admin-service/pom.xml
@@ -13,9 +13,9 @@
         <cglib.version>2.2.2</cglib.version>
     </properties>
 
-	<build>
-		<finalName>hydra</finalName>
-		<plugins>
+    <build>
+        <finalName>hydra</finalName>
+        <plugins>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>1.4</version>
@@ -34,19 +34,19 @@
                     </execution>
                 </executions>
             </plugin>
-			<plugin>
-				<groupId>org.mortbay.jetty</groupId>
-				<artifactId>jetty-maven-plugin</artifactId>
-				<version>8.1.14.v20131031</version>
-				<configuration>
-					<scanIntervalSeconds>10</scanIntervalSeconds>
-					<webApp>
-						<contextPath>/hydra</contextPath>
-					</webApp>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+            <plugin>
+                <groupId>org.mortbay.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>8.1.14.v20131031</version>
+                <configuration>
+                    <scanIntervalSeconds>10</scanIntervalSeconds>
+                    <webApp>
+                        <contextPath>/hydra</contextPath>
+                    </webApp>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <dependency>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -41,8 +41,16 @@
 						<configuration>
 							<tasks>
 								<copy file="../core/target/hydra-core-jar-with-dependencies.jar" tofile="bin/hydra-core.jar" />
-								<copy file="../core/target/resource.properties" tofile="bin/resource.properties" />
+								<copy file="../core/target/resource.properties" tofile="bin/hydra-core.properties" />
+								<copy file="../admin-service/target/hydra.war" tofile="bin/hydra-admin-service.war" />
+								<copy file="../admin-service/target/admin-service.properties" tofile="bin/hydra-admin-service.properties" />
 								<copy file="../tools/inserter/target/hydra-inserter-jar-with-dependencies.jar" tofile="tools/hydra-inserter.jar" />
+								<copy file="../stages/processing/basic/target/hydra-basic-stages-jar-with-dependencies.jar" tofile="lib/hydra-basic-stages-jar-with-dependencies.jar" />
+								<copy file="../stages/processing/tika/target/hydra-tika-stages-jar-with-dependencies.jar" tofile="lib/hydra-tika-stages-jar-with-dependencies.jar" />
+								<copy file="../stages/processing/web/target/hydra-web-stages-jar-with-dependencies.jar" tofile="lib/hydra-web-stages-jar-with-dependencies.jar" />
+								<copy file="../stages/out/elasticsearch-out/target/hydra-elasticsearch-out-stage-jar-with-dependencies.jar" tofile="lib/hydra-elasticsearch-out-stage-jar-with-dependencies.jar" />
+								<copy file="../stages/out/solr-out/target/hydra-solr-out-stage-jar-with-dependencies.jar" tofile="lib/hydra-solr-out-stage-jar-with-dependencies.jar" />
+								<copy file="../stages/out/solr-out-3.6/target/hydra-solr-3-out-stage-jar-with-dependencies.jar" tofile="lib/hydra-solr-3-out-stage-jar-with-dependencies.jar" />
 							</tasks>
 						</configuration>
 						<goals>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -17,14 +17,61 @@
 		<dependency>
 			<groupId>com.findwise.hydra</groupId>
 			<artifactId>hydra-core</artifactId>
-			<version>0.6.0-SNAPSHOT</version>
+			<version>${project.parent.version}</version>
 			<classifier>jar-with-dependencies</classifier>
 		</dependency>
 		<dependency>
 			<groupId>com.findwise.hydra</groupId>
 			<artifactId>hydra-inserter</artifactId>
-			<version>0.6.0-SNAPSHOT</version>
+			<version>${project.parent.version}</version>
 			<classifier>jar-with-dependencies</classifier>
+		</dependency>
+		<dependency>
+			<groupId>com.findwise.hydra</groupId>
+			<artifactId>hydra-admin-service</artifactId>
+			<version>${project.parent.version}</version>
+			<type>war</type>
+		</dependency>
+		<!-- Stage Libraries -->
+		<dependency>
+			<groupId>com.findwise.hydra</groupId>
+			<artifactId>hydra-basic-stages</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.findwise.hydra</groupId>
+			<artifactId>hydra-groovy-runner</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.findwise.hydra</groupId>
+			<artifactId>hydra-tika-stages</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.findwise.hydra</groupId>
+			<artifactId>hydra-web-stages</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.findwise.hydra</groupId>
+			<artifactId>hydra-elasticsearch-out-stage</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.findwise.hydra</groupId>
+			<artifactId>hydra-solr-out-stage</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.findwise.hydra</groupId>
+			<artifactId>hydra-solr-3-out-stage</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.findwise.hydra</groupId>
+			<artifactId>hydra-debugging</artifactId>
+			<version>${project.parent.version}</version>
 		</dependency>
 	</dependencies>
 
@@ -40,17 +87,25 @@
 						<inherited>false</inherited>
 						<configuration>
 							<tasks>
+								<!-- Core -->
 								<copy file="../core/target/hydra-core-jar-with-dependencies.jar" tofile="bin/hydra-core.jar" />
 								<copy file="../core/target/resource.properties" tofile="bin/hydra-core.properties" />
+								<!-- Admin Service -->
 								<copy file="../admin-service/target/hydra.war" tofile="bin/hydra-admin-service.war" />
 								<copy file="../admin-service/target/admin-service.properties" tofile="bin/hydra-admin-service.properties" />
+								<!-- Tools -->
 								<copy file="../tools/inserter/target/hydra-inserter-jar-with-dependencies.jar" tofile="tools/hydra-inserter.jar" />
+								<!-- Stage Libraries: Processing -->
 								<copy file="../stages/processing/basic/target/hydra-basic-stages-jar-with-dependencies.jar" tofile="lib/hydra-basic-stages-jar-with-dependencies.jar" />
+								<copy file="../stages/processing/hydra-groovy-runner/target/hydra-groovy-runner-jar-with-dependencies.jar" tofile="lib/hydra-groovy-runner-jar-with-dependencies.jar" />
 								<copy file="../stages/processing/tika/target/hydra-tika-stages-jar-with-dependencies.jar" tofile="lib/hydra-tika-stages-jar-with-dependencies.jar" />
 								<copy file="../stages/processing/web/target/hydra-web-stages-jar-with-dependencies.jar" tofile="lib/hydra-web-stages-jar-with-dependencies.jar" />
+								<!-- Stage Libraries: Output -->
 								<copy file="../stages/out/elasticsearch-out/target/hydra-elasticsearch-out-stage-jar-with-dependencies.jar" tofile="lib/hydra-elasticsearch-out-stage-jar-with-dependencies.jar" />
 								<copy file="../stages/out/solr-out/target/hydra-solr-out-stage-jar-with-dependencies.jar" tofile="lib/hydra-solr-out-stage-jar-with-dependencies.jar" />
 								<copy file="../stages/out/solr-out-3.6/target/hydra-solr-3-out-stage-jar-with-dependencies.jar" tofile="lib/hydra-solr-3-out-stage-jar-with-dependencies.jar" />
+								<!-- Stage Libraries: Debugging -->
+								<copy file="../stages/debugging/debugging/target/hydra-debugging-jar-with-dependencies.jar" tofile="lib/hydra-debugging-jar-with-dependencies.jar" />
 							</tasks>
 						</configuration>
 						<goals>

--- a/stages/processing/hydra-groovy-runner/pom.xml
+++ b/stages/processing/hydra-groovy-runner/pom.xml
@@ -34,6 +34,54 @@
 	<build>
 		<plugins>
 			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<configuration>
+					<finalName>${project.artifactId}</finalName>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+					<archive>
+						<manifest>
+							<addClasspath>true</addClasspath>
+							<mainClass>com.findwise.hydra.stage.StageStarter</mainClass>
+						</manifest>
+					</archive>
+				</configuration>
+				<executions>
+					<execution>
+						<id>make-assembly</id>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
 				<version>1.3</version>


### PR DESCRIPTION
- Readme is better structured with the getting started at the top, instead of compilation instructions.
- Most stage libraries are now found in `distribution/lib` after building the parent pom.
