### PR TITLE
Fixes broken configuration when modifying stages in the GUI, if those st...

### DIFF
--- a/admin-service/src/main/java/com/findwise/hydra/admin/ConfigurationService.java
+++ b/admin-service/src/main/java/com/findwise/hydra/admin/ConfigurationService.java
@@ -119,10 +119,10 @@ public class ConfigurationService<T extends DatabaseType> {
 	public void addStageParameters(Stage stage) throws DatabaseException, StageClassNotFoundException {
 		try {
 			Map<String, StageInformation> stages = getPipelineScanner().getStagesMap(stage.getDatabaseFile());
-			String stageClass = (String) stage.getProperties().get(AbstractProcessStageMapper.ARG_NAME_STAGE_CLASS);
+			Map<String, Object> properties = stage.getProperties();
+			String stageClass = (String) properties.get(AbstractProcessStageMapper.ARG_NAME_STAGE_CLASS);
 			if (null != stageClass && stages.containsKey(stageClass)) {
 				Map<String, Object> parameters = (Map<String, Object>) stages.get(stageClass).get("parameters");
-				Map<String, Object> properties = stage.getProperties();
 				for (String parameterName : parameters.keySet()) {
 					Map<String, Object> parameter = (Map<String, Object>) parameters.get(parameterName);
 					if (properties.containsKey(parameterName)) {
@@ -130,6 +130,9 @@ public class ConfigurationService<T extends DatabaseType> {
 					}
 					properties.put(parameterName, parameter);
 				}
+				properties.put("stageName", stage.getName());
+				properties.put("stageGroup", connector.getPipelineReader().getPipeline().getGroupForStage(stage.getName()).getName());
+				properties.put("libId", stage.getDatabaseFile().getId());
 			} else {
 				throw new StageClassNotFoundException("Stage class '" + stageClass
 						+ "' for stage '" + stage.getName() + "' not found."


### PR DESCRIPTION
...ages were not inserted by the GUI

All stage configurations that the GUI touches will now get the fields stageName, stageGroup and libId added to their properties map.
This means the stagegroups endpoint returns a modified properties map that contains the fields, and adding a stage using the Admin Service automatically adds the fields.
The stages endpoint will return only the fields that are currently stored in the database, with no additions.

This fixes #330
