### PR TITLE
Store "fetched" metadata as a list in MongoDocument

### DIFF
--- a/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocument.java
+++ b/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocument.java
@@ -614,13 +614,17 @@ public class MongoDocument implements DBObject, DatabaseDocument<MongoType> {
 	}
 
 	private void appendFetchedByToFetchedList(String stage) {
-		touchedMetadata.add(MONGO_FETCHED_METADATA_TAG_LIST);
 		if (!getMetadata().containsField(MONGO_FETCHED_METADATA_TAG_LIST)) {
+			touchedMetadata.add(MONGO_FETCHED_METADATA_TAG_LIST);
 			List<String> fetchedList = new ArrayList<String>();
 			fetchedList.add(stage);
 			getMetadata().put(MONGO_FETCHED_METADATA_TAG_LIST, fetchedList);
 		} else {
-			getMetadataListField(MONGO_FETCHED_METADATA_TAG_LIST).add(stage);
+			List<Object> fetchedList = getMetadataListField(MONGO_FETCHED_METADATA_TAG_LIST);
+			if (!fetchedList.contains(stage)) {
+				touchedMetadata.add(MONGO_FETCHED_METADATA_TAG_LIST);
+				fetchedList.add(stage);
+			}
 		}
 	}
 

--- a/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocumentIO.java
+++ b/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocumentIO.java
@@ -351,14 +351,15 @@ public class MongoDocumentIO implements DocumentReader<MongoType>, DocumentWrite
 		}
 		DBObject update = new BasicDBObject();
 		List<String> tags = new ArrayList<String>();
+		
 		for(String t : tag) {
 			update.put(MongoDocument.METADATA_KEY + "." + DatabaseDocument.FETCHED_METADATA_TAG + "." + t, new Date());
 			tags.add(t);
 		}
-		update.put(MongoDocument.METADATA_KEY + "." + MongoDocument.MONGO_FETCHED_METADATA_TAG_LIST, tags);
 
 		DBObject dbo = getUpdateObject(update);
-
+		dbo.put("$addToSet", new BasicDBObject(MongoDocument.METADATA_KEY + "." + MongoDocument.MONGO_FETCHED_METADATA_TAG_LIST,new BasicDBObject("$each",tags)));
+		
 		return findAndModify(mq.toDBObject(), dbo);
 	}
 	
