### PR TITLE
Makes failed stage API calls to the Core log in a more understandable way

### DIFF
--- a/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
+++ b/api/src/main/java/com/findwise/hydra/local/RemotePipeline.java
@@ -116,7 +116,7 @@ public class RemotePipeline {
 			internalLogger.debug("No document found matching query");
 			EntityUtils.consume(response.getEntity());
 		} else {
-			logUnexpected(response);
+			logUnexpected("getDocument()", response);
 		}
 		if (isPerformanceLogging()) {
 			long end = System.currentTimeMillis();
@@ -126,9 +126,9 @@ public class RemotePipeline {
 		return ld;
 	}
 
-	private static void logUnexpected(HttpResponse response) throws IOException {
-		internalLogger.error("Node gave an unexpected response: " + response.getStatusLine());
-		internalLogger.error("Message: " + EntityUtils.toString(response.getEntity()));
+	private static void logUnexpected(String apiMethod, HttpResponse response) throws IOException {
+		internalLogger.error(apiMethod + " gave an unexpected response: " + response.getStatusLine()
+				+ ", Message: " + EntityUtils.toString(response.getEntity()));
 	}
 
 	/**
@@ -195,7 +195,7 @@ public class RemotePipeline {
 			return true;
 		}
 
-		logUnexpected(response);
+		logUnexpected("save(partial=" + partialUpdate + ")", response);
 		return false;
 	}
 
@@ -207,7 +207,7 @@ public class RemotePipeline {
 			return true;
 		}
 
-		logUnexpected(response);
+		logUnexpected("markPending()", response);
 
 		return false;
 	}
@@ -220,7 +220,7 @@ public class RemotePipeline {
 			return true;
 		}
 
-		logUnexpected(response);
+		logUnexpected("markFailed()", response);
 
 		return false;
 	}
@@ -238,7 +238,7 @@ public class RemotePipeline {
 			return true;
 		}
 
-		logUnexpected(response);
+		logUnexpected("markProcessed()", response);
 
 		return false;
 	}
@@ -251,7 +251,7 @@ public class RemotePipeline {
 			return true;
 		}
 
-		logUnexpected(response);
+		logUnexpected("markDiscarded()", response);
 
 		return false;
 	}
@@ -284,7 +284,7 @@ public class RemotePipeline {
 			EntityUtils.consume(response.getEntity());
 			return null;
 		} else {
-			logUnexpected(response);
+			logUnexpected("getProperties()", response);
 			return null;
 		}
 	}
@@ -330,7 +330,7 @@ public class RemotePipeline {
 
 			return df;
 		} else {
-			logUnexpected(response);
+			logUnexpected("getFile()", response);
 			return null;
 		}
 	}
@@ -342,7 +342,7 @@ public class RemotePipeline {
 			EntityUtils.consume(response.getEntity());
 			return true;
 		} else {
-			logUnexpected(response);
+			logUnexpected("saveFile()", response);
 			return false;
 		}
 	}
@@ -354,7 +354,7 @@ public class RemotePipeline {
 			EntityUtils.consume(response.getEntity());
 			return true;
 		} else {
-			logUnexpected(response);
+			logUnexpected("deleteFile()", response);
 			return false;
 		}
 	}
@@ -370,7 +370,7 @@ public class RemotePipeline {
 				throw new IOException(e);
 			}
 		} else {
-			logUnexpected(response);
+			logUnexpected("getFileNames()", response);
 			return null;
 		}
 	}


### PR DESCRIPTION
The log messages on failures in `RemotePipeline` were cryptic and caused misunderstandings. They now report what api method was called and log on a single line.

This fixes #345 
