### PR TITLE
Default jvmparams

### DIFF
--- a/core/src/main/java/com/findwise/hydra/CoreConfiguration.java
+++ b/core/src/main/java/com/findwise/hydra/CoreConfiguration.java
@@ -9,6 +9,8 @@ public interface CoreConfiguration extends DatabaseConfiguration {
 	static final String PIPELINE_POLLING_INTERVAL = "core.polling_interval";
 	static final String COMMUNICATION_PORT_PARAM = "core.communication_port";
 	static final String REST_THREAD_COUNT = "core.rest.thread_count";
+	static final String STAGE_JVM_PARAMETERS = "core.stages.jvm_parameters";
+	static final String DEFAULT_STAGE_JVM_PARAMETERS = null;
 	
 	int getRestPort();
 
@@ -23,4 +25,6 @@ public interface CoreConfiguration extends DatabaseConfiguration {
 	int getLoggingPort();
 
 	int getRestThreadCount();
+
+	String getStageJvmParameters();
 }

--- a/core/src/main/java/com/findwise/hydra/CoreMapConfiguration.java
+++ b/core/src/main/java/com/findwise/hydra/CoreMapConfiguration.java
@@ -104,6 +104,10 @@ public class CoreMapConfiguration implements CoreConfiguration, Configuration {
 		return Integer.parseInt(getParameter(LOGGING_PORT, "" + DEFAULT_LOGGING_PORT));
 	}
 
+	public void setLoggingPort(int loggingPort) {
+		setParameter(LOGGING_PORT, "" + loggingPort);
+	}
+
 	@Override
 	public int getRestThreadCount() {
 		return Integer.parseInt(getParameter(REST_THREAD_COUNT, String
@@ -114,8 +118,13 @@ public class CoreMapConfiguration implements CoreConfiguration, Configuration {
 		setParameter(REST_THREAD_COUNT, String.valueOf(restThreadCount));
 	}
 
-	public void setLoggingPort(int loggingPort) {
-		setParameter(LOGGING_PORT, "" + loggingPort);
+	@Override
+	public String getStageJvmParameters() {
+		return getParameter(STAGE_JVM_PARAMETERS, DEFAULT_STAGE_JVM_PARAMETERS);
+	}
+
+	public void setDefaultJvmParameters(String defaultJvmParameters) {
+		setParameter(STAGE_JVM_PARAMETERS, defaultJvmParameters);
 	}
 
 	public String getParameter(String key) {

--- a/core/src/main/java/com/findwise/hydra/FileConfiguration.java
+++ b/core/src/main/java/com/findwise/hydra/FileConfiguration.java
@@ -97,4 +97,9 @@ public class FileConfiguration implements CoreConfiguration, Configuration {
 	public int getRestThreadCount() {
 		return conf.getInt(REST_THREAD_COUNT, Runtime.getRuntime().availableProcessors());
 	}
+
+	@Override
+	public String getStageJvmParameters() {
+		return conf.getString(STAGE_JVM_PARAMETERS, DEFAULT_STAGE_JVM_PARAMETERS);
+	}
 }

--- a/core/src/main/java/com/findwise/hydra/StageManager.java
+++ b/core/src/main/java/com/findwise/hydra/StageManager.java
@@ -16,14 +16,14 @@ public final class StageManager {
 	}
 	
 	public static StageManager getStageManager() {
-		if(self==null) {
+		if (self == null) {
 			self = new StageManager();
 		}
 		return self;
 	}
 	
 	public StageRunner getRunner(String groupName) {
-		if(runnerMap.containsKey(groupName)) {
+		if (runnerMap.containsKey(groupName)) {
 			return runnerMap.get(groupName);
 		}
 		return null;
@@ -34,8 +34,8 @@ public final class StageManager {
 	}
 	
 	public StageRunner getRunnerForStage(String stageName) {
-		for(StageRunner runner : runnerMap.values()) {
-			if(runner.getStageGroup().hasStage(stageName)) {
+		for (StageRunner runner : runnerMap.values()) {
+			if (runner.getStageGroup().hasStage(stageName)) {
 				return runner;
 			}
 		}
@@ -51,7 +51,7 @@ public final class StageManager {
 	}
 	
 	public StageRunner removeRunner(String groupName) {
-		if(runnerMap.containsKey(groupName)) {
+		if (runnerMap.containsKey(groupName)) {
 			StageRunner ret = runnerMap.get(groupName);
 			runnerMap.remove(groupName);
 			return ret;
@@ -61,7 +61,7 @@ public final class StageManager {
 	
 	public void findAndDestroy(String groupName) {
 		StageRunner sw = removeRunner(groupName);
-		if(sw!=null) {
+		if (sw != null) {
 			sw.destroy();
 		}
 	}

--- a/core/src/main/java/com/findwise/hydra/StageRunner.java
+++ b/core/src/main/java/com/findwise/hydra/StageRunner.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecuteResultHandler;
@@ -93,11 +94,10 @@ public class StageRunner extends Thread {
 
 		stageDestroyer = new StageDestroyer();
 
+		setParameters(stageGroup.toPropertiesMap());
 		if (stageGroup.getSize() == 1) {
 			//If there is only a single stage in this group, it's configuration takes precedent
 			setParameters(stageGroup.getStages().iterator().next().getProperties());
-		} else {
-			setParameters(stageGroup.toPropertiesMap());
 		}
 
 		prepared = true;
@@ -186,7 +186,7 @@ public class StageRunner extends Thread {
 	 */
 	private boolean runGroup() {
 		CommandLine cmdLine = new CommandLine(java);
-		cmdLine.addArgument(jvmParameters, false);
+		cmdLine.addArguments(splitJvmParameters(), false);
 		cmdLine.addArgument("-cp");
 		cmdLine.addArgument("${classpath}", false);
 		cmdLine.addArgument(GroupStarter.class.getCanonicalName());
@@ -236,6 +236,10 @@ public class StageRunner extends Thread {
 			return false;
 		}
 		return true;
+	}
+
+	private String[] splitJvmParameters() {
+		return jvmParameters.split("(\\s)(?=-)");
 	}
 
 	private String getClassPath() {

--- a/core/src/main/java/com/findwise/hydra/StageRunner.java
+++ b/core/src/main/java/com/findwise/hydra/StageRunner.java
@@ -79,6 +79,9 @@ public class StageRunner extends Thread {
 	 * @throws IOException
 	 */
 	public void prepare() throws IOException {
+		// Clean working directory to ensure renamed libraries are not added on classpath
+		removeFiles();
+
 		if ((!baseDirectory.isDirectory() && !baseDirectory.mkdir()) ||
 				(!targetDirectory.isDirectory() && !targetDirectory.mkdir())) {
 			throw new IOException("Unable to write files, target (" + targetDirectory.getAbsolutePath() + ") is not a directory");

--- a/core/src/main/java/com/findwise/hydra/StageRunner.java
+++ b/core/src/main/java/com/findwise/hydra/StageRunner.java
@@ -27,18 +27,19 @@ import com.findwise.hydra.stage.GroupStarter;
 
 public class StageRunner extends Thread {
 
+	private static final int DEFAULT_TIMES_TO_RETRY = -1;
+	private static final String DEFAULT_JAVA_PATH = "java";
 	private StageGroup stageGroup;
 	private Logger logger = LoggerFactory.getLogger(getClass());
 	private StageDestroyer stageDestroyer;
 	private boolean prepared = false;
-	private int timesToRetry = -1;
+	private int timesToRetry = DEFAULT_TIMES_TO_RETRY;
 	private int timesStarted;
 	private int pipelinePort;
 
-	private List<File> files = null;
 	private String jvmParameters = null;
 	private String startupArgsString = null;
-	private String java = "java";
+	private String java = DEFAULT_JAVA_PATH;
 
 	private boolean hasQueried = false;
 
@@ -60,7 +61,7 @@ public class StageRunner extends Thread {
 		return hasQueried;
 	}
 
-	public StageRunner(StageGroup stageGroup, File baseDirectory, int pipelinePort, boolean performanceLogging, int loggingPort, ShutdownHandler shutdownHandler) {
+	public StageRunner(StageGroup stageGroup, File baseDirectory, int pipelinePort, boolean performanceLogging, int loggingPort, ShutdownHandler shutdownHandler, String defaultJvmParameters) {
 		this.stageGroup = stageGroup;
 		this.baseDirectory = baseDirectory;
 		this.targetDirectory = new File(baseDirectory, stageGroup.getName());
@@ -68,6 +69,7 @@ public class StageRunner extends Thread {
 		this.performanceLogging = performanceLogging;
 		this.loggingPort = loggingPort;
 		this.shutdownHandler = shutdownHandler;
+		this.jvmParameters = defaultJvmParameters;
 		timesStarted = 0;
 	}
 
@@ -77,57 +79,57 @@ public class StageRunner extends Thread {
 	 * @throws IOException
 	 */
 	public void prepare() throws IOException {
-		files = new ArrayList<File>();
-
-
 		if ((!baseDirectory.isDirectory() && !baseDirectory.mkdir()) ||
 				(!targetDirectory.isDirectory() && !targetDirectory.mkdir())) {
 			throw new IOException("Unable to write files, target (" + targetDirectory.getAbsolutePath() + ") is not a directory");
 		}
 
 		for (DatabaseFile df : stageGroup.getDatabaseFiles()) {
-			File f = new File(targetDirectory, df.getFilename());
-			files.add(f);
-			InputStream dfis = df.getInputStream();
-			assert(dfis != null);
-			FileOutputStream fos = new FileOutputStream(f);
-			assert(fos != null);
-			try {
-				IOUtils.copy(dfis, fos);
-			} finally {
-				IOUtils.closeQuietly(dfis);
-				IOUtils.closeQuietly(fos);
-			}
+			copyStageLibraryToDirectory(df, targetDirectory);
 		}
 
 		stageDestroyer = new StageDestroyer();
 
-		setParameters(stageGroup.toPropertiesMap());
 		if (stageGroup.getSize() == 1) {
 			//If there is only a single stage in this group, it's configuration takes precedent
 			setParameters(stageGroup.getStages().iterator().next().getProperties());
+		} else {
+			setParameters(stageGroup.toPropertiesMap());
 		}
 
 		prepared = true;
 	}
 
+	private void copyStageLibraryToDirectory(DatabaseFile df, File directory) throws IOException {
+		File f = new File(directory, df.getFilename());
+		InputStream dfis = df.getInputStream();
+		assert(dfis != null);
+		FileOutputStream fos = new FileOutputStream(f);
+		assert(fos != null);
+		try {
+			IOUtils.copy(dfis, fos);
+		} finally {
+			IOUtils.closeQuietly(dfis);
+			IOUtils.closeQuietly(fos);
+		}
+	}
+
 	public final void setParameters(Map<String, Object> conf) {
-		if (conf.containsKey(StageGroup.JVM_PARAMETERS_KEY) && conf.get(StageGroup.JVM_PARAMETERS_KEY) != null) {
-			jvmParameters = (String) conf.get(StageGroup.JVM_PARAMETERS_KEY);
-		} else {
-			jvmParameters = null;
+		if (hasParameter(conf, StageGroup.JAVA_LOCATION_KEY)) {
+			java = (String) conf.get(StageGroup.JAVA_LOCATION_KEY);
 		}
 
-		if (conf.containsKey(StageGroup.JAVA_LOCATION_KEY) && conf.get(StageGroup.JAVA_LOCATION_KEY) != null) {
-			java = (String) conf.get(StageGroup.JAVA_LOCATION_KEY);
-		} else {
-			java = "java";
+		if (hasParameter(conf, StageGroup.JVM_PARAMETERS_KEY)) {
+			jvmParameters = (String) conf.get(StageGroup.JVM_PARAMETERS_KEY);
 		}
-		if (conf.containsKey(StageGroup.RETRIES_KEY) && conf.get(StageGroup.RETRIES_KEY) != null) {
+
+		if (hasParameter(conf, StageGroup.RETRIES_KEY)) {
 			timesToRetry = (Integer) conf.get(StageGroup.RETRIES_KEY);
-		} else {
-			timesToRetry = -1;
 		}
+	}
+
+	private boolean hasParameter(Map<String, Object> conf, String parameter) {
+		return conf.containsKey(parameter) && conf.get(parameter) != null;
 	}
 
 	public void run() {

--- a/core/src/main/java/com/findwise/hydra/StageRunner.java
+++ b/core/src/main/java/com/findwise/hydra/StageRunner.java
@@ -239,7 +239,11 @@ public class StageRunner extends Thread {
 	}
 
 	private String[] splitJvmParameters() {
-		return jvmParameters.split("(\\s)(?=-)");
+		if (jvmParameters != null) {
+			return jvmParameters.split("\\s(?=-)");
+		} else {
+			return new String[]{};
+		}
 	}
 
 	private String getClassPath() {

--- a/core/src/main/resources/resource.properties
+++ b/core/src/main/resources/resource.properties
@@ -57,6 +57,13 @@ core.cache.enabled = true
 
 # core.rest.thread_count = 32
 
+# Default JVM parameters for stages
+#
+# Type: String
+# Default: null
+
+# core.stages.jvm_parameters =
+
 ######################################
 # Settings for the backing database. #
 ######################################

--- a/core/src/main/resources/resource.properties
+++ b/core/src/main/resources/resource.properties
@@ -62,7 +62,7 @@ core.cache.enabled = true
 # Type: String
 # Default: null
 
-# core.stages.jvm_parameters =
+# core.stages.jvm_parameters = -Xms4m -Xmx64m
 
 ######################################
 # Settings for the backing database. #

--- a/core/src/test/java/com/findwise/hydra/StageRunnerTest.java
+++ b/core/src/test/java/com/findwise/hydra/StageRunnerTest.java
@@ -24,7 +24,7 @@ public class StageRunnerTest {
 		ShutdownHandler shutdownHandler = Mockito.mock(ShutdownHandler.class);
 		Mockito.when(shutdownHandler.isShuttingDown()).thenReturn(false);
 		
-		StageRunner sr = new StageRunner(group, new File("test"), 0, false, 0, shutdownHandler);
+		StageRunner sr = new StageRunner(group, new File("test"), 0, false, 0, shutdownHandler, "");
 		sr.setStageDestroyer(sd);
 		
 		sr.destroy();

--- a/test-suite/functional-tests/src/test/java/com/findwise/hydra/FullScaleIT.java
+++ b/test-suite/functional-tests/src/test/java/com/findwise/hydra/FullScaleIT.java
@@ -68,7 +68,8 @@ public class FullScaleIT {
 		mongoConnector.connect();
 
 		// Initialize core, but don't start until test wants to.
-		CoreConfiguration coreConfiguration = new CoreMapConfiguration(mongoConfiguration, new MapConfiguration());
+		CoreMapConfiguration coreConfiguration = new CoreMapConfiguration(mongoConfiguration, new MapConfiguration());
+		coreConfiguration.setDefaultJvmParameters("-Xms4m -Xmx16m");
 		core = new Main(coreConfiguration);
 	}
 


### PR DESCRIPTION
This makes it easier to configure stagegroups where some stages need e.g. keystore files, or to set a max heapsize for all stages.

Also fixes issues with stages not removing jars when a stage library is renamed (e.g. when versions change).

This also allows the `jvm_parameters` stage parameter to be cross-platform: As long as paths in JVM parameters are quoted properly no special handling for different platforms should be needed. Before this, the JVM parameters had to be quoted inside the string on Windows.