@@ -626,7 +627,7 @@ public class MongoDocumentIO implements DocumentReader<MongoType>, DocumentWrite
 	}
 	
 	private MongoDocument findAndModify(DBObject query, DBObject modification) {
-		DBObject c = documents.findAndModify(query, modification);
+		DBObject c = documents.findAndModify( query, null, null, false, modification, true, false );
 		
 		if(c==null) {
 			return null;

--- a/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocumentIO.java
+++ b/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocumentIO.java
@@ -347,13 +347,16 @@ public class MongoDocumentIO implements DocumentReader<MongoType>, DocumentWrite
 		mq.requireMetadataFieldNotEquals(Document.COMMITTING_METADATA_FLAG, true);
 
 		for(String t : tag) {
-			mq.requireMetadataFieldNotExists(DatabaseDocument.FETCHED_METADATA_TAG+"."+t);
+			mq.requireNotFetchedByStage(t);
 		}
 		DBObject update = new BasicDBObject();
+		List<String> tags = new ArrayList<String>();
 		for(String t : tag) {
-			update.put(MongoDocument.METADATA_KEY+"."+DatabaseDocument.FETCHED_METADATA_TAG+"."+t, new Date());
+			update.put(MongoDocument.METADATA_KEY + "." + DatabaseDocument.FETCHED_METADATA_TAG + "." + t, new Date());
+			tags.add(t);
 		}
-		
+		update.put(MongoDocument.METADATA_KEY + "." + MongoDocument.MONGO_FETCHED_METADATA_TAG_LIST, tags);
+
 		DBObject dbo = getUpdateObject(update);
 
 		return findAndModify(mq.toDBObject(), dbo);
@@ -362,8 +365,8 @@ public class MongoDocumentIO implements DocumentReader<MongoType>, DocumentWrite
 	private void ensureIndex(String tag) {
 		if(!seenTags.contains(tag)) {
 			long start = System.currentTimeMillis();
-			documents.ensureIndex(MongoDocument.METADATA_KEY+"."+DatabaseDocument.FETCHED_METADATA_TAG+"."+tag);
-			logger.info("Ensured index for stage "+tag+" in "+(System.currentTimeMillis()-start)+" ms");
+			documents.ensureIndex(MongoDocument.METADATA_KEY + "." + MongoDocument.MONGO_FETCHED_METADATA_TAG_LIST);
+			logger.info("Ensured index for stage " + tag + " in " + (System.currentTimeMillis() - start) + " ms");
 			seenTags.add(tag);
 		}
 	}

--- a/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocumentIO.java
+++ b/database-impl/mongodb/src/main/java/com/findwise/hydra/mongodb/MongoDocumentIO.java
@@ -53,13 +53,12 @@ public class MongoDocumentIO implements DocumentReader<MongoType>, DocumentWrite
 	private final WriteConcern concern;
 	
 	private final StatusUpdater updater;
-	
-	private final Set<String> seenTags = new HashSet<String>();
-	
+		
 	private static Logger logger = LoggerFactory.getLogger(MongoDocumentIO.class);
 
 	private final long maxDocumentsToKeep;
 	private final int oldDocsSize;
+	private boolean indexEnsured =false;
 	
 	public static final String DOCUMENT_COLLECTION = "documents";
 	public static final String OLD_DOCUMENT_COLLECTION ="oldDocuments";
@@ -335,9 +334,9 @@ public class MongoDocumentIO implements DocumentReader<MongoType>, DocumentWrite
 	 */
 	@Override
 	public MongoDocument getAndTag(DatabaseQuery<MongoType> query, String ... tag) {
-		for(String t : tag) {
-			ensureIndex(t);
-		}
+		
+		ensureIndex();
+		
 		MongoQuery mq = (MongoQuery)query;
 		mq.requireMetadataFieldNotExists(Document.PENDING_METADATA_FLAG);
 
@@ -363,12 +362,12 @@ public class MongoDocumentIO implements DocumentReader<MongoType>, DocumentWrite
 		return findAndModify(mq.toDBObject(), dbo);
 	}
 	
-	private void ensureIndex(String tag) {
-		if(!seenTags.contains(tag)) {
+	private void ensureIndex() {
+		if(!indexEnsured) {
 			long start = System.currentTimeMillis();
 			documents.ensureIndex(MongoDocument.METADATA_KEY + "." + MongoDocument.MONGO_FETCHED_METADATA_TAG_LIST);
-			logger.info("Ensured index for stage " + tag + " in " + (System.currentTimeMillis() - start) + " ms");
-			seenTags.add(tag);
+			logger.info("Ensured index for"+ MongoDocument.METADATA_KEY + "." + MongoDocument.MONGO_FETCHED_METADATA_TAG_LIST +" in " + (System.currentTimeMillis() - start) + " ms");
+			indexEnsured = true;
 		}
 	}
 	

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOIT.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOIT.java
@@ -3,7 +3,6 @@ package com.findwise.hydra.mongodb;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -21,7 +20,6 @@ import java.util.Random;
 
 import org.apache.commons.io.IOUtils;
 import org.bson.types.ObjectId;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOMongoLessTest.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentIOMongoLessTest.java
@@ -3,7 +3,7 @@ package com.findwise.hydra.mongodb;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
-import junit.framework.Assert;
+import static org.junit.Assert.*;
 
 import org.bson.types.ObjectId;
 import org.junit.Before;
@@ -76,9 +76,9 @@ public class MongoDocumentIOMongoLessTest {
 				"I am suck!"));
 
 		boolean processed = documentIO.markProcessed(document, "Test stage");
-
-		Assert.assertFalse("Processing should not be fine", processed);
-		Assert.assertTrue("The document should have logged errors", document.hasErrors());
+		
+		assertFalse("Processing should not be fine", processed);
+		assertTrue("The document should have logged errors", document.hasErrors());
 	}
 
 	@Test
@@ -103,10 +103,10 @@ public class MongoDocumentIOMongoLessTest {
 
 		boolean processed = documentIO.markProcessed(document, "Test stage");
 
-		Assert.assertTrue("Processing should return successfully.", processed);
-		Assert.assertTrue("The field 'body' should be removed.",
+		assertTrue("Processing should return successfully.", processed);
+		assertTrue("The field 'body' should be removed.",
 				document.getContentField(contentField).equals("<Removed>"));
-		Assert.assertTrue("The document should have logged errors", document.hasErrors());
+		assertTrue("The document should have logged errors", document.hasErrors());
 	}
 
 	@Test
@@ -135,9 +135,9 @@ public class MongoDocumentIOMongoLessTest {
 		boolean processed = documentIO.markProcessed(document, "Test stage");
 
 		// One field should have been removed now, and it should be the longest one.
-		Assert.assertEquals(shortValue, document.getContentField("short"));
-		Assert.assertEquals("<Removed>", document.getContentField("long"));
-		Assert.assertTrue("Processing should return successfully.", processed);
+		assertEquals(shortValue, document.getContentField("short"));
+		assertEquals("<Removed>", document.getContentField("long"));
+		assertTrue("Processing should return successfully.", processed);
 	}
 
 }

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentTest.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentTest.java
@@ -1,10 +1,6 @@
 package com.findwise.hydra.mongodb;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentTest.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentTest.java
@@ -6,8 +6,12 @@ import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
+import com.findwise.hydra.Document;
 import org.bson.types.ObjectId;
 import org.junit.Test;
 
@@ -252,7 +256,7 @@ public class MongoDocumentTest {
 		mq.requireNotFetchedByStage("stage2");
 		assertTrue(md.matches(mq));
 	}
-	
+
 	@Test
 	public void testRemoveFetchedBy() {
 		MongoDocument md = new MongoDocument();
@@ -260,10 +264,14 @@ public class MongoDocumentTest {
 		md.setFetchedBy("stage", new Date());
 		md.setFetchedBy("stage2", new Date());
 		assertEquals(2, md.getFetchedBy().size());
-		
+		assertEquals(Arrays.asList("stage", "stage2"),
+				md.getMetadataField(MongoDocument.MONGO_FETCHED_METADATA_TAG_LIST));
+
 		md.removeFetchedBy("stage2");
 		assertEquals(1, md.getFetchedBy().size());
 		assertTrue(md.fetchedBy("stage"));
+		assertEquals(Arrays.asList("stage"),
+				md.getMetadataField(MongoDocument.MONGO_FETCHED_METADATA_TAG_LIST));
 	}
 	
 	@Test
@@ -300,5 +308,16 @@ public class MongoDocumentTest {
 		mq = new MongoQuery();
 		mq.requireNotTouchedByStage("stage2");
 		assertTrue(md.matches(mq));
+	}
+
+	@Test
+	public void testPutMetadataField_appends_to_fetchedList() {
+		MongoDocument md = new MongoDocument();
+		Map<String, Date> fetched = new HashMap<String, Date>();
+		fetched.put("somestage", new Date());
+		md.putMetadataField(Document.FETCHED_METADATA_TAG, fetched);
+
+		assertTrue(md.hasMetadataField(MongoDocument.MONGO_FETCHED_METADATA_TAG_LIST));
+		assertEquals(Arrays.asList("somestage"), md.getMetadataField(MongoDocument.MONGO_FETCHED_METADATA_TAG_LIST));
 	}
 }

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentTest.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoDocumentTest.java
@@ -7,8 +7,10 @@ import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.findwise.hydra.Document;
@@ -311,7 +313,7 @@ public class MongoDocumentTest {
 	}
 
 	@Test
-	public void testPutMetadataField_appends_to_fetchedList() {
+	public void testPutMetadataField_adds_to_fetchedList() {
 		MongoDocument md = new MongoDocument();
 		Map<String, Date> fetched = new HashMap<String, Date>();
 		fetched.put("somestage", new Date());
@@ -320,4 +322,24 @@ public class MongoDocumentTest {
 		assertTrue(md.hasMetadataField(MongoDocument.MONGO_FETCHED_METADATA_TAG_LIST));
 		assertEquals(Arrays.asList("somestage"), md.getMetadataField(MongoDocument.MONGO_FETCHED_METADATA_TAG_LIST));
 	}
+
+	@Test
+	public void testPutMetadataField_does_not_append_to_fetchedList_when_stage_already_there() {
+		MongoDocument md = new MongoDocument();
+		Map<String, Date> fetched1 = new HashMap<String, Date>();
+		fetched1.put("somestage", new Date());
+		md.putMetadataField(Document.FETCHED_METADATA_TAG, fetched1);
+		Map<String, Date> fetched2 = new HashMap<String, Date>();
+		fetched2.put("somestage", new Date());
+		fetched2.put("someOtherStage", new Date());
+		md.putMetadataField(Document.FETCHED_METADATA_TAG, fetched2);
+
+		assertTrue(md.hasMetadataField(MongoDocument.MONGO_FETCHED_METADATA_TAG_LIST));
+		List<String> expected = Arrays.asList("somestage", "someOtherStage");
+		List<?> actual = (List<?>) md.getMetadataField(MongoDocument.MONGO_FETCHED_METADATA_TAG_LIST);
+		assertEquals(expected.size(), actual.size());
+		assertTrue(actual.containsAll(expected));
+		assertFalse(Collections.disjoint(expected, actual));
+	}
+
 }

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoPipelineIOIT.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/MongoPipelineIOIT.java
@@ -9,7 +9,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
 
-import junit.framework.Assert;
+import static org.junit.Assert.*;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -108,25 +108,25 @@ public class MongoPipelineIOIT {
 		p.addGroup(multiGroup);
 		p.addGroup(singleGroup);
 		
-		Assert.assertEquals(2, p.getStageGroups().size());
-		Assert.assertTrue(p.hasGroup("multi"));
-		Assert.assertTrue(p.hasGroup("singleStage"));
+		assertEquals(2, p.getStageGroups().size());
+		assertTrue(p.hasGroup("multi"));
+		assertTrue(p.hasGroup("singleStage"));
 		
 		mongoConnectorResource.reset();
 		mdc = mongoConnectorResource.getConnector();
 		MongoPipelineReader reader = new MongoPipelineReader(mdc.getDB());
 		MongoPipelineWriter writer = new MongoPipelineWriter(reader, WriteConcern.SAFE);
 		
-		Assert.assertEquals(0, reader.getPipeline().getStages().size());
+		assertEquals(0, reader.getPipeline().getStages().size());
 		writer.write(p);
 		
-		Assert.assertEquals(3, reader.getPipeline().getStages().size());
+		assertEquals(3, reader.getPipeline().getStages().size());
 
-		Assert.assertTrue(reader.getPipeline().hasGroup("multi"));
-		Assert.assertTrue(reader.getPipeline().hasGroup("singleStage"));
+		assertTrue(reader.getPipeline().hasGroup("multi"));
+		assertTrue(reader.getPipeline().hasGroup("singleStage"));
 
-		Assert.assertEquals(2, reader.getPipeline().getGroup("multi").getSize());
-		Assert.assertEquals(1, reader.getPipeline().getGroup("singleStage").getSize());
+		assertEquals(2, reader.getPipeline().getGroup("multi").getSize());
+		assertEquals(1, reader.getPipeline().getGroup("singleStage").getSize());
 	}
 	
 	@Test
@@ -158,9 +158,9 @@ public class MongoPipelineIOIT {
 		writer.write(p);
 		
 		StageGroup g2 = reader.getPipeline().getGroup("multi");
-		Assert.assertEquals(multiGroup.getJvmParameters(), g2.getJvmParameters());
-		Assert.assertEquals(multiGroup.getRetries(), g2.getRetries());
-		Assert.assertEquals(multiGroup.isLogging(), g2.isLogging());
-		Assert.assertEquals(multiGroup.getCmdlineArgs(), g2.getCmdlineArgs());
+		assertEquals(multiGroup.getJvmParameters(), g2.getJvmParameters());
+		assertEquals(multiGroup.getRetries(), g2.getRetries());
+		assertEquals(multiGroup.isLogging(), g2.isLogging());
+		assertEquals(multiGroup.getCmdlineArgs(), g2.getCmdlineArgs());
 	}
 }

--- a/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/QueryIT.java
+++ b/database-impl/mongodb/src/test/java/com/findwise/hydra/mongodb/QueryIT.java
@@ -220,5 +220,4 @@ public class QueryIT {
 			}
 		}
 	}
-
 }


### PR DESCRIPTION
This PR adds a second field for querying `fetched` metadata: `fetchedList`. This is internal to the MongoDB implementation - in the API the `fetched` metadata remains a map.

With this change, the hard limit of 64 stages has been removed. Fixes #230.
