### PR TITLE
 #364 Fix dependency conflict issue

### DIFF
--- a/stages/in/server/pom.xml
+++ b/stages/in/server/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore-nio</artifactId>
-            <version>4.1</version>
+            <version>4.2.1</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
#364 fix dependency conflict issue for httpcore:jar

Thanks for your support. I have two solutions to fix this issue.
1.Upgrade the httpcore:jar 4.1 to 4.2.1.
2.Upgrade the precursor library (httpcore-nio:jar 4.1) of httpcore:jar 4.1 to introduce the newer version of httpcore:jar 4.2.1. Then we can keep the version consistency of httpcore.
I think solution 2 is better.

